### PR TITLE
Add clean region id from the current region id

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ $ node . --regions-title-dump=path/to/0005001b-10052000 --iso-title-dump=path/to
 }
 ```
 
-`regions` is an array of region objects for each region inside a country. All objects are sorted by their `id` property from smallest to largest. The structure is
+`regions` is an array of region objects for each region inside a country. All objects are sorted by their `full_id` property from smallest to largest. The structure is
 
 ```json
 {
-	"id": 1234567890,
+	"id": 123,
+	"full_id": 1234567890,
 	"name": "Region Name",
 	"translations": {
 		"japanese": "Region Name Translation",

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ $ node . --regions-title-dump=path/to/0005001b-10052000 --iso-title-dump=path/to
 }
 ```
 
-`regions` is an array of region objects for each region inside a country. All objects are sorted by their `full_id` property from smallest to largest. The structure is
+`regions` is an array of region objects for each region inside a country. All objects are sorted by their `id` property from smallest to largest. The structure is
 
 ```json
 {
-	"id": 123,
-	"full_id": 1234567890,
+	"id": 1234567890,
+	"individual_id": 123,
 	"name": "Region Name",
 	"translations": {
 		"japanese": "Region Name Translation",

--- a/regions.json
+++ b/regions.json
@@ -23,8 +23,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 16777216,
+                "id": 16777216,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -50,8 +50,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 16908288,
+                "id": 16908288,
+                "individual_id": 2,
                 "name": "Tokyo",
                 "translations": {
                     "japanese": "東京都",
@@ -77,8 +77,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 16973824,
+                "id": 16973824,
+                "individual_id": 3,
                 "name": "Hokkaido",
                 "translations": {
                     "japanese": "北海道",
@@ -104,8 +104,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 17039360,
+                "id": 17039360,
+                "individual_id": 4,
                 "name": "Aomori",
                 "translations": {
                     "japanese": "青森県",
@@ -131,8 +131,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 17104896,
+                "id": 17104896,
+                "individual_id": 5,
                 "name": "Iwate",
                 "translations": {
                     "japanese": "岩手県",
@@ -158,8 +158,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 17170432,
+                "id": 17170432,
+                "individual_id": 6,
                 "name": "Miyagi",
                 "translations": {
                     "japanese": "宮城県",
@@ -185,8 +185,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 17235968,
+                "id": 17235968,
+                "individual_id": 7,
                 "name": "Akita",
                 "translations": {
                     "japanese": "秋田県",
@@ -212,8 +212,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 17301504,
+                "id": 17301504,
+                "individual_id": 8,
                 "name": "Yamagata",
                 "translations": {
                     "japanese": "山形県",
@@ -239,8 +239,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 17367040,
+                "id": 17367040,
+                "individual_id": 9,
                 "name": "Fukushima",
                 "translations": {
                     "japanese": "福島県",
@@ -266,8 +266,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 17432576,
+                "id": 17432576,
+                "individual_id": 10,
                 "name": "Ibaraki",
                 "translations": {
                     "japanese": "茨城県",
@@ -293,8 +293,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 17498112,
+                "id": 17498112,
+                "individual_id": 11,
                 "name": "Tochigi",
                 "translations": {
                     "japanese": "栃木県",
@@ -320,8 +320,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 17563648,
+                "id": 17563648,
+                "individual_id": 12,
                 "name": "Gunma",
                 "translations": {
                     "japanese": "群馬県",
@@ -347,8 +347,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 17629184,
+                "id": 17629184,
+                "individual_id": 13,
                 "name": "Saitama",
                 "translations": {
                     "japanese": "埼玉県",
@@ -374,8 +374,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 17694720,
+                "id": 17694720,
+                "individual_id": 14,
                 "name": "Chiba",
                 "translations": {
                     "japanese": "千葉県",
@@ -401,8 +401,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 17760256,
+                "id": 17760256,
+                "individual_id": 15,
                 "name": "Kanagawa",
                 "translations": {
                     "japanese": "神奈川県",
@@ -428,8 +428,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 17825792,
+                "id": 17825792,
+                "individual_id": 16,
                 "name": "Toyama",
                 "translations": {
                     "japanese": "富山県",
@@ -455,8 +455,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 17891328,
+                "id": 17891328,
+                "individual_id": 17,
                 "name": "Ishikawa",
                 "translations": {
                     "japanese": "石川県",
@@ -482,8 +482,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 17956864,
+                "id": 17956864,
+                "individual_id": 18,
                 "name": "Fukui",
                 "translations": {
                     "japanese": "福井県",
@@ -509,8 +509,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 18022400,
+                "id": 18022400,
+                "individual_id": 19,
                 "name": "Yamanashi",
                 "translations": {
                     "japanese": "山梨県",
@@ -536,8 +536,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 18087936,
+                "id": 18087936,
+                "individual_id": 20,
                 "name": "Nagano",
                 "translations": {
                     "japanese": "長野県",
@@ -563,8 +563,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 18153472,
+                "id": 18153472,
+                "individual_id": 21,
                 "name": "Niigata",
                 "translations": {
                     "japanese": "新潟県",
@@ -590,8 +590,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 18219008,
+                "id": 18219008,
+                "individual_id": 22,
                 "name": "Gifu",
                 "translations": {
                     "japanese": "岐阜県",
@@ -617,8 +617,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 18284544,
+                "id": 18284544,
+                "individual_id": 23,
                 "name": "Shizuoka",
                 "translations": {
                     "japanese": "静岡県",
@@ -644,8 +644,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 18350080,
+                "id": 18350080,
+                "individual_id": 24,
                 "name": "Aichi",
                 "translations": {
                     "japanese": "愛知県",
@@ -671,8 +671,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 18415616,
+                "id": 18415616,
+                "individual_id": 25,
                 "name": "Mie",
                 "translations": {
                     "japanese": "三重県",
@@ -698,8 +698,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 18481152,
+                "id": 18481152,
+                "individual_id": 26,
                 "name": "Shiga",
                 "translations": {
                     "japanese": "滋賀県",
@@ -725,8 +725,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 18546688,
+                "id": 18546688,
+                "individual_id": 27,
                 "name": "Kyoto",
                 "translations": {
                     "japanese": "京都府",
@@ -752,8 +752,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 18612224,
+                "id": 18612224,
+                "individual_id": 28,
                 "name": "Osaka",
                 "translations": {
                     "japanese": "大阪府",
@@ -779,8 +779,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 18677760,
+                "id": 18677760,
+                "individual_id": 29,
                 "name": "Hyogo",
                 "translations": {
                     "japanese": "兵庫県",
@@ -806,8 +806,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 18743296,
+                "id": 18743296,
+                "individual_id": 30,
                 "name": "Nara",
                 "translations": {
                     "japanese": "奈良県",
@@ -833,8 +833,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 18808832,
+                "id": 18808832,
+                "individual_id": 31,
                 "name": "Wakayama",
                 "translations": {
                     "japanese": "和歌山県",
@@ -860,8 +860,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 18874368,
+                "id": 18874368,
+                "individual_id": 32,
                 "name": "Tottori",
                 "translations": {
                     "japanese": "鳥取県",
@@ -887,8 +887,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 18939904,
+                "id": 18939904,
+                "individual_id": 33,
                 "name": "Shimane",
                 "translations": {
                     "japanese": "島根県",
@@ -914,8 +914,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 19005440,
+                "id": 19005440,
+                "individual_id": 34,
                 "name": "Okayama",
                 "translations": {
                     "japanese": "岡山県",
@@ -941,8 +941,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 19070976,
+                "id": 19070976,
+                "individual_id": 35,
                 "name": "Hiroshima",
                 "translations": {
                     "japanese": "広島県",
@@ -968,8 +968,8 @@
                 }
             },
             {
-                "id": 36,
-                "full_id": 19136512,
+                "id": 19136512,
+                "individual_id": 36,
                 "name": "Yamaguchi",
                 "translations": {
                     "japanese": "山口県",
@@ -995,8 +995,8 @@
                 }
             },
             {
-                "id": 37,
-                "full_id": 19202048,
+                "id": 19202048,
+                "individual_id": 37,
                 "name": "Tokushima",
                 "translations": {
                     "japanese": "徳島県",
@@ -1022,8 +1022,8 @@
                 }
             },
             {
-                "id": 38,
-                "full_id": 19267584,
+                "id": 19267584,
+                "individual_id": 38,
                 "name": "Kagawa",
                 "translations": {
                     "japanese": "香川県",
@@ -1049,8 +1049,8 @@
                 }
             },
             {
-                "id": 39,
-                "full_id": 19333120,
+                "id": 19333120,
+                "individual_id": 39,
                 "name": "Ehime",
                 "translations": {
                     "japanese": "愛媛県",
@@ -1076,8 +1076,8 @@
                 }
             },
             {
-                "id": 40,
-                "full_id": 19398656,
+                "id": 19398656,
+                "individual_id": 40,
                 "name": "Kochi",
                 "translations": {
                     "japanese": "高知県",
@@ -1103,8 +1103,8 @@
                 }
             },
             {
-                "id": 41,
-                "full_id": 19464192,
+                "id": 19464192,
+                "individual_id": 41,
                 "name": "Fukuoka",
                 "translations": {
                     "japanese": "福岡県",
@@ -1130,8 +1130,8 @@
                 }
             },
             {
-                "id": 42,
-                "full_id": 19529728,
+                "id": 19529728,
+                "individual_id": 42,
                 "name": "Saga",
                 "translations": {
                     "japanese": "佐賀県",
@@ -1157,8 +1157,8 @@
                 }
             },
             {
-                "id": 43,
-                "full_id": 19595264,
+                "id": 19595264,
+                "individual_id": 43,
                 "name": "Nagasaki",
                 "translations": {
                     "japanese": "長崎県",
@@ -1184,8 +1184,8 @@
                 }
             },
             {
-                "id": 44,
-                "full_id": 19660800,
+                "id": 19660800,
+                "individual_id": 44,
                 "name": "Kumamoto",
                 "translations": {
                     "japanese": "熊本県",
@@ -1211,8 +1211,8 @@
                 }
             },
             {
-                "id": 45,
-                "full_id": 19726336,
+                "id": 19726336,
+                "individual_id": 45,
                 "name": "Oita",
                 "translations": {
                     "japanese": "大分県",
@@ -1238,8 +1238,8 @@
                 }
             },
             {
-                "id": 46,
-                "full_id": 19791872,
+                "id": 19791872,
+                "individual_id": 46,
                 "name": "Miyazaki",
                 "translations": {
                     "japanese": "宮崎県",
@@ -1265,8 +1265,8 @@
                 }
             },
             {
-                "id": 47,
-                "full_id": 19857408,
+                "id": 19857408,
+                "individual_id": 47,
                 "name": "Kagoshima",
                 "translations": {
                     "japanese": "鹿児島県",
@@ -1292,8 +1292,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 19922944,
+                "id": 19922944,
+                "individual_id": 48,
                 "name": "Okinawa",
                 "translations": {
                     "japanese": "沖縄県",
@@ -1344,8 +1344,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 134217728,
+                "id": 134217728,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1371,8 +1371,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 134283264,
+                "id": 134283264,
+                "individual_id": 1,
                 "name": "Anguilla",
                 "translations": {
                     "japanese": "アンギラ",
@@ -1423,8 +1423,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 150994944,
+                "id": 150994944,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1450,8 +1450,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 151126016,
+                "id": 151126016,
+                "individual_id": 2,
                 "name": "Saint John",
                 "translations": {
                     "japanese": "セント・ジョン",
@@ -1477,8 +1477,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 151191552,
+                "id": 151191552,
+                "individual_id": 3,
                 "name": "Barbuda",
                 "translations": {
                     "japanese": "バーブーダ島",
@@ -1504,8 +1504,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 151257088,
+                "id": 151257088,
+                "individual_id": 4,
                 "name": "Saint George",
                 "translations": {
                     "japanese": "セント・ジョージ",
@@ -1531,8 +1531,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 151322624,
+                "id": 151322624,
+                "individual_id": 5,
                 "name": "Saint Mary",
                 "translations": {
                     "japanese": "セント・メアリー",
@@ -1558,8 +1558,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 151388160,
+                "id": 151388160,
+                "individual_id": 6,
                 "name": "Saint Paul",
                 "translations": {
                     "japanese": "セント・ポール",
@@ -1585,8 +1585,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 151453696,
+                "id": 151453696,
+                "individual_id": 7,
                 "name": "Saint Peter",
                 "translations": {
                     "japanese": "セント・ピーター",
@@ -1612,8 +1612,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 151519232,
+                "id": 151519232,
+                "individual_id": 8,
                 "name": "Saint Philip",
                 "translations": {
                     "japanese": "セント・フィリップ",
@@ -1664,8 +1664,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 167772160,
+                "id": 167772160,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1691,8 +1691,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 167903232,
+                "id": 167903232,
+                "individual_id": 2,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "特別区",
@@ -1718,8 +1718,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 167968768,
+                "id": 167968768,
+                "individual_id": 3,
                 "name": "Buenos Aires",
                 "translations": {
                     "japanese": "ブエノスアイレス州",
@@ -1745,8 +1745,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 168034304,
+                "id": 168034304,
+                "individual_id": 4,
                 "name": "Catamarca",
                 "translations": {
                     "japanese": "カタマルカ州",
@@ -1772,8 +1772,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 168099840,
+                "id": 168099840,
+                "individual_id": 5,
                 "name": "Chaco",
                 "translations": {
                     "japanese": "チャコ州",
@@ -1799,8 +1799,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 168165376,
+                "id": 168165376,
+                "individual_id": 6,
                 "name": "Chubut",
                 "translations": {
                     "japanese": "チュブト州",
@@ -1826,8 +1826,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 168230912,
+                "id": 168230912,
+                "individual_id": 7,
                 "name": "Córdoba",
                 "translations": {
                     "japanese": "コルドバ州",
@@ -1853,8 +1853,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 168296448,
+                "id": 168296448,
+                "individual_id": 8,
                 "name": "Corrientes",
                 "translations": {
                     "japanese": "コリエンテス州",
@@ -1880,8 +1880,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 168361984,
+                "id": 168361984,
+                "individual_id": 9,
                 "name": "Entre Ríos",
                 "translations": {
                     "japanese": "エントレ・リオス州",
@@ -1907,8 +1907,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 168427520,
+                "id": 168427520,
+                "individual_id": 10,
                 "name": "Formosa",
                 "translations": {
                     "japanese": "フォルモサ州",
@@ -1934,8 +1934,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 168493056,
+                "id": 168493056,
+                "individual_id": 11,
                 "name": "Jujuy",
                 "translations": {
                     "japanese": "フフイ州",
@@ -1961,8 +1961,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 168558592,
+                "id": 168558592,
+                "individual_id": 12,
                 "name": "La Pampa",
                 "translations": {
                     "japanese": "ラ・パンパ州",
@@ -1988,8 +1988,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 168624128,
+                "id": 168624128,
+                "individual_id": 13,
                 "name": "La Rioja",
                 "translations": {
                     "japanese": "ラ・リオハ州",
@@ -2015,8 +2015,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 168689664,
+                "id": 168689664,
+                "individual_id": 14,
                 "name": "Mendoza",
                 "translations": {
                     "japanese": "メンドーサ州",
@@ -2042,8 +2042,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 168755200,
+                "id": 168755200,
+                "individual_id": 15,
                 "name": "Misiones",
                 "translations": {
                     "japanese": "ミシオネス州",
@@ -2069,8 +2069,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 168820736,
+                "id": 168820736,
+                "individual_id": 16,
                 "name": "Neuquén",
                 "translations": {
                     "japanese": "ネウケン州",
@@ -2096,8 +2096,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 168886272,
+                "id": 168886272,
+                "individual_id": 17,
                 "name": "Río Negro",
                 "translations": {
                     "japanese": "リオネグロ州",
@@ -2123,8 +2123,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 168951808,
+                "id": 168951808,
+                "individual_id": 18,
                 "name": "Salta",
                 "translations": {
                     "japanese": "サルタ州",
@@ -2150,8 +2150,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 169017344,
+                "id": 169017344,
+                "individual_id": 19,
                 "name": "San Juan",
                 "translations": {
                     "japanese": "サン・フアン州",
@@ -2177,8 +2177,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 169082880,
+                "id": 169082880,
+                "individual_id": 20,
                 "name": "San Luis",
                 "translations": {
                     "japanese": "サン・ルイス州",
@@ -2204,8 +2204,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 169148416,
+                "id": 169148416,
+                "individual_id": 21,
                 "name": "Santa Cruz",
                 "translations": {
                     "japanese": "サンタ・クルス州",
@@ -2231,8 +2231,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 169213952,
+                "id": 169213952,
+                "individual_id": 22,
                 "name": "Santa Fe",
                 "translations": {
                     "japanese": "サンタ・フェ州",
@@ -2258,8 +2258,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 169279488,
+                "id": 169279488,
+                "individual_id": 23,
                 "name": "Santiago del Estero",
                 "translations": {
                     "japanese": "サンティアゴ・デル・エステロ州",
@@ -2285,8 +2285,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 169345024,
+                "id": 169345024,
+                "individual_id": 24,
                 "name": "Tierra del Fuego, Antártida e Islas del Atlántico Sur",
                 "translations": {
                     "japanese": "ティエラ・デル・フエゴ州",
@@ -2312,8 +2312,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 169410560,
+                "id": 169410560,
+                "individual_id": 25,
                 "name": "Tucumán",
                 "translations": {
                     "japanese": "トゥクマン州",
@@ -2364,8 +2364,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 184549376,
+                "id": 184549376,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2391,8 +2391,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 184614912,
+                "id": 184614912,
+                "individual_id": 1,
                 "name": "Aruba",
                 "translations": {
                     "japanese": "アルバ",
@@ -2443,8 +2443,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 201326592,
+                "id": 201326592,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2470,8 +2470,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 201392128,
+                "id": 201392128,
+                "individual_id": 1,
                 "name": "Bahamas",
                 "translations": {
                     "japanese": "バハマ",
@@ -2522,8 +2522,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 218103808,
+                "id": 218103808,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2549,8 +2549,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 218169344,
+                "id": 218169344,
+                "individual_id": 1,
                 "name": "Barbados",
                 "translations": {
                     "japanese": "バルバドス",
@@ -2601,8 +2601,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 234881024,
+                "id": 234881024,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2628,8 +2628,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 235012096,
+                "id": 235012096,
+                "individual_id": 2,
                 "name": "Cayo",
                 "translations": {
                     "japanese": "カヨー州",
@@ -2655,8 +2655,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 235077632,
+                "id": 235077632,
+                "individual_id": 3,
                 "name": "Belize",
                 "translations": {
                     "japanese": "ベリーズ州",
@@ -2682,8 +2682,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 235143168,
+                "id": 235143168,
+                "individual_id": 4,
                 "name": "Corozal",
                 "translations": {
                     "japanese": "コロサル州",
@@ -2709,8 +2709,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 235208704,
+                "id": 235208704,
+                "individual_id": 5,
                 "name": "Orange Walk",
                 "translations": {
                     "japanese": "オレンジウォーク州",
@@ -2736,8 +2736,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 235274240,
+                "id": 235274240,
+                "individual_id": 6,
                 "name": "Stann Creek",
                 "translations": {
                     "japanese": "スタンクリーク州",
@@ -2763,8 +2763,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 235339776,
+                "id": 235339776,
+                "individual_id": 7,
                 "name": "Toledo",
                 "translations": {
                     "japanese": "トレド州",
@@ -2815,8 +2815,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 251658240,
+                "id": 251658240,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2842,8 +2842,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 251789312,
+                "id": 251789312,
+                "individual_id": 2,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラパス県",
@@ -2869,8 +2869,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 251854848,
+                "id": 251854848,
+                "individual_id": 3,
                 "name": "Chuquisaca",
                 "translations": {
                     "japanese": "チュキサカ県",
@@ -2896,8 +2896,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 251920384,
+                "id": 251920384,
+                "individual_id": 4,
                 "name": "Cochabamba",
                 "translations": {
                     "japanese": "コチャバンバ県",
@@ -2923,8 +2923,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 251985920,
+                "id": 251985920,
+                "individual_id": 5,
                 "name": "El Beni",
                 "translations": {
                     "japanese": "ベニ県",
@@ -2950,8 +2950,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 252051456,
+                "id": 252051456,
+                "individual_id": 6,
                 "name": "Oruro",
                 "translations": {
                     "japanese": "オルロ県",
@@ -2977,8 +2977,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 252116992,
+                "id": 252116992,
+                "individual_id": 7,
                 "name": "Pando",
                 "translations": {
                     "japanese": "パンド県",
@@ -3004,8 +3004,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 252182528,
+                "id": 252182528,
+                "individual_id": 8,
                 "name": "Potosí",
                 "translations": {
                     "japanese": "ポトシ県",
@@ -3031,8 +3031,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 252248064,
+                "id": 252248064,
+                "individual_id": 9,
                 "name": "Santa Cruz",
                 "translations": {
                     "japanese": "サンタ・クルス県",
@@ -3058,8 +3058,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 252313600,
+                "id": 252313600,
+                "individual_id": 10,
                 "name": "Tarija",
                 "translations": {
                     "japanese": "タリハ県",
@@ -3110,8 +3110,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 268435456,
+                "id": 268435456,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3137,8 +3137,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 268566528,
+                "id": 268566528,
+                "individual_id": 2,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト・フェデラル州",
@@ -3164,8 +3164,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 268632064,
+                "id": 268632064,
+                "individual_id": 3,
                 "name": "Acre",
                 "translations": {
                     "japanese": "アクレ州",
@@ -3191,8 +3191,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 268697600,
+                "id": 268697600,
+                "individual_id": 4,
                 "name": "Alagoas",
                 "translations": {
                     "japanese": "アラゴアス州",
@@ -3218,8 +3218,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 268763136,
+                "id": 268763136,
+                "individual_id": 5,
                 "name": "Amapá",
                 "translations": {
                     "japanese": "アマパー州",
@@ -3245,8 +3245,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 268828672,
+                "id": 268828672,
+                "individual_id": 6,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマゾナス州",
@@ -3272,8 +3272,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 268894208,
+                "id": 268894208,
+                "individual_id": 7,
                 "name": "Bahia",
                 "translations": {
                     "japanese": "バイア州",
@@ -3299,8 +3299,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 268959744,
+                "id": 268959744,
+                "individual_id": 8,
                 "name": "Ceará",
                 "translations": {
                     "japanese": "セアラ州",
@@ -3326,8 +3326,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 269025280,
+                "id": 269025280,
+                "individual_id": 9,
                 "name": "Espírito Santo",
                 "translations": {
                     "japanese": "エスピリト・サント州",
@@ -3353,8 +3353,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 269090816,
+                "id": 269090816,
+                "individual_id": 10,
                 "name": "Mato Grosso do Sul",
                 "translations": {
                     "japanese": "マット・グロッソ・ド・スル州",
@@ -3380,8 +3380,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 269156352,
+                "id": 269156352,
+                "individual_id": 11,
                 "name": "Maranhão",
                 "translations": {
                     "japanese": "マラニョン州",
@@ -3407,8 +3407,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 269221888,
+                "id": 269221888,
+                "individual_id": 12,
                 "name": "Mato Grosso",
                 "translations": {
                     "japanese": "マット・グロッソ州",
@@ -3434,8 +3434,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 269287424,
+                "id": 269287424,
+                "individual_id": 13,
                 "name": "Minas Gerais",
                 "translations": {
                     "japanese": "ミナス・ジェライス州",
@@ -3461,8 +3461,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 269352960,
+                "id": 269352960,
+                "individual_id": 14,
                 "name": "Pará",
                 "translations": {
                     "japanese": "パラー州",
@@ -3488,8 +3488,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 269418496,
+                "id": 269418496,
+                "individual_id": 15,
                 "name": "Paraíba",
                 "translations": {
                     "japanese": "パライーバ州",
@@ -3515,8 +3515,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 269484032,
+                "id": 269484032,
+                "individual_id": 16,
                 "name": "Paraná",
                 "translations": {
                     "japanese": "パラナ州",
@@ -3542,8 +3542,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 269549568,
+                "id": 269549568,
+                "individual_id": 17,
                 "name": "Piauí",
                 "translations": {
                     "japanese": "ピアウイー州",
@@ -3569,8 +3569,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 269615104,
+                "id": 269615104,
+                "individual_id": 18,
                 "name": "Rio de Janeiro",
                 "translations": {
                     "japanese": "リオ・デ・ジャネイロ州",
@@ -3596,8 +3596,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 269680640,
+                "id": 269680640,
+                "individual_id": 19,
                 "name": "Rio Grande do Norte",
                 "translations": {
                     "japanese": "リオ・グランデ・ド・ノルテ州",
@@ -3623,8 +3623,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 269746176,
+                "id": 269746176,
+                "individual_id": 20,
                 "name": "Rio Grande do Sul",
                 "translations": {
                     "japanese": "リオ・グランデ・ド・スル州",
@@ -3650,8 +3650,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 269811712,
+                "id": 269811712,
+                "individual_id": 21,
                 "name": "Rondônia",
                 "translations": {
                     "japanese": "ロンドニア州",
@@ -3677,8 +3677,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 269877248,
+                "id": 269877248,
+                "individual_id": 22,
                 "name": "Roraima",
                 "translations": {
                     "japanese": "ロライマ州",
@@ -3704,8 +3704,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 269942784,
+                "id": 269942784,
+                "individual_id": 23,
                 "name": "Santa Catarina",
                 "translations": {
                     "japanese": "サンタ・カタリーナ州",
@@ -3731,8 +3731,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 270008320,
+                "id": 270008320,
+                "individual_id": 24,
                 "name": "São Paulo",
                 "translations": {
                     "japanese": "サン・パウロ州",
@@ -3758,8 +3758,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 270073856,
+                "id": 270073856,
+                "individual_id": 25,
                 "name": "Sergipe",
                 "translations": {
                     "japanese": "セルジッペ州",
@@ -3785,8 +3785,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 270139392,
+                "id": 270139392,
+                "individual_id": 26,
                 "name": "Goiás",
                 "translations": {
                     "japanese": "ゴイアス州",
@@ -3812,8 +3812,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 270204928,
+                "id": 270204928,
+                "individual_id": 27,
                 "name": "Pernambuco",
                 "translations": {
                     "japanese": "ペルナンブコ州",
@@ -3839,8 +3839,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 270270464,
+                "id": 270270464,
+                "individual_id": 28,
                 "name": "Tocantins",
                 "translations": {
                     "japanese": "トカンティンス州",
@@ -3891,8 +3891,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 285212672,
+                "id": 285212672,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3918,8 +3918,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 285278208,
+                "id": 285278208,
+                "individual_id": 1,
                 "name": "British Virgin Islands",
                 "translations": {
                     "japanese": "英領ヴァージン諸島",
@@ -3970,8 +3970,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 301989888,
+                "id": 301989888,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3997,8 +3997,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 302120960,
+                "id": 302120960,
+                "individual_id": 2,
                 "name": "Ontario",
                 "translations": {
                     "japanese": "オンタリオ州",
@@ -4024,8 +4024,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 302186496,
+                "id": 302186496,
+                "individual_id": 3,
                 "name": "Alberta",
                 "translations": {
                     "japanese": "アルバータ州",
@@ -4051,8 +4051,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 302252032,
+                "id": 302252032,
+                "individual_id": 4,
                 "name": "British Columbia",
                 "translations": {
                     "japanese": "ブリティッシュ・コロンビア州",
@@ -4078,8 +4078,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 302317568,
+                "id": 302317568,
+                "individual_id": 5,
                 "name": "Manitoba",
                 "translations": {
                     "japanese": "マニトバ州",
@@ -4105,8 +4105,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 302383104,
+                "id": 302383104,
+                "individual_id": 6,
                 "name": "New Brunswick",
                 "translations": {
                     "japanese": "ニュー・ブランズウィック州",
@@ -4132,8 +4132,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 302448640,
+                "id": 302448640,
+                "individual_id": 7,
                 "name": "Newfoundland and Labrador",
                 "translations": {
                     "japanese": "ニューファンドランド・ラブラドール州",
@@ -4159,8 +4159,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 302514176,
+                "id": 302514176,
+                "individual_id": 8,
                 "name": "Nova Scotia",
                 "translations": {
                     "japanese": "ノバ・スコシア州",
@@ -4186,8 +4186,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 302579712,
+                "id": 302579712,
+                "individual_id": 9,
                 "name": "Prince Edward Island",
                 "translations": {
                     "japanese": "プリンス・エドワード・アイランド州",
@@ -4213,8 +4213,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 302645248,
+                "id": 302645248,
+                "individual_id": 10,
                 "name": "Quebec",
                 "translations": {
                     "japanese": "ケベック州",
@@ -4240,8 +4240,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 302710784,
+                "id": 302710784,
+                "individual_id": 11,
                 "name": "Saskatchewan",
                 "translations": {
                     "japanese": "サスカチュワン州",
@@ -4267,8 +4267,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 302776320,
+                "id": 302776320,
+                "individual_id": 12,
                 "name": "Yukon",
                 "translations": {
                     "japanese": "ユーコン準州",
@@ -4294,8 +4294,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 302841856,
+                "id": 302841856,
+                "individual_id": 13,
                 "name": "Northwest Territories",
                 "translations": {
                     "japanese": "ノースウェスト準州",
@@ -4321,8 +4321,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 302907392,
+                "id": 302907392,
+                "individual_id": 14,
                 "name": "Nunavut",
                 "translations": {
                     "japanese": "ヌナブト準州",
@@ -4373,8 +4373,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 318767104,
+                "id": 318767104,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4400,8 +4400,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 318832640,
+                "id": 318832640,
+                "individual_id": 1,
                 "name": "Cayman Islands",
                 "translations": {
                     "japanese": "ケイマン諸島",
@@ -4452,8 +4452,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 335544320,
+                "id": 335544320,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4479,8 +4479,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 335675392,
+                "id": 335675392,
+                "individual_id": 2,
                 "name": "Región Metropolitana",
                 "translations": {
                     "japanese": "レジョン・メトロポリタナ州",
@@ -4506,8 +4506,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 335740928,
+                "id": 335740928,
+                "individual_id": 3,
                 "name": "Valparaíso",
                 "translations": {
                     "japanese": "バルパライソ州",
@@ -4533,8 +4533,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 335806464,
+                "id": 335806464,
+                "individual_id": 4,
                 "name": "Aisén del General Carlos Ibáñez del Campo",
                 "translations": {
                     "japanese": "アイセン・デル・Ｇ・カルロス・イバニェス・デル・カンポ州",
@@ -4560,8 +4560,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 335872000,
+                "id": 335872000,
+                "individual_id": 5,
                 "name": "Antofagasta",
                 "translations": {
                     "japanese": "アントファガスタ州",
@@ -4587,8 +4587,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 335937536,
+                "id": 335937536,
+                "individual_id": 6,
                 "name": "Araucanía",
                 "translations": {
                     "japanese": "アラウカニア州",
@@ -4614,8 +4614,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 336003072,
+                "id": 336003072,
+                "individual_id": 7,
                 "name": "Atacama",
                 "translations": {
                     "japanese": "アタカマ州",
@@ -4641,8 +4641,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 336068608,
+                "id": 336068608,
+                "individual_id": 8,
                 "name": "Bío-Bío",
                 "translations": {
                     "japanese": "ビオビオ州",
@@ -4668,8 +4668,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 336134144,
+                "id": 336134144,
+                "individual_id": 9,
                 "name": "Coquimbo",
                 "translations": {
                     "japanese": "コキンボ州",
@@ -4695,8 +4695,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 336199680,
+                "id": 336199680,
+                "individual_id": 10,
                 "name": "Libertador General Bernardo O'Higgins",
                 "translations": {
                     "japanese": "L・ベルナルド・オヒギンス州",
@@ -4722,8 +4722,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 336265216,
+                "id": 336265216,
+                "individual_id": 11,
                 "name": "Los Lagos",
                 "translations": {
                     "japanese": "ロス・ラゴス州",
@@ -4749,8 +4749,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 336330752,
+                "id": 336330752,
+                "individual_id": 12,
                 "name": "Magallanes y Antártica Chilena",
                 "translations": {
                     "japanese": "マガリャネス州",
@@ -4776,8 +4776,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 336396288,
+                "id": 336396288,
+                "individual_id": 13,
                 "name": "Maule",
                 "translations": {
                     "japanese": "マウレ州",
@@ -4803,8 +4803,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 336461824,
+                "id": 336461824,
+                "individual_id": 14,
                 "name": "Tarapacá",
                 "translations": {
                     "japanese": "タラパカ州",
@@ -4855,8 +4855,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 352321536,
+                "id": 352321536,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4882,8 +4882,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 352452608,
+                "id": 352452608,
+                "individual_id": 2,
                 "name": "Distrito Capital",
                 "translations": {
                     "japanese": "ディストリト・キャピタル",
@@ -4909,8 +4909,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 352518144,
+                "id": 352518144,
+                "individual_id": 3,
                 "name": "Cundinamarca",
                 "translations": {
                     "japanese": "クンディナマルカ県",
@@ -4936,8 +4936,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 352583680,
+                "id": 352583680,
+                "individual_id": 4,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス県",
@@ -4963,8 +4963,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 352649216,
+                "id": 352649216,
+                "individual_id": 5,
                 "name": "Antioquia",
                 "translations": {
                     "japanese": "アンティオキア県",
@@ -4990,8 +4990,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 352714752,
+                "id": 352714752,
+                "individual_id": 6,
                 "name": "Arauca",
                 "translations": {
                     "japanese": "アラウカ県",
@@ -5017,8 +5017,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 352780288,
+                "id": 352780288,
+                "individual_id": 7,
                 "name": "Atlántico",
                 "translations": {
                     "japanese": "アトランティコ県",
@@ -5044,8 +5044,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 352845824,
+                "id": 352845824,
+                "individual_id": 8,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル県",
@@ -5071,8 +5071,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 352911360,
+                "id": 352911360,
+                "individual_id": 9,
                 "name": "Boyacá",
                 "translations": {
                     "japanese": "ボヤカ県",
@@ -5098,8 +5098,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 352976896,
+                "id": 352976896,
+                "individual_id": 10,
                 "name": "Caldas",
                 "translations": {
                     "japanese": "カルダス県",
@@ -5125,8 +5125,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 353042432,
+                "id": 353042432,
+                "individual_id": 11,
                 "name": "Caquetá",
                 "translations": {
                     "japanese": "カケタ県",
@@ -5152,8 +5152,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 353107968,
+                "id": 353107968,
+                "individual_id": 12,
                 "name": "Cauca",
                 "translations": {
                     "japanese": "カウカ県",
@@ -5179,8 +5179,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 353173504,
+                "id": 353173504,
+                "individual_id": 13,
                 "name": "Cesar",
                 "translations": {
                     "japanese": "セサル県",
@@ -5206,8 +5206,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 353239040,
+                "id": 353239040,
+                "individual_id": 14,
                 "name": "Chocó",
                 "translations": {
                     "japanese": "チョコ県",
@@ -5233,8 +5233,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 353304576,
+                "id": 353304576,
+                "individual_id": 15,
                 "name": "Córdoba",
                 "translations": {
                     "japanese": "コルドバ県",
@@ -5260,8 +5260,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 353370112,
+                "id": 353370112,
+                "individual_id": 16,
                 "name": "Guaviare",
                 "translations": {
                     "japanese": "グアビアレ県",
@@ -5287,8 +5287,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 353435648,
+                "id": 353435648,
+                "individual_id": 17,
                 "name": "Guainía",
                 "translations": {
                     "japanese": "グアイニア県",
@@ -5314,8 +5314,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 353501184,
+                "id": 353501184,
+                "individual_id": 18,
                 "name": "Huila",
                 "translations": {
                     "japanese": "ウィラ県",
@@ -5341,8 +5341,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 353566720,
+                "id": 353566720,
+                "individual_id": 19,
                 "name": "La Guajira",
                 "translations": {
                     "japanese": "グアヒーラ県",
@@ -5368,8 +5368,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 353632256,
+                "id": 353632256,
+                "individual_id": 20,
                 "name": "Magdalena",
                 "translations": {
                     "japanese": "マグダレーナ県",
@@ -5395,8 +5395,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 353697792,
+                "id": 353697792,
+                "individual_id": 21,
                 "name": "Meta",
                 "translations": {
                     "japanese": "メタ県",
@@ -5422,8 +5422,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 353763328,
+                "id": 353763328,
+                "individual_id": 22,
                 "name": "Nariño",
                 "translations": {
                     "japanese": "ナリーニョ県",
@@ -5449,8 +5449,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 353828864,
+                "id": 353828864,
+                "individual_id": 23,
                 "name": "Norte de Santander",
                 "translations": {
                     "japanese": "ノルテ・デ・サンタンデル県",
@@ -5476,8 +5476,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 353894400,
+                "id": 353894400,
+                "individual_id": 24,
                 "name": "Putumayo",
                 "translations": {
                     "japanese": "プトゥマイオ県",
@@ -5503,8 +5503,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 353959936,
+                "id": 353959936,
+                "individual_id": 25,
                 "name": "Quindío",
                 "translations": {
                     "japanese": "キンディオ県",
@@ -5530,8 +5530,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 354025472,
+                "id": 354025472,
+                "individual_id": 26,
                 "name": "Risaralda",
                 "translations": {
                     "japanese": "リサラルダ県",
@@ -5557,8 +5557,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 354091008,
+                "id": 354091008,
+                "individual_id": 27,
                 "name": "Archipiélago de San Andrés, Providencia y Santa Catalina",
                 "translations": {
                     "japanese": "サン・アンドレス・イ・プロビデンシア県",
@@ -5584,8 +5584,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 354156544,
+                "id": 354156544,
+                "individual_id": 28,
                 "name": "Santander",
                 "translations": {
                     "japanese": "サンタンデル県",
@@ -5611,8 +5611,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 354222080,
+                "id": 354222080,
+                "individual_id": 29,
                 "name": "Sucre",
                 "translations": {
                     "japanese": "スクレ県",
@@ -5638,8 +5638,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 354287616,
+                "id": 354287616,
+                "individual_id": 30,
                 "name": "Tolima",
                 "translations": {
                     "japanese": "トリマ県",
@@ -5665,8 +5665,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 354353152,
+                "id": 354353152,
+                "individual_id": 31,
                 "name": "Valle del Cauca",
                 "translations": {
                     "japanese": "バジェ・デル・カウカ県",
@@ -5692,8 +5692,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 354418688,
+                "id": 354418688,
+                "individual_id": 32,
                 "name": "Vaupés",
                 "translations": {
                     "japanese": "バウペス県",
@@ -5719,8 +5719,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 354484224,
+                "id": 354484224,
+                "individual_id": 33,
                 "name": "Vichada",
                 "translations": {
                     "japanese": "ビチャダ県",
@@ -5746,8 +5746,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 354549760,
+                "id": 354549760,
+                "individual_id": 34,
                 "name": "Casanare",
                 "translations": {
                     "japanese": "カサナレ県",
@@ -5798,8 +5798,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 369098752,
+                "id": 369098752,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -5825,8 +5825,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 369229824,
+                "id": 369229824,
+                "individual_id": 2,
                 "name": "San José",
                 "translations": {
                     "japanese": "サン・ホセ州",
@@ -5852,8 +5852,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 369295360,
+                "id": 369295360,
+                "individual_id": 3,
                 "name": "Alajuela",
                 "translations": {
                     "japanese": "アラフエラ州",
@@ -5879,8 +5879,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 369360896,
+                "id": 369360896,
+                "individual_id": 4,
                 "name": "Cartago",
                 "translations": {
                     "japanese": "カルタゴ州",
@@ -5906,8 +5906,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 369426432,
+                "id": 369426432,
+                "individual_id": 5,
                 "name": "Guanacaste",
                 "translations": {
                     "japanese": "グアナカステ州",
@@ -5933,8 +5933,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 369491968,
+                "id": 369491968,
+                "individual_id": 6,
                 "name": "Heredia",
                 "translations": {
                     "japanese": "エレディア州",
@@ -5960,8 +5960,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 369557504,
+                "id": 369557504,
+                "individual_id": 7,
                 "name": "Limón",
                 "translations": {
                     "japanese": "リモン州",
@@ -5987,8 +5987,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 369623040,
+                "id": 369623040,
+                "individual_id": 8,
                 "name": "Puntarenas",
                 "translations": {
                     "japanese": "プンタレナス州",
@@ -6039,8 +6039,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 385875968,
+                "id": 385875968,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -6066,8 +6066,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 385941504,
+                "id": 385941504,
+                "individual_id": 1,
                 "name": "Dominica",
                 "translations": {
                     "japanese": "ドミニカ国",
@@ -6118,8 +6118,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 402653184,
+                "id": 402653184,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -6145,8 +6145,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 402784256,
+                "id": 402784256,
+                "individual_id": 2,
                 "name": "Distrito Nacional",
                 "translations": {
                     "japanese": "ディストリト・ナショナル首都圏",
@@ -6172,8 +6172,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 402849792,
+                "id": 402849792,
+                "individual_id": 3,
                 "name": "Azua",
                 "translations": {
                     "japanese": "アスア",
@@ -6199,8 +6199,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 402915328,
+                "id": 402915328,
+                "individual_id": 4,
                 "name": "Baoruco",
                 "translations": {
                     "japanese": "バオルコ",
@@ -6226,8 +6226,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 402980864,
+                "id": 402980864,
+                "individual_id": 5,
                 "name": "Barahona",
                 "translations": {
                     "japanese": "バラオナ",
@@ -6253,8 +6253,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 403046400,
+                "id": 403046400,
+                "individual_id": 6,
                 "name": "Dajabón",
                 "translations": {
                     "japanese": "ダハボン",
@@ -6280,8 +6280,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 403111936,
+                "id": 403111936,
+                "individual_id": 7,
                 "name": "Duarte",
                 "translations": {
                     "japanese": "ドゥアルテ",
@@ -6307,8 +6307,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 403177472,
+                "id": 403177472,
+                "individual_id": 8,
                 "name": "Espaillat",
                 "translations": {
                     "japanese": "エスパイジャト",
@@ -6334,8 +6334,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 403243008,
+                "id": 403243008,
+                "individual_id": 9,
                 "name": "Independencia",
                 "translations": {
                     "japanese": "インデペンデンシア",
@@ -6361,8 +6361,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 403308544,
+                "id": 403308544,
+                "individual_id": 10,
                 "name": "La Altagracia",
                 "translations": {
                     "japanese": "ラ・アルタグラシア",
@@ -6388,8 +6388,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 403374080,
+                "id": 403374080,
+                "individual_id": 11,
                 "name": "Elías Piña",
                 "translations": {
                     "japanese": "エリアス・ピーニャ",
@@ -6415,8 +6415,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 403439616,
+                "id": 403439616,
+                "individual_id": 12,
                 "name": "La Romana",
                 "translations": {
                     "japanese": "ラ・ロマーナ",
@@ -6442,8 +6442,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 403505152,
+                "id": 403505152,
+                "individual_id": 13,
                 "name": "María Trinidad Sánchez",
                 "translations": {
                     "japanese": "マリア・トリニダー・サンチェス",
@@ -6469,8 +6469,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 403570688,
+                "id": 403570688,
+                "individual_id": 14,
                 "name": "Monte Cristi",
                 "translations": {
                     "japanese": "モンテ・クリスティ",
@@ -6496,8 +6496,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 403636224,
+                "id": 403636224,
+                "individual_id": 15,
                 "name": "Pedernales",
                 "translations": {
                     "japanese": "ペデルナレス",
@@ -6523,8 +6523,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 403701760,
+                "id": 403701760,
+                "individual_id": 16,
                 "name": "Peravia",
                 "translations": {
                     "japanese": "ペラビア",
@@ -6550,8 +6550,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 403767296,
+                "id": 403767296,
+                "individual_id": 17,
                 "name": "Puerto Plata",
                 "translations": {
                     "japanese": "プエルト・プラタ",
@@ -6577,8 +6577,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 403832832,
+                "id": 403832832,
+                "individual_id": 18,
                 "name": "Salcedo",
                 "translations": {
                     "japanese": "サルセド",
@@ -6604,8 +6604,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 403898368,
+                "id": 403898368,
+                "individual_id": 19,
                 "name": "Samaná",
                 "translations": {
                     "japanese": "セマナ",
@@ -6631,8 +6631,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 403963904,
+                "id": 403963904,
+                "individual_id": 20,
                 "name": "Sánchez Ramírez",
                 "translations": {
                     "japanese": "サンチェス・ラミレス",
@@ -6658,8 +6658,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 404029440,
+                "id": 404029440,
+                "individual_id": 21,
                 "name": "San Juan",
                 "translations": {
                     "japanese": "サン・フアン",
@@ -6685,8 +6685,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 404094976,
+                "id": 404094976,
+                "individual_id": 22,
                 "name": "San Pedro de Macorís",
                 "translations": {
                     "japanese": "サン・ペドロ・デ・マコリス",
@@ -6712,8 +6712,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 404160512,
+                "id": 404160512,
+                "individual_id": 23,
                 "name": "Santiago",
                 "translations": {
                     "japanese": "サンティアゴ",
@@ -6739,8 +6739,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 404226048,
+                "id": 404226048,
+                "individual_id": 24,
                 "name": "Santiago Rodríguez",
                 "translations": {
                     "japanese": "サンティアゴ・ロドリゲス",
@@ -6766,8 +6766,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 404291584,
+                "id": 404291584,
+                "individual_id": 25,
                 "name": "Valverde",
                 "translations": {
                     "japanese": "バルベルデ",
@@ -6793,8 +6793,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 404357120,
+                "id": 404357120,
+                "individual_id": 26,
                 "name": "El Seíbo",
                 "translations": {
                     "japanese": "エル・セイボ",
@@ -6820,8 +6820,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 404422656,
+                "id": 404422656,
+                "individual_id": 27,
                 "name": "Hato Mayor",
                 "translations": {
                     "japanese": "アト・マジョール",
@@ -6847,8 +6847,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 404488192,
+                "id": 404488192,
+                "individual_id": 28,
                 "name": "La Vega",
                 "translations": {
                     "japanese": "ラ・ベガ",
@@ -6874,8 +6874,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 404553728,
+                "id": 404553728,
+                "individual_id": 29,
                 "name": "Monseñor Nouel",
                 "translations": {
                     "japanese": "モンセニョール・ノウエル",
@@ -6901,8 +6901,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 404619264,
+                "id": 404619264,
+                "individual_id": 30,
                 "name": "Monte Plata",
                 "translations": {
                     "japanese": "モンテ・プラタ",
@@ -6928,8 +6928,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 404684800,
+                "id": 404684800,
+                "individual_id": 31,
                 "name": "San Cristóbal",
                 "translations": {
                     "japanese": "サン・クリストバル",
@@ -6980,8 +6980,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 419430400,
+                "id": 419430400,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -7007,8 +7007,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 419561472,
+                "id": 419561472,
+                "individual_id": 2,
                 "name": "Pichincha",
                 "translations": {
                     "japanese": "ピチンチャ",
@@ -7034,8 +7034,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 419627008,
+                "id": 419627008,
+                "individual_id": 3,
                 "name": "Galápagos",
                 "translations": {
                     "japanese": "ガラパゴス",
@@ -7061,8 +7061,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 419692544,
+                "id": 419692544,
+                "individual_id": 4,
                 "name": "Azuay",
                 "translations": {
                     "japanese": "アスアイ",
@@ -7088,8 +7088,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 419758080,
+                "id": 419758080,
+                "individual_id": 5,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル",
@@ -7115,8 +7115,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 419823616,
+                "id": 419823616,
+                "individual_id": 6,
                 "name": "Cañar",
                 "translations": {
                     "japanese": "カニャル",
@@ -7142,8 +7142,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 419889152,
+                "id": 419889152,
+                "individual_id": 7,
                 "name": "Carchi",
                 "translations": {
                     "japanese": "カルチ",
@@ -7169,8 +7169,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 419954688,
+                "id": 419954688,
+                "individual_id": 8,
                 "name": "Chimborazo",
                 "translations": {
                     "japanese": "チンボラソ",
@@ -7196,8 +7196,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 420020224,
+                "id": 420020224,
+                "individual_id": 9,
                 "name": "Cotopaxi",
                 "translations": {
                     "japanese": "コトパクシ",
@@ -7223,8 +7223,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 420085760,
+                "id": 420085760,
+                "individual_id": 10,
                 "name": "El Oro",
                 "translations": {
                     "japanese": "エル・オロ",
@@ -7250,8 +7250,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 420151296,
+                "id": 420151296,
+                "individual_id": 11,
                 "name": "Esmeraldas",
                 "translations": {
                     "japanese": "エスメラルダス",
@@ -7277,8 +7277,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 420216832,
+                "id": 420216832,
+                "individual_id": 12,
                 "name": "Guayas",
                 "translations": {
                     "japanese": "グアヤス",
@@ -7304,8 +7304,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 420282368,
+                "id": 420282368,
+                "individual_id": 13,
                 "name": "Imbabura",
                 "translations": {
                     "japanese": "インバブラ",
@@ -7331,8 +7331,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 420347904,
+                "id": 420347904,
+                "individual_id": 14,
                 "name": "Loja",
                 "translations": {
                     "japanese": "ロハ",
@@ -7358,8 +7358,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 420413440,
+                "id": 420413440,
+                "individual_id": 15,
                 "name": "Los Ríos",
                 "translations": {
                     "japanese": "ロス・リオス",
@@ -7385,8 +7385,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 420478976,
+                "id": 420478976,
+                "individual_id": 16,
                 "name": "Manabí",
                 "translations": {
                     "japanese": "マナビ",
@@ -7412,8 +7412,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 420544512,
+                "id": 420544512,
+                "individual_id": 17,
                 "name": "Morona-Santiago",
                 "translations": {
                     "japanese": "モロナ・サンティアゴ",
@@ -7439,8 +7439,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 420610048,
+                "id": 420610048,
+                "individual_id": 18,
                 "name": "Pastaza",
                 "translations": {
                     "japanese": "パスタサ",
@@ -7466,8 +7466,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 420675584,
+                "id": 420675584,
+                "individual_id": 19,
                 "name": "Tungurahua",
                 "translations": {
                     "japanese": "トゥングラワ",
@@ -7493,8 +7493,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 420741120,
+                "id": 420741120,
+                "individual_id": 20,
                 "name": "Zamora-Chinchipe",
                 "translations": {
                     "japanese": "サモラ・チンチペ",
@@ -7520,8 +7520,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 420806656,
+                "id": 420806656,
+                "individual_id": 21,
                 "name": "Sucumbios",
                 "translations": {
                     "japanese": "スクンビオス",
@@ -7547,8 +7547,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 420872192,
+                "id": 420872192,
+                "individual_id": 22,
                 "name": "Napo",
                 "translations": {
                     "japanese": "ナポ",
@@ -7574,8 +7574,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 420937728,
+                "id": 420937728,
+                "individual_id": 23,
                 "name": "Orellana",
                 "translations": {
                     "japanese": "オレリャナ",
@@ -7601,8 +7601,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 421003264,
+                "id": 421003264,
+                "individual_id": 24,
                 "name": "Santa Elena",
                 "translations": {
                     "japanese": "サンタ・エレーナ",
@@ -7628,8 +7628,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 421068800,
+                "id": 421068800,
+                "individual_id": 25,
                 "name": "Santo Domingo de los Tsáchilas",
                 "translations": {
                     "japanese": "サント・ドミンゴ・デ・ロス・ツァチラス",
@@ -7680,8 +7680,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 436207616,
+                "id": 436207616,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -7707,8 +7707,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 436338688,
+                "id": 436338688,
+                "individual_id": 2,
                 "name": "San Salvador",
                 "translations": {
                     "japanese": "サン・サルバドル県",
@@ -7734,8 +7734,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 436404224,
+                "id": 436404224,
+                "individual_id": 3,
                 "name": "Ahuachapán",
                 "translations": {
                     "japanese": "アワチャパン県",
@@ -7761,8 +7761,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 436469760,
+                "id": 436469760,
+                "individual_id": 4,
                 "name": "Cabañas",
                 "translations": {
                     "japanese": "カバニャス県",
@@ -7788,8 +7788,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 436535296,
+                "id": 436535296,
+                "individual_id": 5,
                 "name": "Chalatenango",
                 "translations": {
                     "japanese": "チャラテナンゴ県",
@@ -7815,8 +7815,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 436600832,
+                "id": 436600832,
+                "individual_id": 6,
                 "name": "Cuscatlán",
                 "translations": {
                     "japanese": "クスカトラン県",
@@ -7842,8 +7842,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 436666368,
+                "id": 436666368,
+                "individual_id": 7,
                 "name": "La Libertad",
                 "translations": {
                     "japanese": "ラ・リベルター県",
@@ -7869,8 +7869,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 436731904,
+                "id": 436731904,
+                "individual_id": 8,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラパス県",
@@ -7896,8 +7896,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 436797440,
+                "id": 436797440,
+                "individual_id": 9,
                 "name": "La Unión",
                 "translations": {
                     "japanese": "ラ・ウニオン県",
@@ -7923,8 +7923,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 436862976,
+                "id": 436862976,
+                "individual_id": 10,
                 "name": "Morazán",
                 "translations": {
                     "japanese": "モラサン県",
@@ -7950,8 +7950,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 436928512,
+                "id": 436928512,
+                "individual_id": 11,
                 "name": "San Miguel",
                 "translations": {
                     "japanese": "サン・ミゲル県",
@@ -7977,8 +7977,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 436994048,
+                "id": 436994048,
+                "individual_id": 12,
                 "name": "Santa Ana",
                 "translations": {
                     "japanese": "サンタ・アナ県",
@@ -8004,8 +8004,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 437059584,
+                "id": 437059584,
+                "individual_id": 13,
                 "name": "San Vicente",
                 "translations": {
                     "japanese": "サンビセンテ県",
@@ -8031,8 +8031,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 437125120,
+                "id": 437125120,
+                "individual_id": 14,
                 "name": "Sonsonate",
                 "translations": {
                     "japanese": "ソンソナテ県",
@@ -8058,8 +8058,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 437190656,
+                "id": 437190656,
+                "individual_id": 15,
                 "name": "Usulután",
                 "translations": {
                     "japanese": "ウスルタン県",
@@ -8110,8 +8110,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 452984832,
+                "id": 452984832,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8137,8 +8137,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 453050368,
+                "id": 453050368,
+                "individual_id": 1,
                 "name": "French Guiana",
                 "translations": {
                     "japanese": "フランス領ギアナ",
@@ -8189,8 +8189,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 469762048,
+                "id": 469762048,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8216,8 +8216,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 469827584,
+                "id": 469827584,
+                "individual_id": 1,
                 "name": "Grenada",
                 "translations": {
                     "japanese": "グレナダ",
@@ -8268,8 +8268,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 486539264,
+                "id": 486539264,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8295,8 +8295,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 486604800,
+                "id": 486604800,
+                "individual_id": 1,
                 "name": "Guadeloupe",
                 "translations": {
                     "japanese": "グアドループ",
@@ -8347,8 +8347,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 503316480,
+                "id": 503316480,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8374,8 +8374,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 503447552,
+                "id": 503447552,
+                "individual_id": 2,
                 "name": "Guatemala",
                 "translations": {
                     "japanese": "グアテマラ県",
@@ -8401,8 +8401,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 503513088,
+                "id": 503513088,
+                "individual_id": 3,
                 "name": "Alta Verapaz",
                 "translations": {
                     "japanese": "アルタ・べラパス県",
@@ -8428,8 +8428,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 503578624,
+                "id": 503578624,
+                "individual_id": 4,
                 "name": "Baja Verapaz",
                 "translations": {
                     "japanese": "バハ・べラパス県",
@@ -8455,8 +8455,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 503644160,
+                "id": 503644160,
+                "individual_id": 5,
                 "name": "Chimaltenango",
                 "translations": {
                     "japanese": "チマルテナンゴ県",
@@ -8482,8 +8482,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 503709696,
+                "id": 503709696,
+                "individual_id": 6,
                 "name": "Chiquimula",
                 "translations": {
                     "japanese": "チキムラ県",
@@ -8509,8 +8509,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 503775232,
+                "id": 503775232,
+                "individual_id": 7,
                 "name": "El Progreso",
                 "translations": {
                     "japanese": "エル・プログレソ県",
@@ -8536,8 +8536,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 503840768,
+                "id": 503840768,
+                "individual_id": 8,
                 "name": "Escuintla",
                 "translations": {
                     "japanese": "エスクィントラ県",
@@ -8563,8 +8563,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 503906304,
+                "id": 503906304,
+                "individual_id": 9,
                 "name": "Huehuetenango",
                 "translations": {
                     "japanese": "ウェウェテナンゴ県",
@@ -8590,8 +8590,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 503971840,
+                "id": 503971840,
+                "individual_id": 10,
                 "name": "Izabal",
                 "translations": {
                     "japanese": "イザバル県",
@@ -8617,8 +8617,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 504037376,
+                "id": 504037376,
+                "individual_id": 11,
                 "name": "Jalapa",
                 "translations": {
                     "japanese": "ハラパ県",
@@ -8644,8 +8644,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 504102912,
+                "id": 504102912,
+                "individual_id": 12,
                 "name": "Jutiapa",
                 "translations": {
                     "japanese": "フティアパ県",
@@ -8671,8 +8671,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 504168448,
+                "id": 504168448,
+                "individual_id": 13,
                 "name": "Petén",
                 "translations": {
                     "japanese": "エル・ペテン県",
@@ -8698,8 +8698,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 504233984,
+                "id": 504233984,
+                "individual_id": 14,
                 "name": "Quetzaltenango",
                 "translations": {
                     "japanese": "ケツァルテナンゴ県",
@@ -8725,8 +8725,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 504299520,
+                "id": 504299520,
+                "individual_id": 15,
                 "name": "Quiché",
                 "translations": {
                     "japanese": "エル・キチェ県",
@@ -8752,8 +8752,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 504365056,
+                "id": 504365056,
+                "individual_id": 16,
                 "name": "Retalhuleu",
                 "translations": {
                     "japanese": "レタルーレウ県",
@@ -8779,8 +8779,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 504430592,
+                "id": 504430592,
+                "individual_id": 17,
                 "name": "Sacatepéquez",
                 "translations": {
                     "japanese": "サカテペケス県",
@@ -8806,8 +8806,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 504496128,
+                "id": 504496128,
+                "individual_id": 18,
                 "name": "San Marcos",
                 "translations": {
                     "japanese": "サン・マルコス県",
@@ -8833,8 +8833,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 504561664,
+                "id": 504561664,
+                "individual_id": 19,
                 "name": "Santa Rosa",
                 "translations": {
                     "japanese": "サンタ・ローサ県",
@@ -8860,8 +8860,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 504627200,
+                "id": 504627200,
+                "individual_id": 20,
                 "name": "Sololá",
                 "translations": {
                     "japanese": "ソロラ県",
@@ -8887,8 +8887,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 504692736,
+                "id": 504692736,
+                "individual_id": 21,
                 "name": "Suchitepéquez",
                 "translations": {
                     "japanese": "スチテペケス県",
@@ -8914,8 +8914,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 504758272,
+                "id": 504758272,
+                "individual_id": 22,
                 "name": "Totonicapán",
                 "translations": {
                     "japanese": "トトニカパン県",
@@ -8941,8 +8941,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 504823808,
+                "id": 504823808,
+                "individual_id": 23,
                 "name": "Zacapa",
                 "translations": {
                     "japanese": "サカパ県",
@@ -8993,8 +8993,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 520093696,
+                "id": 520093696,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9020,8 +9020,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 520224768,
+                "id": 520224768,
+                "individual_id": 2,
                 "name": "Demerara-Mahaica",
                 "translations": {
                     "japanese": "デメララ・マハイカ州",
@@ -9047,8 +9047,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 520290304,
+                "id": 520290304,
+                "individual_id": 3,
                 "name": "Barima-Waini",
                 "translations": {
                     "japanese": "バリマ・ワイニ州",
@@ -9074,8 +9074,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 520355840,
+                "id": 520355840,
+                "individual_id": 4,
                 "name": "Cuyuni-Mazaruni",
                 "translations": {
                     "japanese": "クユニ・マザルニ州",
@@ -9101,8 +9101,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 520421376,
+                "id": 520421376,
+                "individual_id": 5,
                 "name": "East Berbice-Corentyne",
                 "translations": {
                     "japanese": "東ベルビセ・コレンティネ州",
@@ -9128,8 +9128,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 520486912,
+                "id": 520486912,
+                "individual_id": 6,
                 "name": "Essequibo Islands-West Demerara",
                 "translations": {
                     "japanese": "エセキボ諸島・西デメララ州",
@@ -9155,8 +9155,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 520552448,
+                "id": 520552448,
+                "individual_id": 7,
                 "name": "Mahaica-Berbice",
                 "translations": {
                     "japanese": "マハイカ・ベルビセ州",
@@ -9182,8 +9182,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 520617984,
+                "id": 520617984,
+                "individual_id": 8,
                 "name": "Pomeroon-Supenaam",
                 "translations": {
                     "japanese": "ポメローン・スペナーム州",
@@ -9209,8 +9209,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 520683520,
+                "id": 520683520,
+                "individual_id": 9,
                 "name": "Potaro-Siparuni",
                 "translations": {
                     "japanese": "ポタロ・シパルニ州",
@@ -9236,8 +9236,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 520749056,
+                "id": 520749056,
+                "individual_id": 10,
                 "name": "Upper Demerara-Berbice",
                 "translations": {
                     "japanese": "アッパー・デメララ・ベルビセ州",
@@ -9263,8 +9263,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 520814592,
+                "id": 520814592,
+                "individual_id": 11,
                 "name": "Upper Takutu-Upper Essequibo",
                 "translations": {
                     "japanese": "アッパー・タクトゥ・アッパー・エセキボ州",
@@ -9315,8 +9315,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 536870912,
+                "id": 536870912,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9342,8 +9342,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 537001984,
+                "id": 537001984,
+                "individual_id": 2,
                 "name": "Ouest",
                 "translations": {
                     "japanese": "西県",
@@ -9369,8 +9369,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 537067520,
+                "id": 537067520,
+                "individual_id": 3,
                 "name": "Nord-Ouest",
                 "translations": {
                     "japanese": "北西県",
@@ -9396,8 +9396,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 537133056,
+                "id": 537133056,
+                "individual_id": 4,
                 "name": "Artibonite",
                 "translations": {
                     "japanese": "アルティボニット県",
@@ -9423,8 +9423,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 537198592,
+                "id": 537198592,
+                "individual_id": 5,
                 "name": "Centre",
                 "translations": {
                     "japanese": "中央県",
@@ -9450,8 +9450,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 537264128,
+                "id": 537264128,
+                "individual_id": 6,
                 "name": "Grand'Anse",
                 "translations": {
                     "japanese": "湾岸県",
@@ -9477,8 +9477,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 537329664,
+                "id": 537329664,
+                "individual_id": 7,
                 "name": "Nord",
                 "translations": {
                     "japanese": "北県",
@@ -9504,8 +9504,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 537395200,
+                "id": 537395200,
+                "individual_id": 8,
                 "name": "Nord-Est",
                 "translations": {
                     "japanese": "北東県",
@@ -9531,8 +9531,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 537460736,
+                "id": 537460736,
+                "individual_id": 9,
                 "name": "Sud",
                 "translations": {
                     "japanese": "南県",
@@ -9558,8 +9558,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 537526272,
+                "id": 537526272,
+                "individual_id": 10,
                 "name": "Sud-Est",
                 "translations": {
                     "japanese": "南東県",
@@ -9585,8 +9585,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 537591808,
+                "id": 537591808,
+                "individual_id": 11,
                 "name": "Nippes",
                 "translations": {
                     "japanese": "ニップ県",
@@ -9637,8 +9637,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 553648128,
+                "id": 553648128,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9664,8 +9664,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 553779200,
+                "id": 553779200,
+                "individual_id": 2,
                 "name": "Francisco Morazán",
                 "translations": {
                     "japanese": "フランシスコ・モラサン",
@@ -9691,8 +9691,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 553844736,
+                "id": 553844736,
+                "individual_id": 3,
                 "name": "Atlántida",
                 "translations": {
                     "japanese": "アトランティダ",
@@ -9718,8 +9718,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 553910272,
+                "id": 553910272,
+                "individual_id": 4,
                 "name": "Choluteca",
                 "translations": {
                     "japanese": "チョルテカ",
@@ -9745,8 +9745,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 553975808,
+                "id": 553975808,
+                "individual_id": 5,
                 "name": "Colón",
                 "translations": {
                     "japanese": "コロン",
@@ -9772,8 +9772,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 554041344,
+                "id": 554041344,
+                "individual_id": 6,
                 "name": "Comayagua",
                 "translations": {
                     "japanese": "コマヤグア",
@@ -9799,8 +9799,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 554106880,
+                "id": 554106880,
+                "individual_id": 7,
                 "name": "Copán",
                 "translations": {
                     "japanese": "コパン",
@@ -9826,8 +9826,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 554172416,
+                "id": 554172416,
+                "individual_id": 8,
                 "name": "Cortés",
                 "translations": {
                     "japanese": "コルテス",
@@ -9853,8 +9853,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 554237952,
+                "id": 554237952,
+                "individual_id": 9,
                 "name": "El Paraíso",
                 "translations": {
                     "japanese": "エル・パライソ",
@@ -9880,8 +9880,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 554303488,
+                "id": 554303488,
+                "individual_id": 10,
                 "name": "Gracias a Dios",
                 "translations": {
                     "japanese": "グラシアス・ア・ディオス",
@@ -9907,8 +9907,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 554369024,
+                "id": 554369024,
+                "individual_id": 11,
                 "name": "Intibucá",
                 "translations": {
                     "japanese": "インティブカ",
@@ -9934,8 +9934,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 554434560,
+                "id": 554434560,
+                "individual_id": 12,
                 "name": "Islas de la Bahía",
                 "translations": {
                     "japanese": "イスラス・デ・ラ・バイア",
@@ -9961,8 +9961,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 554500096,
+                "id": 554500096,
+                "individual_id": 13,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラ・パス",
@@ -9988,8 +9988,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 554565632,
+                "id": 554565632,
+                "individual_id": 14,
                 "name": "Lempira",
                 "translations": {
                     "japanese": "レンピラ",
@@ -10015,8 +10015,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 554631168,
+                "id": 554631168,
+                "individual_id": 15,
                 "name": "Ocotepeque",
                 "translations": {
                     "japanese": "オコテペケ",
@@ -10042,8 +10042,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 554696704,
+                "id": 554696704,
+                "individual_id": 16,
                 "name": "Olancho",
                 "translations": {
                     "japanese": "オランチョ",
@@ -10069,8 +10069,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 554762240,
+                "id": 554762240,
+                "individual_id": 17,
                 "name": "Santa Bárbara",
                 "translations": {
                     "japanese": "サンタ・バルバラ",
@@ -10096,8 +10096,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 554827776,
+                "id": 554827776,
+                "individual_id": 18,
                 "name": "Valle",
                 "translations": {
                     "japanese": "バジェ",
@@ -10123,8 +10123,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 554893312,
+                "id": 554893312,
+                "individual_id": 19,
                 "name": "Yoro",
                 "translations": {
                     "japanese": "ヨロ",
@@ -10175,8 +10175,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 570425344,
+                "id": 570425344,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -10202,8 +10202,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 570556416,
+                "id": 570556416,
+                "individual_id": 2,
                 "name": "Saint Thomas",
                 "translations": {
                     "japanese": "セント・トーマス",
@@ -10229,8 +10229,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 570621952,
+                "id": 570621952,
+                "individual_id": 3,
                 "name": "Clarendon",
                 "translations": {
                     "japanese": "クラレンドン",
@@ -10256,8 +10256,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 570687488,
+                "id": 570687488,
+                "individual_id": 4,
                 "name": "Hanover",
                 "translations": {
                     "japanese": "ハノーバー",
@@ -10283,8 +10283,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 570753024,
+                "id": 570753024,
+                "individual_id": 5,
                 "name": "Manchester",
                 "translations": {
                     "japanese": "マンチェスター",
@@ -10310,8 +10310,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 570818560,
+                "id": 570818560,
+                "individual_id": 6,
                 "name": "Portland",
                 "translations": {
                     "japanese": "ポートランド",
@@ -10337,8 +10337,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 570884096,
+                "id": 570884096,
+                "individual_id": 7,
                 "name": "Saint Andrew",
                 "translations": {
                     "japanese": "セント・アンドリュー",
@@ -10364,8 +10364,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 570949632,
+                "id": 570949632,
+                "individual_id": 8,
                 "name": "Saint Ann",
                 "translations": {
                     "japanese": "セント・アン",
@@ -10391,8 +10391,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 571015168,
+                "id": 571015168,
+                "individual_id": 9,
                 "name": "Saint Catherine",
                 "translations": {
                     "japanese": "セント・キャサリン",
@@ -10418,8 +10418,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 571080704,
+                "id": 571080704,
+                "individual_id": 10,
                 "name": "Saint Elizabeth",
                 "translations": {
                     "japanese": "セント・エリザベス",
@@ -10445,8 +10445,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 571146240,
+                "id": 571146240,
+                "individual_id": 11,
                 "name": "Saint James",
                 "translations": {
                     "japanese": "セント・ジェームズ",
@@ -10472,8 +10472,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 571211776,
+                "id": 571211776,
+                "individual_id": 12,
                 "name": "Saint Mary",
                 "translations": {
                     "japanese": "セント・メアリー",
@@ -10499,8 +10499,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 571277312,
+                "id": 571277312,
+                "individual_id": 13,
                 "name": "Trelawny",
                 "translations": {
                     "japanese": "トレローニー",
@@ -10526,8 +10526,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 571342848,
+                "id": 571342848,
+                "individual_id": 14,
                 "name": "Westmoreland",
                 "translations": {
                     "japanese": "ウェストモアランド",
@@ -10553,8 +10553,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 571408384,
+                "id": 571408384,
+                "individual_id": 15,
                 "name": "Kingston",
                 "translations": {
                     "japanese": "キングストン",
@@ -10605,8 +10605,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 587202560,
+                "id": 587202560,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -10632,8 +10632,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 587268096,
+                "id": 587268096,
+                "individual_id": 1,
                 "name": "Martinique",
                 "translations": {
                     "japanese": "マルティニーク",
@@ -10684,8 +10684,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 603979776,
+                "id": 603979776,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -10711,8 +10711,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 604110848,
+                "id": 604110848,
+                "individual_id": 2,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト・フェデラル連邦区",
@@ -10738,8 +10738,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 604176384,
+                "id": 604176384,
+                "individual_id": 3,
                 "name": "Aguascalientes",
                 "translations": {
                     "japanese": "アグアスカリエンテス州",
@@ -10765,8 +10765,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 604241920,
+                "id": 604241920,
+                "individual_id": 4,
                 "name": "Baja California",
                 "translations": {
                     "japanese": "バハ・カリフォルニア州",
@@ -10792,8 +10792,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 604307456,
+                "id": 604307456,
+                "individual_id": 5,
                 "name": "Baja California Sur",
                 "translations": {
                     "japanese": "バハ・カリフォルニア・スル州",
@@ -10819,8 +10819,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 604372992,
+                "id": 604372992,
+                "individual_id": 6,
                 "name": "Campeche",
                 "translations": {
                     "japanese": "カンペチェ州",
@@ -10846,8 +10846,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 604438528,
+                "id": 604438528,
+                "individual_id": 7,
                 "name": "Chiapas",
                 "translations": {
                     "japanese": "チアパス州",
@@ -10873,8 +10873,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 604504064,
+                "id": 604504064,
+                "individual_id": 8,
                 "name": "Chihuahua",
                 "translations": {
                     "japanese": "チワワ州",
@@ -10900,8 +10900,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 604569600,
+                "id": 604569600,
+                "individual_id": 9,
                 "name": "Coahuila de Zaragoza",
                 "translations": {
                     "japanese": "コアウイラ州",
@@ -10927,8 +10927,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 604635136,
+                "id": 604635136,
+                "individual_id": 10,
                 "name": "Colima",
                 "translations": {
                     "japanese": "コリマ州",
@@ -10954,8 +10954,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 604700672,
+                "id": 604700672,
+                "individual_id": 11,
                 "name": "Durango",
                 "translations": {
                     "japanese": "ドゥランゴ州",
@@ -10981,8 +10981,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 604766208,
+                "id": 604766208,
+                "individual_id": 12,
                 "name": "Guanajuato",
                 "translations": {
                     "japanese": "グアナフアト州",
@@ -11008,8 +11008,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 604831744,
+                "id": 604831744,
+                "individual_id": 13,
                 "name": "Guerrero",
                 "translations": {
                     "japanese": "ゲレロ州",
@@ -11035,8 +11035,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 604897280,
+                "id": 604897280,
+                "individual_id": 14,
                 "name": "Hidalgo",
                 "translations": {
                     "japanese": "イダルゴ州",
@@ -11062,8 +11062,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 604962816,
+                "id": 604962816,
+                "individual_id": 15,
                 "name": "Jalisco",
                 "translations": {
                     "japanese": "ハリスコ州",
@@ -11089,8 +11089,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 605028352,
+                "id": 605028352,
+                "individual_id": 16,
                 "name": "México",
                 "translations": {
                     "japanese": "メヒコ州",
@@ -11116,8 +11116,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 605093888,
+                "id": 605093888,
+                "individual_id": 17,
                 "name": "Michoacán de Ocampo",
                 "translations": {
                     "japanese": "ミチョアカン州",
@@ -11143,8 +11143,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 605159424,
+                "id": 605159424,
+                "individual_id": 18,
                 "name": "Morelos",
                 "translations": {
                     "japanese": "モレロス州",
@@ -11170,8 +11170,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 605224960,
+                "id": 605224960,
+                "individual_id": 19,
                 "name": "Nayarit",
                 "translations": {
                     "japanese": "ナヤリット州",
@@ -11197,8 +11197,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 605290496,
+                "id": 605290496,
+                "individual_id": 20,
                 "name": "Nuevo León",
                 "translations": {
                     "japanese": "ヌエボ・レオン州",
@@ -11224,8 +11224,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 605356032,
+                "id": 605356032,
+                "individual_id": 21,
                 "name": "Oaxaca",
                 "translations": {
                     "japanese": "オアハカ州",
@@ -11251,8 +11251,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 605421568,
+                "id": 605421568,
+                "individual_id": 22,
                 "name": "Puebla",
                 "translations": {
                     "japanese": "プエブラ州",
@@ -11278,8 +11278,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 605487104,
+                "id": 605487104,
+                "individual_id": 23,
                 "name": "Querétaro de Arteaga",
                 "translations": {
                     "japanese": "ケレタロ州",
@@ -11305,8 +11305,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 605552640,
+                "id": 605552640,
+                "individual_id": 24,
                 "name": "Quintana Roo",
                 "translations": {
                     "japanese": "キンタナ・ロー州",
@@ -11332,8 +11332,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 605618176,
+                "id": 605618176,
+                "individual_id": 25,
                 "name": "San Luis Potosí",
                 "translations": {
                     "japanese": "サン・ルイス・ポトシ州",
@@ -11359,8 +11359,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 605683712,
+                "id": 605683712,
+                "individual_id": 26,
                 "name": "Sinaloa",
                 "translations": {
                     "japanese": "シナロア州",
@@ -11386,8 +11386,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 605749248,
+                "id": 605749248,
+                "individual_id": 27,
                 "name": "Sonora",
                 "translations": {
                     "japanese": "ソノラ州",
@@ -11413,8 +11413,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 605814784,
+                "id": 605814784,
+                "individual_id": 28,
                 "name": "Tabasco",
                 "translations": {
                     "japanese": "タバスコ州",
@@ -11440,8 +11440,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 605880320,
+                "id": 605880320,
+                "individual_id": 29,
                 "name": "Tamaulipas",
                 "translations": {
                     "japanese": "タマウリパス州",
@@ -11467,8 +11467,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 605945856,
+                "id": 605945856,
+                "individual_id": 30,
                 "name": "Tlaxcala",
                 "translations": {
                     "japanese": "トラスカラ州",
@@ -11494,8 +11494,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 606011392,
+                "id": 606011392,
+                "individual_id": 31,
                 "name": "Veracruz-Llave",
                 "translations": {
                     "japanese": "ベラクルス州",
@@ -11521,8 +11521,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 606076928,
+                "id": 606076928,
+                "individual_id": 32,
                 "name": "Yucatán",
                 "translations": {
                     "japanese": "ユカタン州",
@@ -11548,8 +11548,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 606142464,
+                "id": 606142464,
+                "individual_id": 33,
                 "name": "Zacatecas",
                 "translations": {
                     "japanese": "サカテカス州",
@@ -11600,8 +11600,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 620756992,
+                "id": 620756992,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11627,8 +11627,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 620822528,
+                "id": 620822528,
+                "individual_id": 1,
                 "name": "Montserrat",
                 "translations": {
                     "japanese": "モントセラト",
@@ -11679,8 +11679,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 637534208,
+                "id": 637534208,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11706,8 +11706,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 637599744,
+                "id": 637599744,
+                "individual_id": 1,
                 "name": "Netherlands Antilles",
                 "translations": {
                     "japanese": "オランダ領アンティル",
@@ -11758,8 +11758,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 654311424,
+                "id": 654311424,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11785,8 +11785,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 654442496,
+                "id": 654442496,
+                "individual_id": 2,
                 "name": "Managua",
                 "translations": {
                     "japanese": "マナグア",
@@ -11812,8 +11812,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 654508032,
+                "id": 654508032,
+                "individual_id": 3,
                 "name": "Boaco",
                 "translations": {
                     "japanese": "ボアコ",
@@ -11839,8 +11839,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 654573568,
+                "id": 654573568,
+                "individual_id": 4,
                 "name": "Carazo",
                 "translations": {
                     "japanese": "カラソ",
@@ -11866,8 +11866,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 654639104,
+                "id": 654639104,
+                "individual_id": 5,
                 "name": "Chinandega",
                 "translations": {
                     "japanese": "チナンデガ",
@@ -11893,8 +11893,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 654704640,
+                "id": 654704640,
+                "individual_id": 6,
                 "name": "Chontales",
                 "translations": {
                     "japanese": "チョンタレス",
@@ -11920,8 +11920,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 654770176,
+                "id": 654770176,
+                "individual_id": 7,
                 "name": "Estelí",
                 "translations": {
                     "japanese": "エステリ",
@@ -11947,8 +11947,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 654835712,
+                "id": 654835712,
+                "individual_id": 8,
                 "name": "Granada",
                 "translations": {
                     "japanese": "グラナダ",
@@ -11974,8 +11974,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 654901248,
+                "id": 654901248,
+                "individual_id": 9,
                 "name": "Jinotega",
                 "translations": {
                     "japanese": "ヒノテガ",
@@ -12001,8 +12001,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 654966784,
+                "id": 654966784,
+                "individual_id": 10,
                 "name": "León",
                 "translations": {
                     "japanese": "レオン",
@@ -12028,8 +12028,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 655032320,
+                "id": 655032320,
+                "individual_id": 11,
                 "name": "Madriz",
                 "translations": {
                     "japanese": "マドリス",
@@ -12055,8 +12055,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 655097856,
+                "id": 655097856,
+                "individual_id": 12,
                 "name": "Masaya",
                 "translations": {
                     "japanese": "マサヤ",
@@ -12082,8 +12082,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 655163392,
+                "id": 655163392,
+                "individual_id": 13,
                 "name": "Matagalpa",
                 "translations": {
                     "japanese": "マタガルパ",
@@ -12109,8 +12109,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 655228928,
+                "id": 655228928,
+                "individual_id": 14,
                 "name": "Nueva Segovia",
                 "translations": {
                     "japanese": "ヌエバ・セゴビア",
@@ -12136,8 +12136,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 655294464,
+                "id": 655294464,
+                "individual_id": 15,
                 "name": "Río San Juan",
                 "translations": {
                     "japanese": "リオ・サン・フアン",
@@ -12163,8 +12163,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 655360000,
+                "id": 655360000,
+                "individual_id": 16,
                 "name": "Rivas",
                 "translations": {
                     "japanese": "リバス",
@@ -12190,8 +12190,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 655425536,
+                "id": 655425536,
+                "individual_id": 17,
                 "name": "Atlántico Norte",
                 "translations": {
                     "japanese": "北アトランティコ自治地域",
@@ -12217,8 +12217,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 655491072,
+                "id": 655491072,
+                "individual_id": 18,
                 "name": "Atlántico Sur",
                 "translations": {
                     "japanese": "南アトランティコ自治地域",
@@ -12269,8 +12269,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 671088640,
+                "id": 671088640,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -12296,8 +12296,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 671219712,
+                "id": 671219712,
+                "individual_id": 2,
                 "name": "Panamá",
                 "translations": {
                     "japanese": "パナマ",
@@ -12323,8 +12323,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 671285248,
+                "id": 671285248,
+                "individual_id": 3,
                 "name": "Bocas del Toro",
                 "translations": {
                     "japanese": "ボカズ・デル・トーロ",
@@ -12350,8 +12350,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 671350784,
+                "id": 671350784,
+                "individual_id": 4,
                 "name": "Chiriquí",
                 "translations": {
                     "japanese": "チリキ",
@@ -12377,8 +12377,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 671416320,
+                "id": 671416320,
+                "individual_id": 5,
                 "name": "Coclé",
                 "translations": {
                     "japanese": "コクレ",
@@ -12404,8 +12404,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 671481856,
+                "id": 671481856,
+                "individual_id": 6,
                 "name": "Colón",
                 "translations": {
                     "japanese": "コロン",
@@ -12431,8 +12431,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 671547392,
+                "id": 671547392,
+                "individual_id": 7,
                 "name": "Darién",
                 "translations": {
                     "japanese": "ダリエン",
@@ -12458,8 +12458,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 671612928,
+                "id": 671612928,
+                "individual_id": 8,
                 "name": "Herrera",
                 "translations": {
                     "japanese": "エレーラ",
@@ -12485,8 +12485,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 671678464,
+                "id": 671678464,
+                "individual_id": 9,
                 "name": "Los Santos",
                 "translations": {
                     "japanese": "ロス・サントス",
@@ -12512,8 +12512,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 671744000,
+                "id": 671744000,
+                "individual_id": 10,
                 "name": "Kuna Yala",
                 "translations": {
                     "japanese": "サンブラス諸島",
@@ -12539,8 +12539,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 671809536,
+                "id": 671809536,
+                "individual_id": 11,
                 "name": "Veraguas",
                 "translations": {
                     "japanese": "ベラグアス",
@@ -12591,8 +12591,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 687865856,
+                "id": 687865856,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -12618,8 +12618,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 687996928,
+                "id": 687996928,
+                "individual_id": 2,
                 "name": "Central",
                 "translations": {
                     "japanese": "セントラル県",
@@ -12645,8 +12645,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 688062464,
+                "id": 688062464,
+                "individual_id": 3,
                 "name": "Alto Paraná",
                 "translations": {
                     "japanese": "アルト・パラナ県",
@@ -12672,8 +12672,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 688128000,
+                "id": 688128000,
+                "individual_id": 4,
                 "name": "Amambay",
                 "translations": {
                     "japanese": "アマンバイ県",
@@ -12699,8 +12699,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 688193536,
+                "id": 688193536,
+                "individual_id": 5,
                 "name": "Caaguazú",
                 "translations": {
                     "japanese": "カアグアスー県",
@@ -12726,8 +12726,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 688259072,
+                "id": 688259072,
+                "individual_id": 6,
                 "name": "Caazapá",
                 "translations": {
                     "japanese": "カアサパ県",
@@ -12753,8 +12753,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 688324608,
+                "id": 688324608,
+                "individual_id": 7,
                 "name": "Concepción",
                 "translations": {
                     "japanese": "コンセプシオン県",
@@ -12780,8 +12780,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 688390144,
+                "id": 688390144,
+                "individual_id": 8,
                 "name": "Cordillera",
                 "translations": {
                     "japanese": "コルディリェラ県",
@@ -12807,8 +12807,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 688455680,
+                "id": 688455680,
+                "individual_id": 9,
                 "name": "Guairá",
                 "translations": {
                     "japanese": "グアイラー県",
@@ -12834,8 +12834,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 688521216,
+                "id": 688521216,
+                "individual_id": 10,
                 "name": "Itapúa",
                 "translations": {
                     "japanese": "イタプア県",
@@ -12861,8 +12861,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 688586752,
+                "id": 688586752,
+                "individual_id": 11,
                 "name": "Misiones",
                 "translations": {
                     "japanese": "ミシオネス県",
@@ -12888,8 +12888,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 688652288,
+                "id": 688652288,
+                "individual_id": 12,
                 "name": "Ñeembucú",
                 "translations": {
                     "japanese": "ニェエンブク県",
@@ -12915,8 +12915,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 688717824,
+                "id": 688717824,
+                "individual_id": 13,
                 "name": "Paraguarí",
                 "translations": {
                     "japanese": "パラグアリ県",
@@ -12942,8 +12942,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 688783360,
+                "id": 688783360,
+                "individual_id": 14,
                 "name": "Presidente Hayes",
                 "translations": {
                     "japanese": "プレジデンテ・アエス県",
@@ -12969,8 +12969,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 688848896,
+                "id": 688848896,
+                "individual_id": 15,
                 "name": "San Pedro",
                 "translations": {
                     "japanese": "サン・ペドロ県",
@@ -12996,8 +12996,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 688914432,
+                "id": 688914432,
+                "individual_id": 16,
                 "name": "Canindeyú",
                 "translations": {
                     "japanese": "カニンデジュ県",
@@ -13023,8 +13023,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 688979968,
+                "id": 688979968,
+                "individual_id": 17,
                 "name": "Asunción",
                 "translations": {
                     "japanese": "アスンシオン市",
@@ -13050,8 +13050,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 689045504,
+                "id": 689045504,
+                "individual_id": 18,
                 "name": "Alto Paraguay",
                 "translations": {
                     "japanese": "アルト・パラグアイ県",
@@ -13077,8 +13077,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 689111040,
+                "id": 689111040,
+                "individual_id": 19,
                 "name": "Boquerón",
                 "translations": {
                     "japanese": "ボケロン県",
@@ -13129,8 +13129,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 704643072,
+                "id": 704643072,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13156,8 +13156,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 704774144,
+                "id": 704774144,
+                "individual_id": 2,
                 "name": "Lima",
                 "translations": {
                     "japanese": "リマ",
@@ -13183,8 +13183,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 704839680,
+                "id": 704839680,
+                "individual_id": 3,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス",
@@ -13210,8 +13210,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 704905216,
+                "id": 704905216,
+                "individual_id": 4,
                 "name": "Ancash",
                 "translations": {
                     "japanese": "アンカッシュ",
@@ -13237,8 +13237,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 704970752,
+                "id": 704970752,
+                "individual_id": 5,
                 "name": "Apurímac",
                 "translations": {
                     "japanese": "アプリマック",
@@ -13264,8 +13264,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 705036288,
+                "id": 705036288,
+                "individual_id": 6,
                 "name": "Arequipa",
                 "translations": {
                     "japanese": "アレキパ",
@@ -13291,8 +13291,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 705101824,
+                "id": 705101824,
+                "individual_id": 7,
                 "name": "Ayacucho",
                 "translations": {
                     "japanese": "アヤクーチョ",
@@ -13318,8 +13318,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 705167360,
+                "id": 705167360,
+                "individual_id": 8,
                 "name": "Cajamarca",
                 "translations": {
                     "japanese": "カハマルカ",
@@ -13345,8 +13345,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 705232896,
+                "id": 705232896,
+                "individual_id": 9,
                 "name": "Callao",
                 "translations": {
                     "japanese": "カヤオ",
@@ -13372,8 +13372,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 705298432,
+                "id": 705298432,
+                "individual_id": 10,
                 "name": "Cuzco",
                 "translations": {
                     "japanese": "クスコ",
@@ -13399,8 +13399,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 705363968,
+                "id": 705363968,
+                "individual_id": 11,
                 "name": "Huancavelica",
                 "translations": {
                     "japanese": "ワンカベリカ",
@@ -13426,8 +13426,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 705429504,
+                "id": 705429504,
+                "individual_id": 12,
                 "name": "Huánuco",
                 "translations": {
                     "japanese": "ワヌコ",
@@ -13453,8 +13453,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 705495040,
+                "id": 705495040,
+                "individual_id": 13,
                 "name": "Ica",
                 "translations": {
                     "japanese": "イカ",
@@ -13480,8 +13480,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 705560576,
+                "id": 705560576,
+                "individual_id": 14,
                 "name": "Junín",
                 "translations": {
                     "japanese": "フニン",
@@ -13507,8 +13507,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 705626112,
+                "id": 705626112,
+                "individual_id": 15,
                 "name": "La Libertad",
                 "translations": {
                     "japanese": "ラ・リベルター",
@@ -13534,8 +13534,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 705691648,
+                "id": 705691648,
+                "individual_id": 16,
                 "name": "Lambayeque",
                 "translations": {
                     "japanese": "ランバイェケ",
@@ -13561,8 +13561,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 705757184,
+                "id": 705757184,
+                "individual_id": 17,
                 "name": "Loreto",
                 "translations": {
                     "japanese": "ロレト",
@@ -13588,8 +13588,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 705822720,
+                "id": 705822720,
+                "individual_id": 18,
                 "name": "Madre de Dios",
                 "translations": {
                     "japanese": "マドレ・デ・ディオス",
@@ -13615,8 +13615,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 705888256,
+                "id": 705888256,
+                "individual_id": 19,
                 "name": "Moquegua",
                 "translations": {
                     "japanese": "モケグア",
@@ -13642,8 +13642,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 705953792,
+                "id": 705953792,
+                "individual_id": 20,
                 "name": "Pasco",
                 "translations": {
                     "japanese": "パスコ",
@@ -13669,8 +13669,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 706019328,
+                "id": 706019328,
+                "individual_id": 21,
                 "name": "Piura",
                 "translations": {
                     "japanese": "ピウラ",
@@ -13696,8 +13696,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 706084864,
+                "id": 706084864,
+                "individual_id": 22,
                 "name": "Puno",
                 "translations": {
                     "japanese": "プーノ",
@@ -13723,8 +13723,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 706150400,
+                "id": 706150400,
+                "individual_id": 23,
                 "name": "San Martín",
                 "translations": {
                     "japanese": "サン・マルティン",
@@ -13750,8 +13750,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 706215936,
+                "id": 706215936,
+                "individual_id": 24,
                 "name": "Tacna",
                 "translations": {
                     "japanese": "タクナ",
@@ -13777,8 +13777,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 706281472,
+                "id": 706281472,
+                "individual_id": 25,
                 "name": "Tumbes",
                 "translations": {
                     "japanese": "トゥンベス",
@@ -13804,8 +13804,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 706347008,
+                "id": 706347008,
+                "individual_id": 26,
                 "name": "Ucayali",
                 "translations": {
                     "japanese": "ウカヤリ",
@@ -13856,8 +13856,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 721420288,
+                "id": 721420288,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13883,8 +13883,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 721551360,
+                "id": 721551360,
+                "individual_id": 2,
                 "name": "Saint George Basseterre",
                 "translations": {
                     "japanese": "セント・ジョージ・バセテール",
@@ -13910,8 +13910,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 721616896,
+                "id": 721616896,
+                "individual_id": 3,
                 "name": "Christ Church Nichola Town",
                 "translations": {
                     "japanese": "クライスト・チャーチ・ニコラタウン",
@@ -13937,8 +13937,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 721682432,
+                "id": 721682432,
+                "individual_id": 4,
                 "name": "Saint Anne Sandy Point",
                 "translations": {
                     "japanese": "セント・アン・サンディ・ポイント",
@@ -13964,8 +13964,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 721747968,
+                "id": 721747968,
+                "individual_id": 5,
                 "name": "Saint George Gingerland",
                 "translations": {
                     "japanese": "セント・ジョージ・ジンジャーランド",
@@ -13991,8 +13991,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 721813504,
+                "id": 721813504,
+                "individual_id": 6,
                 "name": "Saint James Windward",
                 "translations": {
                     "japanese": "セント・ジェームズ・ウィンドワード",
@@ -14018,8 +14018,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 721879040,
+                "id": 721879040,
+                "individual_id": 7,
                 "name": "Saint John Capesterre",
                 "translations": {
                     "japanese": "セント・ジョン・カピステール",
@@ -14045,8 +14045,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 721944576,
+                "id": 721944576,
+                "individual_id": 8,
                 "name": "Saint John Figtree",
                 "translations": {
                     "japanese": "セント・ジョン・フィッグトリー",
@@ -14072,8 +14072,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 722010112,
+                "id": 722010112,
+                "individual_id": 9,
                 "name": "Saint Mary Cayon",
                 "translations": {
                     "japanese": "セント・メリー・ケーヨン",
@@ -14099,8 +14099,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 722075648,
+                "id": 722075648,
+                "individual_id": 10,
                 "name": "Saint Paul Capesterre",
                 "translations": {
                     "japanese": "セント・ポール・カピステール",
@@ -14126,8 +14126,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 722141184,
+                "id": 722141184,
+                "individual_id": 11,
                 "name": "Saint Paul Charlestown",
                 "translations": {
                     "japanese": "セント・ポール・チャールズタウン",
@@ -14153,8 +14153,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 722206720,
+                "id": 722206720,
+                "individual_id": 12,
                 "name": "Saint Peter Basseterre",
                 "translations": {
                     "japanese": "セント・ピーター・バセテール",
@@ -14180,8 +14180,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 722272256,
+                "id": 722272256,
+                "individual_id": 13,
                 "name": "Saint Thomas Lowland",
                 "translations": {
                     "japanese": "セント・トーマス・ロウランド",
@@ -14207,8 +14207,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 722337792,
+                "id": 722337792,
+                "individual_id": 14,
                 "name": "Saint Thomas Middle Island",
                 "translations": {
                     "japanese": "セント・トーマス・ミドルアイランド",
@@ -14234,8 +14234,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 722403328,
+                "id": 722403328,
+                "individual_id": 15,
                 "name": "Trinity Palmetto Point",
                 "translations": {
                     "japanese": "トリニティ・パルメット・ポイント",
@@ -14286,8 +14286,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 738197504,
+                "id": 738197504,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14313,8 +14313,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 738263040,
+                "id": 738263040,
+                "individual_id": 1,
                 "name": "St. Lucia",
                 "translations": {
                     "japanese": "セントルシア",
@@ -14365,8 +14365,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 754974720,
+                "id": 754974720,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14392,8 +14392,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 755040256,
+                "id": 755040256,
+                "individual_id": 1,
                 "name": "St. Vincent and the Grenadines",
                 "translations": {
                     "japanese": "セントビンセント・グレナディーン",
@@ -14444,8 +14444,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 771751936,
+                "id": 771751936,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14471,8 +14471,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 771883008,
+                "id": 771883008,
+                "individual_id": 2,
                 "name": "Paramaribo",
                 "translations": {
                     "japanese": "パラマリボ",
@@ -14498,8 +14498,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 771948544,
+                "id": 771948544,
+                "individual_id": 3,
                 "name": "Brokopondo",
                 "translations": {
                     "japanese": "ブロコポンド",
@@ -14525,8 +14525,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 772014080,
+                "id": 772014080,
+                "individual_id": 4,
                 "name": "Commewijne",
                 "translations": {
                     "japanese": "コメウィネ",
@@ -14552,8 +14552,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 772079616,
+                "id": 772079616,
+                "individual_id": 5,
                 "name": "Coronie",
                 "translations": {
                     "japanese": "コロニー",
@@ -14579,8 +14579,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 772145152,
+                "id": 772145152,
+                "individual_id": 6,
                 "name": "Marowijne",
                 "translations": {
                     "japanese": "マロウィネ",
@@ -14606,8 +14606,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 772210688,
+                "id": 772210688,
+                "individual_id": 7,
                 "name": "Nickerie",
                 "translations": {
                     "japanese": "ニッケリー",
@@ -14633,8 +14633,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 772276224,
+                "id": 772276224,
+                "individual_id": 8,
                 "name": "Para",
                 "translations": {
                     "japanese": "パラ",
@@ -14660,8 +14660,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 772341760,
+                "id": 772341760,
+                "individual_id": 9,
                 "name": "Saramacca",
                 "translations": {
                     "japanese": "サラマッカ",
@@ -14687,8 +14687,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 772407296,
+                "id": 772407296,
+                "individual_id": 10,
                 "name": "Sipaliwini",
                 "translations": {
                     "japanese": "シパリウィニ",
@@ -14714,8 +14714,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 772472832,
+                "id": 772472832,
+                "individual_id": 11,
                 "name": "Wanica",
                 "translations": {
                     "japanese": "ワニカ",
@@ -14766,8 +14766,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 788529152,
+                "id": 788529152,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14793,8 +14793,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 788660224,
+                "id": 788660224,
+                "individual_id": 2,
                 "name": "Port-of-Spain",
                 "translations": {
                     "japanese": "ポート・オブ・スペイン",
@@ -14820,8 +14820,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 788725760,
+                "id": 788725760,
+                "individual_id": 3,
                 "name": "Arima",
                 "translations": {
                     "japanese": "アリマ",
@@ -14847,8 +14847,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 788791296,
+                "id": 788791296,
+                "individual_id": 4,
                 "name": "Caroni",
                 "translations": {
                     "japanese": "カロニ州",
@@ -14874,8 +14874,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 788856832,
+                "id": 788856832,
+                "individual_id": 5,
                 "name": "Mayaro",
                 "translations": {
                     "japanese": "マジャロ州",
@@ -14901,8 +14901,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 788922368,
+                "id": 788922368,
+                "individual_id": 6,
                 "name": "Nariva",
                 "translations": {
                     "japanese": "ナリバ州",
@@ -14928,8 +14928,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 788987904,
+                "id": 788987904,
+                "individual_id": 7,
                 "name": "Saint Andrew",
                 "translations": {
                     "japanese": "セント・アンドリュー州",
@@ -14955,8 +14955,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 789053440,
+                "id": 789053440,
+                "individual_id": 8,
                 "name": "Saint David",
                 "translations": {
                     "japanese": "セント・デビッド州",
@@ -14982,8 +14982,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 789118976,
+                "id": 789118976,
+                "individual_id": 9,
                 "name": "Saint George",
                 "translations": {
                     "japanese": "セント・ジョージ州",
@@ -15009,8 +15009,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 789184512,
+                "id": 789184512,
+                "individual_id": 10,
                 "name": "Saint Patrick",
                 "translations": {
                     "japanese": "セント・パトリック州",
@@ -15036,8 +15036,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 789250048,
+                "id": 789250048,
+                "individual_id": 11,
                 "name": "San Fernando",
                 "translations": {
                     "japanese": "サン・フェルナンド",
@@ -15063,8 +15063,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 789315584,
+                "id": 789315584,
+                "individual_id": 12,
                 "name": "Tobago",
                 "translations": {
                     "japanese": "トバゴ島",
@@ -15090,8 +15090,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 789381120,
+                "id": 789381120,
+                "individual_id": 13,
                 "name": "Victoria",
                 "translations": {
                     "japanese": "ビクトリア州",
@@ -15117,8 +15117,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 789446656,
+                "id": 789446656,
+                "individual_id": 14,
                 "name": "Point Fortin",
                 "translations": {
                     "japanese": "ポイントフォーティン",
@@ -15169,8 +15169,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 805306368,
+                "id": 805306368,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -15196,8 +15196,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 805371904,
+                "id": 805371904,
+                "individual_id": 1,
                 "name": "Turks and Caicos Islands",
                 "translations": {
                     "japanese": "タークス・カイコス諸島",
@@ -15248,8 +15248,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 822083584,
+                "id": 822083584,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -15275,8 +15275,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 822214656,
+                "id": 822214656,
+                "individual_id": 2,
                 "name": "District of Columbia",
                 "translations": {
                     "japanese": "コロンビア特別区",
@@ -15302,8 +15302,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 822280192,
+                "id": 822280192,
+                "individual_id": 3,
                 "name": "Alaska",
                 "translations": {
                     "japanese": "アラスカ州",
@@ -15329,8 +15329,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 822345728,
+                "id": 822345728,
+                "individual_id": 4,
                 "name": "Alabama",
                 "translations": {
                     "japanese": "アラバマ州",
@@ -15356,8 +15356,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 822411264,
+                "id": 822411264,
+                "individual_id": 5,
                 "name": "Arkansas",
                 "translations": {
                     "japanese": "アーカンソー州",
@@ -15383,8 +15383,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 822476800,
+                "id": 822476800,
+                "individual_id": 6,
                 "name": "Arizona",
                 "translations": {
                     "japanese": "アリゾナ州",
@@ -15410,8 +15410,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 822542336,
+                "id": 822542336,
+                "individual_id": 7,
                 "name": "California",
                 "translations": {
                     "japanese": "カリフォルニア州",
@@ -15437,8 +15437,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 822607872,
+                "id": 822607872,
+                "individual_id": 8,
                 "name": "Colorado",
                 "translations": {
                     "japanese": "コロラド州",
@@ -15464,8 +15464,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 822673408,
+                "id": 822673408,
+                "individual_id": 9,
                 "name": "Connecticut",
                 "translations": {
                     "japanese": "コネティカット州",
@@ -15491,8 +15491,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 822738944,
+                "id": 822738944,
+                "individual_id": 10,
                 "name": "Delaware",
                 "translations": {
                     "japanese": "デラウェア州",
@@ -15518,8 +15518,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 822804480,
+                "id": 822804480,
+                "individual_id": 11,
                 "name": "Florida",
                 "translations": {
                     "japanese": "フロリダ州",
@@ -15545,8 +15545,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 822870016,
+                "id": 822870016,
+                "individual_id": 12,
                 "name": "Georgia",
                 "translations": {
                     "japanese": "ジョージア州",
@@ -15572,8 +15572,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 822935552,
+                "id": 822935552,
+                "individual_id": 13,
                 "name": "Hawaii",
                 "translations": {
                     "japanese": "ハワイ州",
@@ -15599,8 +15599,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 823001088,
+                "id": 823001088,
+                "individual_id": 14,
                 "name": "Iowa",
                 "translations": {
                     "japanese": "アイオワ州",
@@ -15626,8 +15626,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 823066624,
+                "id": 823066624,
+                "individual_id": 15,
                 "name": "Idaho",
                 "translations": {
                     "japanese": "アイダホ州",
@@ -15653,8 +15653,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 823132160,
+                "id": 823132160,
+                "individual_id": 16,
                 "name": "Illinois",
                 "translations": {
                     "japanese": "イリノイ州",
@@ -15680,8 +15680,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 823197696,
+                "id": 823197696,
+                "individual_id": 17,
                 "name": "Indiana",
                 "translations": {
                     "japanese": "インディアナ州",
@@ -15707,8 +15707,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 823263232,
+                "id": 823263232,
+                "individual_id": 18,
                 "name": "Kansas",
                 "translations": {
                     "japanese": "カンザス州",
@@ -15734,8 +15734,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 823328768,
+                "id": 823328768,
+                "individual_id": 19,
                 "name": "Kentucky",
                 "translations": {
                     "japanese": "ケンタッキー州",
@@ -15761,8 +15761,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 823394304,
+                "id": 823394304,
+                "individual_id": 20,
                 "name": "Louisiana",
                 "translations": {
                     "japanese": "ルイジアナ州",
@@ -15788,8 +15788,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 823459840,
+                "id": 823459840,
+                "individual_id": 21,
                 "name": "Massachusetts",
                 "translations": {
                     "japanese": "マサチューセッツ州",
@@ -15815,8 +15815,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 823525376,
+                "id": 823525376,
+                "individual_id": 22,
                 "name": "Maryland",
                 "translations": {
                     "japanese": "メリーランド州",
@@ -15842,8 +15842,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 823590912,
+                "id": 823590912,
+                "individual_id": 23,
                 "name": "Maine",
                 "translations": {
                     "japanese": "メーン州",
@@ -15869,8 +15869,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 823656448,
+                "id": 823656448,
+                "individual_id": 24,
                 "name": "Michigan",
                 "translations": {
                     "japanese": "ミシガン州",
@@ -15896,8 +15896,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 823721984,
+                "id": 823721984,
+                "individual_id": 25,
                 "name": "Minnesota",
                 "translations": {
                     "japanese": "ミネソタ州",
@@ -15923,8 +15923,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 823787520,
+                "id": 823787520,
+                "individual_id": 26,
                 "name": "Missouri",
                 "translations": {
                     "japanese": "ミズーリ州",
@@ -15950,8 +15950,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 823853056,
+                "id": 823853056,
+                "individual_id": 27,
                 "name": "Mississippi",
                 "translations": {
                     "japanese": "ミシシッピ州",
@@ -15977,8 +15977,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 823918592,
+                "id": 823918592,
+                "individual_id": 28,
                 "name": "Montana",
                 "translations": {
                     "japanese": "モンタナ州",
@@ -16004,8 +16004,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 823984128,
+                "id": 823984128,
+                "individual_id": 29,
                 "name": "North Carolina",
                 "translations": {
                     "japanese": "ノースカロライナ州",
@@ -16031,8 +16031,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 824049664,
+                "id": 824049664,
+                "individual_id": 30,
                 "name": "North Dakota",
                 "translations": {
                     "japanese": "ノースダコタ州",
@@ -16058,8 +16058,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 824115200,
+                "id": 824115200,
+                "individual_id": 31,
                 "name": "Nebraska",
                 "translations": {
                     "japanese": "ネブラスカ州",
@@ -16085,8 +16085,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 824180736,
+                "id": 824180736,
+                "individual_id": 32,
                 "name": "New Hampshire",
                 "translations": {
                     "japanese": "ニューハンプシャー州",
@@ -16112,8 +16112,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 824246272,
+                "id": 824246272,
+                "individual_id": 33,
                 "name": "New Jersey",
                 "translations": {
                     "japanese": "ニュージャージー州",
@@ -16139,8 +16139,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 824311808,
+                "id": 824311808,
+                "individual_id": 34,
                 "name": "New Mexico",
                 "translations": {
                     "japanese": "ニューメキシコ州",
@@ -16166,8 +16166,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 824377344,
+                "id": 824377344,
+                "individual_id": 35,
                 "name": "Nevada",
                 "translations": {
                     "japanese": "ネバダ州",
@@ -16193,8 +16193,8 @@
                 }
             },
             {
-                "id": 36,
-                "full_id": 824442880,
+                "id": 824442880,
+                "individual_id": 36,
                 "name": "New York",
                 "translations": {
                     "japanese": "ニューヨーク州",
@@ -16220,8 +16220,8 @@
                 }
             },
             {
-                "id": 37,
-                "full_id": 824508416,
+                "id": 824508416,
+                "individual_id": 37,
                 "name": "Ohio",
                 "translations": {
                     "japanese": "オハイオ州",
@@ -16247,8 +16247,8 @@
                 }
             },
             {
-                "id": 38,
-                "full_id": 824573952,
+                "id": 824573952,
+                "individual_id": 38,
                 "name": "Oklahoma",
                 "translations": {
                     "japanese": "オクラホマ州",
@@ -16274,8 +16274,8 @@
                 }
             },
             {
-                "id": 39,
-                "full_id": 824639488,
+                "id": 824639488,
+                "individual_id": 39,
                 "name": "Oregon",
                 "translations": {
                     "japanese": "オレゴン州",
@@ -16301,8 +16301,8 @@
                 }
             },
             {
-                "id": 40,
-                "full_id": 824705024,
+                "id": 824705024,
+                "individual_id": 40,
                 "name": "Pennsylvania",
                 "translations": {
                     "japanese": "ペンシルベニア州",
@@ -16328,8 +16328,8 @@
                 }
             },
             {
-                "id": 41,
-                "full_id": 824770560,
+                "id": 824770560,
+                "individual_id": 41,
                 "name": "Rhode Island",
                 "translations": {
                     "japanese": "ロードアイランド州",
@@ -16355,8 +16355,8 @@
                 }
             },
             {
-                "id": 42,
-                "full_id": 824836096,
+                "id": 824836096,
+                "individual_id": 42,
                 "name": "South Carolina",
                 "translations": {
                     "japanese": "サウスカロライナ州",
@@ -16382,8 +16382,8 @@
                 }
             },
             {
-                "id": 43,
-                "full_id": 824901632,
+                "id": 824901632,
+                "individual_id": 43,
                 "name": "South Dakota",
                 "translations": {
                     "japanese": "サウスダコタ州",
@@ -16409,8 +16409,8 @@
                 }
             },
             {
-                "id": 44,
-                "full_id": 824967168,
+                "id": 824967168,
+                "individual_id": 44,
                 "name": "Tennessee",
                 "translations": {
                     "japanese": "テネシー州",
@@ -16436,8 +16436,8 @@
                 }
             },
             {
-                "id": 45,
-                "full_id": 825032704,
+                "id": 825032704,
+                "individual_id": 45,
                 "name": "Texas",
                 "translations": {
                     "japanese": "テキサス州",
@@ -16463,8 +16463,8 @@
                 }
             },
             {
-                "id": 46,
-                "full_id": 825098240,
+                "id": 825098240,
+                "individual_id": 46,
                 "name": "Utah",
                 "translations": {
                     "japanese": "ユタ州",
@@ -16490,8 +16490,8 @@
                 }
             },
             {
-                "id": 47,
-                "full_id": 825163776,
+                "id": 825163776,
+                "individual_id": 47,
                 "name": "Virginia",
                 "translations": {
                     "japanese": "バージニア州",
@@ -16517,8 +16517,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 825229312,
+                "id": 825229312,
+                "individual_id": 48,
                 "name": "Vermont",
                 "translations": {
                     "japanese": "バーモント州",
@@ -16544,8 +16544,8 @@
                 }
             },
             {
-                "id": 49,
-                "full_id": 825294848,
+                "id": 825294848,
+                "individual_id": 49,
                 "name": "Washington",
                 "translations": {
                     "japanese": "ワシントン州",
@@ -16571,8 +16571,8 @@
                 }
             },
             {
-                "id": 50,
-                "full_id": 825360384,
+                "id": 825360384,
+                "individual_id": 50,
                 "name": "Wisconsin",
                 "translations": {
                     "japanese": "ウィスコンシン州",
@@ -16598,8 +16598,8 @@
                 }
             },
             {
-                "id": 51,
-                "full_id": 825425920,
+                "id": 825425920,
+                "individual_id": 51,
                 "name": "West Virginia",
                 "translations": {
                     "japanese": "ウェストバージニア州",
@@ -16625,8 +16625,8 @@
                 }
             },
             {
-                "id": 52,
-                "full_id": 825491456,
+                "id": 825491456,
+                "individual_id": 52,
                 "name": "Wyoming",
                 "translations": {
                     "japanese": "ワイオミング州",
@@ -16652,8 +16652,8 @@
                 }
             },
             {
-                "id": 53,
-                "full_id": 825556992,
+                "id": 825556992,
+                "individual_id": 53,
                 "name": "Puerto Rico",
                 "translations": {
                     "japanese": "プエルトリコ",
@@ -16704,8 +16704,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 838860800,
+                "id": 838860800,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -16731,8 +16731,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 838991872,
+                "id": 838991872,
+                "individual_id": 2,
                 "name": "Montevideo",
                 "translations": {
                     "japanese": "モンテビデオ",
@@ -16758,8 +16758,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 839057408,
+                "id": 839057408,
+                "individual_id": 3,
                 "name": "Artigas",
                 "translations": {
                     "japanese": "アルティガス",
@@ -16785,8 +16785,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 839122944,
+                "id": 839122944,
+                "individual_id": 4,
                 "name": "Canelones",
                 "translations": {
                     "japanese": "カネロネス",
@@ -16812,8 +16812,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 839188480,
+                "id": 839188480,
+                "individual_id": 5,
                 "name": "Cerro Largo",
                 "translations": {
                     "japanese": "セロ・ラルゴ",
@@ -16839,8 +16839,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 839254016,
+                "id": 839254016,
+                "individual_id": 6,
                 "name": "Colonia",
                 "translations": {
                     "japanese": "コロニア",
@@ -16866,8 +16866,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 839319552,
+                "id": 839319552,
+                "individual_id": 7,
                 "name": "Durazno",
                 "translations": {
                     "japanese": "ドゥラスノ",
@@ -16893,8 +16893,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 839385088,
+                "id": 839385088,
+                "individual_id": 8,
                 "name": "Flores",
                 "translations": {
                     "japanese": "フロレス",
@@ -16920,8 +16920,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 839450624,
+                "id": 839450624,
+                "individual_id": 9,
                 "name": "Florida",
                 "translations": {
                     "japanese": "フロリダ",
@@ -16947,8 +16947,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 839516160,
+                "id": 839516160,
+                "individual_id": 10,
                 "name": "Lavalleja",
                 "translations": {
                     "japanese": "ラバジェハ",
@@ -16974,8 +16974,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 839581696,
+                "id": 839581696,
+                "individual_id": 11,
                 "name": "Maldonado",
                 "translations": {
                     "japanese": "マルドナド",
@@ -17001,8 +17001,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 839647232,
+                "id": 839647232,
+                "individual_id": 12,
                 "name": "Paysandú",
                 "translations": {
                     "japanese": "パイサンドゥ",
@@ -17028,8 +17028,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 839712768,
+                "id": 839712768,
+                "individual_id": 13,
                 "name": "Río Negro",
                 "translations": {
                     "japanese": "リオ・ネグロ",
@@ -17055,8 +17055,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 839778304,
+                "id": 839778304,
+                "individual_id": 14,
                 "name": "Rivera",
                 "translations": {
                     "japanese": "リベラ",
@@ -17082,8 +17082,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 839843840,
+                "id": 839843840,
+                "individual_id": 15,
                 "name": "Rocha",
                 "translations": {
                     "japanese": "ロチャ",
@@ -17109,8 +17109,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 839909376,
+                "id": 839909376,
+                "individual_id": 16,
                 "name": "Salto",
                 "translations": {
                     "japanese": "サルト",
@@ -17136,8 +17136,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 839974912,
+                "id": 839974912,
+                "individual_id": 17,
                 "name": "San José",
                 "translations": {
                     "japanese": "サン・ホセ",
@@ -17163,8 +17163,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 840040448,
+                "id": 840040448,
+                "individual_id": 18,
                 "name": "Soriano",
                 "translations": {
                     "japanese": "ソリアノ",
@@ -17190,8 +17190,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 840105984,
+                "id": 840105984,
+                "individual_id": 19,
                 "name": "Tacuarembó",
                 "translations": {
                     "japanese": "タクアレンボ",
@@ -17217,8 +17217,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 840171520,
+                "id": 840171520,
+                "individual_id": 20,
                 "name": "Treinta y Tres",
                 "translations": {
                     "japanese": "トレインタ・イ・トレス",
@@ -17269,8 +17269,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 855638016,
+                "id": 855638016,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -17296,8 +17296,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 855703552,
+                "id": 855703552,
+                "individual_id": 1,
                 "name": "US Virgin Islands",
                 "translations": {
                     "japanese": "米領バージン諸島",
@@ -17348,8 +17348,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 872415232,
+                "id": 872415232,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -17375,8 +17375,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 872546304,
+                "id": 872546304,
+                "individual_id": 2,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト首都地区",
@@ -17402,8 +17402,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 872611840,
+                "id": 872611840,
+                "individual_id": 3,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス",
@@ -17429,8 +17429,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 872677376,
+                "id": 872677376,
+                "individual_id": 4,
                 "name": "Anzoátegui",
                 "translations": {
                     "japanese": "アンソアテギ",
@@ -17456,8 +17456,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 872742912,
+                "id": 872742912,
+                "individual_id": 5,
                 "name": "Apure",
                 "translations": {
                     "japanese": "アプレ",
@@ -17483,8 +17483,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 872808448,
+                "id": 872808448,
+                "individual_id": 6,
                 "name": "Aragua",
                 "translations": {
                     "japanese": "アラグア",
@@ -17510,8 +17510,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 872873984,
+                "id": 872873984,
+                "individual_id": 7,
                 "name": "Barinas",
                 "translations": {
                     "japanese": "バリナス",
@@ -17537,8 +17537,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 872939520,
+                "id": 872939520,
+                "individual_id": 8,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル",
@@ -17564,8 +17564,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 873005056,
+                "id": 873005056,
+                "individual_id": 9,
                 "name": "Carabobo",
                 "translations": {
                     "japanese": "カラボボ",
@@ -17591,8 +17591,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 873070592,
+                "id": 873070592,
+                "individual_id": 10,
                 "name": "Cojedes",
                 "translations": {
                     "japanese": "コヘデス",
@@ -17618,8 +17618,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 873136128,
+                "id": 873136128,
+                "individual_id": 11,
                 "name": "Delta Amacuro",
                 "translations": {
                     "japanese": "デルタ・アマクロ",
@@ -17645,8 +17645,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 873201664,
+                "id": 873201664,
+                "individual_id": 12,
                 "name": "Falcón",
                 "translations": {
                     "japanese": "ファルコン",
@@ -17672,8 +17672,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 873267200,
+                "id": 873267200,
+                "individual_id": 13,
                 "name": "Guárico",
                 "translations": {
                     "japanese": "グアリコ",
@@ -17699,8 +17699,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 873332736,
+                "id": 873332736,
+                "individual_id": 14,
                 "name": "Lara",
                 "translations": {
                     "japanese": "ララ",
@@ -17726,8 +17726,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 873398272,
+                "id": 873398272,
+                "individual_id": 15,
                 "name": "Mérida",
                 "translations": {
                     "japanese": "メリダ",
@@ -17753,8 +17753,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 873463808,
+                "id": 873463808,
+                "individual_id": 16,
                 "name": "Miranda",
                 "translations": {
                     "japanese": "ミランダ",
@@ -17780,8 +17780,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 873529344,
+                "id": 873529344,
+                "individual_id": 17,
                 "name": "Monagas",
                 "translations": {
                     "japanese": "モナガス",
@@ -17807,8 +17807,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 873594880,
+                "id": 873594880,
+                "individual_id": 18,
                 "name": "Nueva Esparta",
                 "translations": {
                     "japanese": "ヌエバエスパルタ",
@@ -17834,8 +17834,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 873660416,
+                "id": 873660416,
+                "individual_id": 19,
                 "name": "Portuguesa",
                 "translations": {
                     "japanese": "ポルトゥゲサ",
@@ -17861,8 +17861,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 873725952,
+                "id": 873725952,
+                "individual_id": 20,
                 "name": "Sucre",
                 "translations": {
                     "japanese": "スクレ",
@@ -17888,8 +17888,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 873791488,
+                "id": 873791488,
+                "individual_id": 21,
                 "name": "Táchira",
                 "translations": {
                     "japanese": "タチラ",
@@ -17915,8 +17915,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 873857024,
+                "id": 873857024,
+                "individual_id": 22,
                 "name": "Trujillo",
                 "translations": {
                     "japanese": "トルヒーヨ",
@@ -17942,8 +17942,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 873922560,
+                "id": 873922560,
+                "individual_id": 23,
                 "name": "Yaracuy",
                 "translations": {
                     "japanese": "ヤラクイ",
@@ -17969,8 +17969,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 873988096,
+                "id": 873988096,
+                "individual_id": 24,
                 "name": "Zulia",
                 "translations": {
                     "japanese": "スリア",
@@ -17996,8 +17996,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 874053632,
+                "id": 874053632,
+                "individual_id": 25,
                 "name": "Dependencias Federales",
                 "translations": {
                     "japanese": "連邦保護領",
@@ -18023,8 +18023,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 874119168,
+                "id": 874119168,
+                "individual_id": 26,
                 "name": "Vargas",
                 "translations": {
                     "japanese": "バルガス",
@@ -18075,8 +18075,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1073741824,
+                "id": 1073741824,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18102,8 +18102,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1073872896,
+                "id": 1073872896,
+                "individual_id": 2,
                 "name": "Tirana",
                 "translations": {
                     "japanese": "ティラナ州",
@@ -18129,8 +18129,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1073938432,
+                "id": 1073938432,
+                "individual_id": 3,
                 "name": "Berat",
                 "translations": {
                     "japanese": "ベラト州",
@@ -18156,8 +18156,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1074003968,
+                "id": 1074003968,
+                "individual_id": 4,
                 "name": "Dibër",
                 "translations": {
                     "japanese": "ディブラ州",
@@ -18183,8 +18183,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1074069504,
+                "id": 1074069504,
+                "individual_id": 5,
                 "name": "Durrës",
                 "translations": {
                     "japanese": "デュラス州",
@@ -18210,8 +18210,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1074135040,
+                "id": 1074135040,
+                "individual_id": 6,
                 "name": "Elbasan",
                 "translations": {
                     "japanese": "エルバサン州",
@@ -18237,8 +18237,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1074200576,
+                "id": 1074200576,
+                "individual_id": 7,
                 "name": "Fier",
                 "translations": {
                     "japanese": "フィエル州",
@@ -18264,8 +18264,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1074266112,
+                "id": 1074266112,
+                "individual_id": 8,
                 "name": "Gjirokastër",
                 "translations": {
                     "japanese": "ギロカストラ州",
@@ -18291,8 +18291,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1074331648,
+                "id": 1074331648,
+                "individual_id": 9,
                 "name": "Korçë",
                 "translations": {
                     "japanese": "コルチャ州",
@@ -18318,8 +18318,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1074397184,
+                "id": 1074397184,
+                "individual_id": 10,
                 "name": "Kukës",
                 "translations": {
                     "japanese": "クケス州",
@@ -18345,8 +18345,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1074462720,
+                "id": 1074462720,
+                "individual_id": 11,
                 "name": "Lezhë",
                 "translations": {
                     "japanese": "レジャ州",
@@ -18372,8 +18372,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1074528256,
+                "id": 1074528256,
+                "individual_id": 12,
                 "name": "Shkodër",
                 "translations": {
                     "japanese": "シュコドラ州",
@@ -18399,8 +18399,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1074593792,
+                "id": 1074593792,
+                "individual_id": 13,
                 "name": "Vlorë",
                 "translations": {
                     "japanese": "ヴロラ州",
@@ -18451,8 +18451,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1090519040,
+                "id": 1090519040,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18478,8 +18478,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1090650112,
+                "id": 1090650112,
+                "individual_id": 2,
                 "name": "Australian Capital Territory",
                 "translations": {
                     "japanese": "オーストラリア首都特別地域",
@@ -18505,8 +18505,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1090715648,
+                "id": 1090715648,
+                "individual_id": 3,
                 "name": "New South Wales",
                 "translations": {
                     "japanese": "ニューサウスウェールズ州",
@@ -18532,8 +18532,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1090781184,
+                "id": 1090781184,
+                "individual_id": 4,
                 "name": "Northern Territory",
                 "translations": {
                     "japanese": "ノーザンテリトリー",
@@ -18559,8 +18559,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1090846720,
+                "id": 1090846720,
+                "individual_id": 5,
                 "name": "Queensland",
                 "translations": {
                     "japanese": "クィーンズランド州",
@@ -18586,8 +18586,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1090912256,
+                "id": 1090912256,
+                "individual_id": 6,
                 "name": "South Australia",
                 "translations": {
                     "japanese": "南オーストラリア州",
@@ -18613,8 +18613,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1090977792,
+                "id": 1090977792,
+                "individual_id": 7,
                 "name": "Tasmania",
                 "translations": {
                     "japanese": "タスマニア州",
@@ -18640,8 +18640,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1091043328,
+                "id": 1091043328,
+                "individual_id": 8,
                 "name": "Victoria",
                 "translations": {
                     "japanese": "ヴィクトリア州",
@@ -18667,8 +18667,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1091108864,
+                "id": 1091108864,
+                "individual_id": 9,
                 "name": "Western Australia",
                 "translations": {
                     "japanese": "西オーストラリア州",
@@ -18719,8 +18719,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1107296256,
+                "id": 1107296256,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18746,8 +18746,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1107427328,
+                "id": 1107427328,
+                "individual_id": 2,
                 "name": "Vienna",
                 "translations": {
                     "japanese": "ウィーン",
@@ -18773,8 +18773,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1107492864,
+                "id": 1107492864,
+                "individual_id": 3,
                 "name": "Burgenland",
                 "translations": {
                     "japanese": "ブルゲンラント州",
@@ -18800,8 +18800,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1107558400,
+                "id": 1107558400,
+                "individual_id": 4,
                 "name": "Carinthia",
                 "translations": {
                     "japanese": "ケルンテン州",
@@ -18827,8 +18827,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1107623936,
+                "id": 1107623936,
+                "individual_id": 5,
                 "name": "Lower Austria",
                 "translations": {
                     "japanese": "ニーダー・エスターライヒ州",
@@ -18854,8 +18854,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1107689472,
+                "id": 1107689472,
+                "individual_id": 6,
                 "name": "Upper Austria",
                 "translations": {
                     "japanese": "オーバー・エスターライヒ州",
@@ -18881,8 +18881,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1107755008,
+                "id": 1107755008,
+                "individual_id": 7,
                 "name": "Salzburg",
                 "translations": {
                     "japanese": "ザルツブルク州",
@@ -18908,8 +18908,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1107820544,
+                "id": 1107820544,
+                "individual_id": 8,
                 "name": "Styria",
                 "translations": {
                     "japanese": "シュタイアーマルク州",
@@ -18935,8 +18935,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1107886080,
+                "id": 1107886080,
+                "individual_id": 9,
                 "name": "Tyrol",
                 "translations": {
                     "japanese": "ティロル州",
@@ -18962,8 +18962,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1107951616,
+                "id": 1107951616,
+                "individual_id": 10,
                 "name": "Vorarlberg",
                 "translations": {
                     "japanese": "フォアアールベルク州",
@@ -19014,8 +19014,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1124073472,
+                "id": 1124073472,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -19041,8 +19041,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1124204544,
+                "id": 1124204544,
+                "individual_id": 2,
                 "name": "Brussels Region",
                 "translations": {
                     "japanese": "ブリュッセル首都地域圏",
@@ -19068,8 +19068,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1124270080,
+                "id": 1124270080,
+                "individual_id": 3,
                 "name": "Flanders",
                 "translations": {
                     "japanese": "フランデレン地域圏",
@@ -19095,8 +19095,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1124335616,
+                "id": 1124335616,
+                "individual_id": 4,
                 "name": "Wallonia",
                 "translations": {
                     "japanese": "ワロン地域圏",
@@ -19147,8 +19147,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1140850688,
+                "id": 1140850688,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -19174,8 +19174,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1140981760,
+                "id": 1140981760,
+                "individual_id": 2,
                 "name": "Federation of Bosnia and Herzegovina",
                 "translations": {
                     "japanese": "ボスニア・ヘルツェゴビナ連邦",
@@ -19201,8 +19201,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1141047296,
+                "id": 1141047296,
+                "individual_id": 3,
                 "name": "Republika Srpska",
                 "translations": {
                     "japanese": "セルビア人共和国",
@@ -19228,8 +19228,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1141112832,
+                "id": 1141112832,
+                "individual_id": 4,
                 "name": "Brčko District",
                 "translations": {
                     "japanese": "ブルチュコ",
@@ -19280,8 +19280,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1157627904,
+                "id": 1157627904,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -19307,8 +19307,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1157693440,
+                "id": 1157693440,
+                "individual_id": 1,
                 "name": "Botswana",
                 "translations": {
                     "japanese": "ボツワナ",
@@ -19359,8 +19359,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1174405120,
+                "id": 1174405120,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -19386,8 +19386,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1174536192,
+                "id": 1174536192,
+                "individual_id": 2,
                 "name": "Sofia City",
                 "translations": {
                     "japanese": "ソフィア市",
@@ -19413,8 +19413,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1174601728,
+                "id": 1174601728,
+                "individual_id": 3,
                 "name": "Sofia Province",
                 "translations": {
                     "japanese": "ソフィア州",
@@ -19440,8 +19440,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1174667264,
+                "id": 1174667264,
+                "individual_id": 4,
                 "name": "Blagoevgrad",
                 "translations": {
                     "japanese": "ブラゴエブグラト州",
@@ -19467,8 +19467,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1174732800,
+                "id": 1174732800,
+                "individual_id": 5,
                 "name": "Pleven",
                 "translations": {
                     "japanese": "プレベン州",
@@ -19494,8 +19494,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1174798336,
+                "id": 1174798336,
+                "individual_id": 6,
                 "name": "Vidin",
                 "translations": {
                     "japanese": "ビディン州",
@@ -19521,8 +19521,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1174863872,
+                "id": 1174863872,
+                "individual_id": 7,
                 "name": "Varna",
                 "translations": {
                     "japanese": "バルナ州",
@@ -19548,8 +19548,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1174929408,
+                "id": 1174929408,
+                "individual_id": 8,
                 "name": "Burgas",
                 "translations": {
                     "japanese": "ブルガス州",
@@ -19575,8 +19575,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1174994944,
+                "id": 1174994944,
+                "individual_id": 9,
                 "name": "Dobrich",
                 "translations": {
                     "japanese": "ドブリチ州",
@@ -19602,8 +19602,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1175060480,
+                "id": 1175060480,
+                "individual_id": 10,
                 "name": "Gabrovo",
                 "translations": {
                     "japanese": "ガブロボ州",
@@ -19629,8 +19629,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1175126016,
+                "id": 1175126016,
+                "individual_id": 11,
                 "name": "Haskovo",
                 "translations": {
                     "japanese": "ハスコボ州",
@@ -19656,8 +19656,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1175191552,
+                "id": 1175191552,
+                "individual_id": 12,
                 "name": "Yambol",
                 "translations": {
                     "japanese": "ヤンボル州",
@@ -19683,8 +19683,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1175257088,
+                "id": 1175257088,
+                "individual_id": 13,
                 "name": "Kardzhali",
                 "translations": {
                     "japanese": "クルジャリ州",
@@ -19710,8 +19710,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1175322624,
+                "id": 1175322624,
+                "individual_id": 14,
                 "name": "Kyustendil",
                 "translations": {
                     "japanese": "キュステンディル州",
@@ -19737,8 +19737,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1175388160,
+                "id": 1175388160,
+                "individual_id": 15,
                 "name": "Lovech",
                 "translations": {
                     "japanese": "ロベチ州",
@@ -19764,8 +19764,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1175453696,
+                "id": 1175453696,
+                "individual_id": 16,
                 "name": "Montana",
                 "translations": {
                     "japanese": "モンタナ州",
@@ -19791,8 +19791,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1175519232,
+                "id": 1175519232,
+                "individual_id": 17,
                 "name": "Pazardzhik",
                 "translations": {
                     "japanese": "パザルジク州",
@@ -19818,8 +19818,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1175584768,
+                "id": 1175584768,
+                "individual_id": 18,
                 "name": "Pernik",
                 "translations": {
                     "japanese": "ペルニク州",
@@ -19845,8 +19845,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1175650304,
+                "id": 1175650304,
+                "individual_id": 19,
                 "name": "Plovdiv",
                 "translations": {
                     "japanese": "プロブディフ州",
@@ -19872,8 +19872,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1175715840,
+                "id": 1175715840,
+                "individual_id": 20,
                 "name": "Razgrad",
                 "translations": {
                     "japanese": "ラズグラド州",
@@ -19899,8 +19899,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1175781376,
+                "id": 1175781376,
+                "individual_id": 21,
                 "name": "Ruse",
                 "translations": {
                     "japanese": "ルセ州",
@@ -19926,8 +19926,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1175846912,
+                "id": 1175846912,
+                "individual_id": 22,
                 "name": "Silistra",
                 "translations": {
                     "japanese": "シリストラ州",
@@ -19953,8 +19953,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1175912448,
+                "id": 1175912448,
+                "individual_id": 23,
                 "name": "Sliven",
                 "translations": {
                     "japanese": "スリベン州",
@@ -19980,8 +19980,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1175977984,
+                "id": 1175977984,
+                "individual_id": 24,
                 "name": "Smolyan",
                 "translations": {
                     "japanese": "スモリャン州",
@@ -20007,8 +20007,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1176043520,
+                "id": 1176043520,
+                "individual_id": 25,
                 "name": "Stara Zagora",
                 "translations": {
                     "japanese": "スタラ・ザゴラ州",
@@ -20034,8 +20034,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1176109056,
+                "id": 1176109056,
+                "individual_id": 26,
                 "name": "Shumen",
                 "translations": {
                     "japanese": "シュメン州",
@@ -20061,8 +20061,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1176174592,
+                "id": 1176174592,
+                "individual_id": 27,
                 "name": "Targovishte",
                 "translations": {
                     "japanese": "トゥルゴビシュテ州",
@@ -20088,8 +20088,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1176240128,
+                "id": 1176240128,
+                "individual_id": 28,
                 "name": "Veliko Tarnovo",
                 "translations": {
                     "japanese": "ベリコ・トゥルノボ州",
@@ -20115,8 +20115,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 1176305664,
+                "id": 1176305664,
+                "individual_id": 29,
                 "name": "Vratsa",
                 "translations": {
                     "japanese": "ブラツァ州",
@@ -20167,8 +20167,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1191182336,
+                "id": 1191182336,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20194,8 +20194,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1191575552,
+                "id": 1191575552,
+                "individual_id": 6,
                 "name": "Zagreb",
                 "translations": {
                     "japanese": "ザグレブ直轄市",
@@ -20221,8 +20221,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1191641088,
+                "id": 1191641088,
+                "individual_id": 7,
                 "name": "Bjelovar-Bilogora County",
                 "translations": {
                     "japanese": "ビェロヴァル＝ビロゴラ郡",
@@ -20248,8 +20248,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1191706624,
+                "id": 1191706624,
+                "individual_id": 8,
                 "name": "Brod-Posavina County",
                 "translations": {
                     "japanese": "ブロド＝ポサヴィナ郡",
@@ -20275,8 +20275,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1191772160,
+                "id": 1191772160,
+                "individual_id": 9,
                 "name": "Dubrovnik-Neretva County",
                 "translations": {
                     "japanese": "ドゥブロヴニク＝ネレトヴァ郡",
@@ -20302,8 +20302,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1191837696,
+                "id": 1191837696,
+                "individual_id": 10,
                 "name": "Istria County",
                 "translations": {
                     "japanese": "イストラ郡",
@@ -20329,8 +20329,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1191903232,
+                "id": 1191903232,
+                "individual_id": 11,
                 "name": "Karlovac County",
                 "translations": {
                     "japanese": "カルロヴァツ郡",
@@ -20356,8 +20356,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1191968768,
+                "id": 1191968768,
+                "individual_id": 12,
                 "name": "Koprivnica-Križevci County",
                 "translations": {
                     "japanese": "コプリヴニツァ＝クリジェヴツィ郡",
@@ -20383,8 +20383,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1192034304,
+                "id": 1192034304,
+                "individual_id": 13,
                 "name": "Krapina-Zagorje County",
                 "translations": {
                     "japanese": "クラピナ＝ザゴリエ郡",
@@ -20410,8 +20410,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1192099840,
+                "id": 1192099840,
+                "individual_id": 14,
                 "name": "Lika-Senj County",
                 "translations": {
                     "japanese": "リカ＝セニ郡",
@@ -20437,8 +20437,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1192165376,
+                "id": 1192165376,
+                "individual_id": 15,
                 "name": "Međimurje County",
                 "translations": {
                     "japanese": "メジムリェ郡",
@@ -20464,8 +20464,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1192230912,
+                "id": 1192230912,
+                "individual_id": 16,
                 "name": "Osijek-Baranja County",
                 "translations": {
                     "japanese": "オシエク＝バラニャ郡",
@@ -20491,8 +20491,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1192296448,
+                "id": 1192296448,
+                "individual_id": 17,
                 "name": "Požega-Slavonia County",
                 "translations": {
                     "japanese": "ポジェガ＝スラヴォニア郡",
@@ -20518,8 +20518,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1192361984,
+                "id": 1192361984,
+                "individual_id": 18,
                 "name": "Primorje-Gorski Kotar County",
                 "translations": {
                     "japanese": "プリモリェ＝ゴルスキ・コタル郡",
@@ -20545,8 +20545,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1192427520,
+                "id": 1192427520,
+                "individual_id": 19,
                 "name": "Sisak-Moslavina County",
                 "translations": {
                     "japanese": "シサク＝モスラヴィナ郡",
@@ -20572,8 +20572,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1192493056,
+                "id": 1192493056,
+                "individual_id": 20,
                 "name": "Split-Dalmatia County",
                 "translations": {
                     "japanese": "スプリト＝ダルマチア郡",
@@ -20599,8 +20599,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1192558592,
+                "id": 1192558592,
+                "individual_id": 21,
                 "name": "Šibenik-Knin County",
                 "translations": {
                     "japanese": "シベニク＝クニン郡",
@@ -20626,8 +20626,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1192624128,
+                "id": 1192624128,
+                "individual_id": 22,
                 "name": "Varaždin County",
                 "translations": {
                     "japanese": "ヴァラジュディン郡",
@@ -20653,8 +20653,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1192689664,
+                "id": 1192689664,
+                "individual_id": 23,
                 "name": "Virovitica-Podravina County",
                 "translations": {
                     "japanese": "ヴィロヴィティツァ＝ポドラヴィナ郡",
@@ -20680,8 +20680,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1192755200,
+                "id": 1192755200,
+                "individual_id": 24,
                 "name": "Vukovar-Syrmia County",
                 "translations": {
                     "japanese": "ヴコヴァル＝スリイェム郡",
@@ -20707,8 +20707,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1192820736,
+                "id": 1192820736,
+                "individual_id": 25,
                 "name": "Zadar County",
                 "translations": {
                     "japanese": "ザダル郡",
@@ -20734,8 +20734,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1192886272,
+                "id": 1192886272,
+                "individual_id": 26,
                 "name": "Zagreb County",
                 "translations": {
                     "japanese": "ザグレブ郡",
@@ -20786,8 +20786,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1207959552,
+                "id": 1207959552,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20813,8 +20813,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1208025088,
+                "id": 1208025088,
+                "individual_id": 1,
                 "name": "Cyprus",
                 "translations": {
                     "japanese": "キプロス",
@@ -20865,8 +20865,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1224736768,
+                "id": 1224736768,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20892,8 +20892,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1224867840,
+                "id": 1224867840,
+                "individual_id": 2,
                 "name": "Prague",
                 "translations": {
                     "japanese": "プラハ",
@@ -20919,8 +20919,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1224933376,
+                "id": 1224933376,
+                "individual_id": 3,
                 "name": "Central Bohemian Region",
                 "translations": {
                     "japanese": "中部ボヘミア地方",
@@ -20946,8 +20946,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1224998912,
+                "id": 1224998912,
+                "individual_id": 4,
                 "name": "South Bohemian Region",
                 "translations": {
                     "japanese": "南ボヘミア地方",
@@ -20973,8 +20973,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1225064448,
+                "id": 1225064448,
+                "individual_id": 5,
                 "name": "Plzeň Region",
                 "translations": {
                     "japanese": "プルゼニ地方",
@@ -21000,8 +21000,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1225129984,
+                "id": 1225129984,
+                "individual_id": 6,
                 "name": "Karlovy Vary Region",
                 "translations": {
                     "japanese": "カールスバート地方",
@@ -21027,8 +21027,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1225195520,
+                "id": 1225195520,
+                "individual_id": 7,
                 "name": "Ústí nad Labem Region",
                 "translations": {
                     "japanese": "ウースチー・ナド・ラベム地方",
@@ -21054,8 +21054,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1225261056,
+                "id": 1225261056,
+                "individual_id": 8,
                 "name": "Liberec Region",
                 "translations": {
                     "japanese": "リベレツ地方",
@@ -21081,8 +21081,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1225326592,
+                "id": 1225326592,
+                "individual_id": 9,
                 "name": "Hradec Králové Region",
                 "translations": {
                     "japanese": "フラデツ・クラロベ地方",
@@ -21108,8 +21108,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1225392128,
+                "id": 1225392128,
+                "individual_id": 10,
                 "name": "Pardubice Region",
                 "translations": {
                     "japanese": "パルドゥビツェ地方",
@@ -21135,8 +21135,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1225457664,
+                "id": 1225457664,
+                "individual_id": 11,
                 "name": "Olomouc Region",
                 "translations": {
                     "japanese": "オロモウツ地方",
@@ -21162,8 +21162,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1225523200,
+                "id": 1225523200,
+                "individual_id": 12,
                 "name": "Moravian-Silesian Region",
                 "translations": {
                     "japanese": "モラビア・シレジア地方",
@@ -21189,8 +21189,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1225588736,
+                "id": 1225588736,
+                "individual_id": 13,
                 "name": "South Moravian Region",
                 "translations": {
                     "japanese": "南モラビア地方",
@@ -21216,8 +21216,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1225654272,
+                "id": 1225654272,
+                "individual_id": 14,
                 "name": "Zlín Region",
                 "translations": {
                     "japanese": "ズリン地方",
@@ -21243,8 +21243,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1225719808,
+                "id": 1225719808,
+                "individual_id": 15,
                 "name": "Vysočina Region",
                 "translations": {
                     "japanese": "ヴィソチナ地方",
@@ -21295,8 +21295,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1241513984,
+                "id": 1241513984,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -21322,8 +21322,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1242693632,
+                "id": 1242693632,
+                "individual_id": 18,
                 "name": "Greenland",
                 "translations": {
                     "japanese": "グリーンランド",
@@ -21349,8 +21349,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1242759168,
+                "id": 1242759168,
+                "individual_id": 19,
                 "name": "Capital Region of Denmark",
                 "translations": {
                     "japanese": "デンマーク首都地域",
@@ -21376,8 +21376,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1242824704,
+                "id": 1242824704,
+                "individual_id": 20,
                 "name": "Central Denmark Region",
                 "translations": {
                     "japanese": "中央ユラン地域",
@@ -21403,8 +21403,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1242890240,
+                "id": 1242890240,
+                "individual_id": 21,
                 "name": "North Denmark Region",
                 "translations": {
                     "japanese": "北ユラン地域",
@@ -21430,8 +21430,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1242955776,
+                "id": 1242955776,
+                "individual_id": 22,
                 "name": "Region Zealand",
                 "translations": {
                     "japanese": "シェラン地域",
@@ -21457,8 +21457,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1243021312,
+                "id": 1243021312,
+                "individual_id": 23,
                 "name": "Region of Southern Denmark",
                 "translations": {
                     "japanese": "南デンマーク地域",
@@ -21484,8 +21484,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1243086848,
+                "id": 1243086848,
+                "individual_id": 24,
                 "name": "Faroe Islands",
                 "translations": {
                     "japanese": "フェロー諸島",
@@ -21536,8 +21536,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1258291200,
+                "id": 1258291200,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -21563,8 +21563,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1258356736,
+                "id": 1258356736,
+                "individual_id": 1,
                 "name": "Estonia",
                 "translations": {
                     "japanese": "エストニア",
@@ -21615,8 +21615,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1275068416,
+                "id": 1275068416,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -21642,8 +21642,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1275592704,
+                "id": 1275592704,
+                "individual_id": 8,
                 "name": "Uusimaa / Nyland",
                 "translations": {
                     "japanese": "ウーシマー県",
@@ -21669,8 +21669,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1275658240,
+                "id": 1275658240,
+                "individual_id": 9,
                 "name": "Lappi / Lapland",
                 "translations": {
                     "japanese": "ラッピ州",
@@ -21696,8 +21696,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1275723776,
+                "id": 1275723776,
+                "individual_id": 10,
                 "name": "Pohjois-Pohjanmaa / Norra Österbotten",
                 "translations": {
                     "japanese": "北ポフヤンマー県",
@@ -21723,8 +21723,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1275789312,
+                "id": 1275789312,
+                "individual_id": 11,
                 "name": "Kainuu / Kajanaland",
                 "translations": {
                     "japanese": "カイヌー県",
@@ -21750,8 +21750,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1275854848,
+                "id": 1275854848,
+                "individual_id": 12,
                 "name": "Pohjois-Karjala / Norra Karelen",
                 "translations": {
                     "japanese": "北カレリア県",
@@ -21777,8 +21777,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1275920384,
+                "id": 1275920384,
+                "individual_id": 13,
                 "name": "Pohjois-Savo / Norra Savolax",
                 "translations": {
                     "japanese": "北サヴォ県",
@@ -21804,8 +21804,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1275985920,
+                "id": 1275985920,
+                "individual_id": 14,
                 "name": "Etelä-Savo / Södra Savolax",
                 "translations": {
                     "japanese": "南サヴォ県",
@@ -21831,8 +21831,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1276051456,
+                "id": 1276051456,
+                "individual_id": 15,
                 "name": "Etelä-Pohjanmaa / Södra Österbotten",
                 "translations": {
                     "japanese": "南ポフヤンマー県",
@@ -21858,8 +21858,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1276116992,
+                "id": 1276116992,
+                "individual_id": 16,
                 "name": "Pohjanmaa / Österbotten",
                 "translations": {
                     "japanese": "ポフヤンマー県",
@@ -21885,8 +21885,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1276182528,
+                "id": 1276182528,
+                "individual_id": 17,
                 "name": "Pirkanmaa / Birkaland",
                 "translations": {
                     "japanese": "ピルカンマー県",
@@ -21912,8 +21912,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1276248064,
+                "id": 1276248064,
+                "individual_id": 18,
                 "name": "Satakunta / Satakunda",
                 "translations": {
                     "japanese": "サタクンタ県",
@@ -21939,8 +21939,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1276313600,
+                "id": 1276313600,
+                "individual_id": 19,
                 "name": "Keski-Pohjanmaa / Mellersta Österbotten",
                 "translations": {
                     "japanese": "中部ポフヤンマー県",
@@ -21966,8 +21966,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1276379136,
+                "id": 1276379136,
+                "individual_id": 20,
                 "name": "Keski-Suomi / Mellersta Finland",
                 "translations": {
                     "japanese": "中央スオミ県",
@@ -21993,8 +21993,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1276444672,
+                "id": 1276444672,
+                "individual_id": 21,
                 "name": "Varsinais-Suomi / Egentliga Finland",
                 "translations": {
                     "japanese": "ヴァルシナイス=スオミ県",
@@ -22020,8 +22020,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1276510208,
+                "id": 1276510208,
+                "individual_id": 22,
                 "name": "Etelä-Karjala / Södra Karelen",
                 "translations": {
                     "japanese": "南カレリア県",
@@ -22047,8 +22047,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1276575744,
+                "id": 1276575744,
+                "individual_id": 23,
                 "name": "Päijät-Häme / Päijänne Tavastland",
                 "translations": {
                     "japanese": "パイヤト=ハメ県",
@@ -22074,8 +22074,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1276641280,
+                "id": 1276641280,
+                "individual_id": 24,
                 "name": "Kanta-Häme / Egentliga Tavastland",
                 "translations": {
                     "japanese": "カンタ=ハメ県",
@@ -22101,8 +22101,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1276772352,
+                "id": 1276772352,
+                "individual_id": 26,
                 "name": "Kymenlaakso / Kymmenedalen",
                 "translations": {
                     "japanese": "キュメンラークソ県",
@@ -22128,8 +22128,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1276837888,
+                "id": 1276837888,
+                "individual_id": 27,
                 "name": "Ahvenanmaa / Åland",
                 "translations": {
                     "japanese": "アハベナンマー州",
@@ -22180,8 +22180,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1291845632,
+                "id": 1291845632,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -22207,8 +22207,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1291976704,
+                "id": 1291976704,
+                "individual_id": 2,
                 "name": "Île-de-France",
                 "translations": {
                     "japanese": "イール・ド・フランス",
@@ -22234,8 +22234,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1292042240,
+                "id": 1292042240,
+                "individual_id": 3,
                 "name": "Alsace",
                 "translations": {
                     "japanese": "アルザス",
@@ -22261,8 +22261,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1292107776,
+                "id": 1292107776,
+                "individual_id": 4,
                 "name": "Aquitaine",
                 "translations": {
                     "japanese": "アキテーヌ",
@@ -22288,8 +22288,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1292173312,
+                "id": 1292173312,
+                "individual_id": 5,
                 "name": "Auvergne",
                 "translations": {
                     "japanese": "オーベルニュ",
@@ -22315,8 +22315,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1292238848,
+                "id": 1292238848,
+                "individual_id": 6,
                 "name": "Lower Normandy",
                 "translations": {
                     "japanese": "バス・ノルマンディ",
@@ -22342,8 +22342,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1292304384,
+                "id": 1292304384,
+                "individual_id": 7,
                 "name": "Burgundy",
                 "translations": {
                     "japanese": "ブルゴーニュ",
@@ -22369,8 +22369,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1292369920,
+                "id": 1292369920,
+                "individual_id": 8,
                 "name": "Brittany",
                 "translations": {
                     "japanese": "ブルターニュ",
@@ -22396,8 +22396,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1292435456,
+                "id": 1292435456,
+                "individual_id": 9,
                 "name": "Centre",
                 "translations": {
                     "japanese": "サントル",
@@ -22423,8 +22423,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1292500992,
+                "id": 1292500992,
+                "individual_id": 10,
                 "name": "Champagne-Ardenne",
                 "translations": {
                     "japanese": "シャンパーニュ・アルデンヌ",
@@ -22450,8 +22450,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1292566528,
+                "id": 1292566528,
+                "individual_id": 11,
                 "name": "Corsica",
                 "translations": {
                     "japanese": "コルシカ",
@@ -22477,8 +22477,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1292632064,
+                "id": 1292632064,
+                "individual_id": 12,
                 "name": "Franche-Comté",
                 "translations": {
                     "japanese": "フランシュ・コンテ",
@@ -22504,8 +22504,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1292697600,
+                "id": 1292697600,
+                "individual_id": 13,
                 "name": "Upper Normandy",
                 "translations": {
                     "japanese": "オート・ノルマンディ",
@@ -22531,8 +22531,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1292763136,
+                "id": 1292763136,
+                "individual_id": 14,
                 "name": "Languedoc-Roussillon",
                 "translations": {
                     "japanese": "ラングドック・ルシヨン",
@@ -22558,8 +22558,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1292828672,
+                "id": 1292828672,
+                "individual_id": 15,
                 "name": "Limousin",
                 "translations": {
                     "japanese": "リムーザン",
@@ -22585,8 +22585,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1292894208,
+                "id": 1292894208,
+                "individual_id": 16,
                 "name": "Lorraine",
                 "translations": {
                     "japanese": "ロレーヌ",
@@ -22612,8 +22612,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1292959744,
+                "id": 1292959744,
+                "individual_id": 17,
                 "name": "Midi-Pyrénées",
                 "translations": {
                     "japanese": "ミディ・ピレネー",
@@ -22639,8 +22639,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1293025280,
+                "id": 1293025280,
+                "individual_id": 18,
                 "name": "Nord-Pas-de-Calais",
                 "translations": {
                     "japanese": "ノール・パ・ド・カレー",
@@ -22666,8 +22666,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1293090816,
+                "id": 1293090816,
+                "individual_id": 19,
                 "name": "Pays de la Loire",
                 "translations": {
                     "japanese": "ペイ・ド・ラ・ロワール",
@@ -22693,8 +22693,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1293156352,
+                "id": 1293156352,
+                "individual_id": 20,
                 "name": "Picardy",
                 "translations": {
                     "japanese": "ピカルディー",
@@ -22720,8 +22720,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1293221888,
+                "id": 1293221888,
+                "individual_id": 21,
                 "name": "Poitou-Charentes",
                 "translations": {
                     "japanese": "ポワトゥー・シャラント",
@@ -22747,8 +22747,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1293287424,
+                "id": 1293287424,
+                "individual_id": 22,
                 "name": "Provence-Alpes-Côte d'Azur",
                 "translations": {
                     "japanese": "プロヴァンス・アルプ・コート・ダジュール",
@@ -22774,8 +22774,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1293352960,
+                "id": 1293352960,
+                "individual_id": 23,
                 "name": "Rhône-Alpes",
                 "translations": {
                     "japanese": "ローヌ・アルプ",
@@ -22801,8 +22801,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1293418496,
+                "id": 1293418496,
+                "individual_id": 24,
                 "name": "Guadeloupe",
                 "translations": {
                     "japanese": "グアドループ",
@@ -22828,8 +22828,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1293484032,
+                "id": 1293484032,
+                "individual_id": 25,
                 "name": "Martinique",
                 "translations": {
                     "japanese": "マルチニーク",
@@ -22855,8 +22855,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1293549568,
+                "id": 1293549568,
+                "individual_id": 26,
                 "name": "French Guiana",
                 "translations": {
                     "japanese": "フランス領ギアナ",
@@ -22882,8 +22882,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1293615104,
+                "id": 1293615104,
+                "individual_id": 27,
                 "name": "Réunion",
                 "translations": {
                     "japanese": "レユニオン",
@@ -22909,8 +22909,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1293680640,
+                "id": 1293680640,
+                "individual_id": 28,
                 "name": "Mayotte",
                 "translations": {
                     "japanese": "マヨット島",
@@ -22961,8 +22961,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1308622848,
+                "id": 1308622848,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -22988,8 +22988,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1308753920,
+                "id": 1308753920,
+                "individual_id": 2,
                 "name": "Berlin",
                 "translations": {
                     "japanese": "ベルリン",
@@ -23015,8 +23015,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1308819456,
+                "id": 1308819456,
+                "individual_id": 3,
                 "name": "Hesse",
                 "translations": {
                     "japanese": "ヘッセン州",
@@ -23042,8 +23042,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1308884992,
+                "id": 1308884992,
+                "individual_id": 4,
                 "name": "Baden-Württemberg",
                 "translations": {
                     "japanese": "バーデン・ビュルテンベルク州",
@@ -23069,8 +23069,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1308950528,
+                "id": 1308950528,
+                "individual_id": 5,
                 "name": "Bavaria",
                 "translations": {
                     "japanese": "バイエルン州",
@@ -23096,8 +23096,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1309016064,
+                "id": 1309016064,
+                "individual_id": 6,
                 "name": "Brandenburg",
                 "translations": {
                     "japanese": "ブランデンブルク州",
@@ -23123,8 +23123,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1309081600,
+                "id": 1309081600,
+                "individual_id": 7,
                 "name": "Bremen",
                 "translations": {
                     "japanese": "ブレーメン",
@@ -23150,8 +23150,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1309147136,
+                "id": 1309147136,
+                "individual_id": 8,
                 "name": "Hamburg",
                 "translations": {
                     "japanese": "ハンブルク",
@@ -23177,8 +23177,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1309212672,
+                "id": 1309212672,
+                "individual_id": 9,
                 "name": "Mecklenburg-Vorpommern",
                 "translations": {
                     "japanese": "メクレンブルク・フォアポンメルン州",
@@ -23204,8 +23204,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1309278208,
+                "id": 1309278208,
+                "individual_id": 10,
                 "name": "Lower Saxony",
                 "translations": {
                     "japanese": "ニーダーザクセン州",
@@ -23231,8 +23231,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1309343744,
+                "id": 1309343744,
+                "individual_id": 11,
                 "name": "North Rhine-Westphalia",
                 "translations": {
                     "japanese": "ノルトライン・ウェストファーレン州",
@@ -23258,8 +23258,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1309409280,
+                "id": 1309409280,
+                "individual_id": 12,
                 "name": "Rhineland-Palatinate",
                 "translations": {
                     "japanese": "ラインラント・ファルツ州",
@@ -23285,8 +23285,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1309474816,
+                "id": 1309474816,
+                "individual_id": 13,
                 "name": "Saarland",
                 "translations": {
                     "japanese": "ザールラント州",
@@ -23312,8 +23312,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1309540352,
+                "id": 1309540352,
+                "individual_id": 14,
                 "name": "Saxony",
                 "translations": {
                     "japanese": "ザクセン州",
@@ -23339,8 +23339,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1309605888,
+                "id": 1309605888,
+                "individual_id": 15,
                 "name": "Saxony-Anhalt",
                 "translations": {
                     "japanese": "ザクセン・アンハルト州",
@@ -23366,8 +23366,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1309671424,
+                "id": 1309671424,
+                "individual_id": 16,
                 "name": "Schleswig-Holstein",
                 "translations": {
                     "japanese": "シュレスビヒ・ホルシュタイン州",
@@ -23393,8 +23393,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1309736960,
+                "id": 1309736960,
+                "individual_id": 17,
                 "name": "Thuringia",
                 "translations": {
                     "japanese": "テューリンゲン州",
@@ -23445,8 +23445,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1325400064,
+                "id": 1325400064,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -23472,8 +23472,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1325531136,
+                "id": 1325531136,
+                "individual_id": 2,
                 "name": "Attica",
                 "translations": {
                     "japanese": "アッティカ",
@@ -23499,8 +23499,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1325596672,
+                "id": 1325596672,
+                "individual_id": 3,
                 "name": "Central Greece",
                 "translations": {
                     "japanese": "中央ギリシャ",
@@ -23526,8 +23526,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1325662208,
+                "id": 1325662208,
+                "individual_id": 4,
                 "name": "Central Macedonia",
                 "translations": {
                     "japanese": "中央マケドニア",
@@ -23553,8 +23553,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1325727744,
+                "id": 1325727744,
+                "individual_id": 5,
                 "name": "Crete",
                 "translations": {
                     "japanese": "クレタ",
@@ -23580,8 +23580,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1325793280,
+                "id": 1325793280,
+                "individual_id": 6,
                 "name": "East Macedonia and Thrace",
                 "translations": {
                     "japanese": "東マケドニア・トラキア",
@@ -23607,8 +23607,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1325858816,
+                "id": 1325858816,
+                "individual_id": 7,
                 "name": "Epirus",
                 "translations": {
                     "japanese": "イピロス",
@@ -23634,8 +23634,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1325924352,
+                "id": 1325924352,
+                "individual_id": 8,
                 "name": "Ionian Islands",
                 "translations": {
                     "japanese": "イオニア",
@@ -23661,8 +23661,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1325989888,
+                "id": 1325989888,
+                "individual_id": 9,
                 "name": "North Aegean",
                 "translations": {
                     "japanese": "北エーゲ",
@@ -23688,8 +23688,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1326055424,
+                "id": 1326055424,
+                "individual_id": 10,
                 "name": "Peloponnese",
                 "translations": {
                     "japanese": "ペロポネソス",
@@ -23715,8 +23715,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1326120960,
+                "id": 1326120960,
+                "individual_id": 11,
                 "name": "South Aegean",
                 "translations": {
                     "japanese": "南エーゲ",
@@ -23742,8 +23742,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1326186496,
+                "id": 1326186496,
+                "individual_id": 12,
                 "name": "Thessaly",
                 "translations": {
                     "japanese": "テッサリーア",
@@ -23769,8 +23769,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1326252032,
+                "id": 1326252032,
+                "individual_id": 13,
                 "name": "West Greece",
                 "translations": {
                     "japanese": "西ギリシャ",
@@ -23796,8 +23796,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1326317568,
+                "id": 1326317568,
+                "individual_id": 14,
                 "name": "West Macedonia",
                 "translations": {
                     "japanese": "西マケドニア",
@@ -23848,8 +23848,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1342177280,
+                "id": 1342177280,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -23875,8 +23875,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1342308352,
+                "id": 1342308352,
+                "individual_id": 2,
                 "name": "Budapest",
                 "translations": {
                     "japanese": "ブダペスト",
@@ -23902,8 +23902,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1342373888,
+                "id": 1342373888,
+                "individual_id": 3,
                 "name": "Bács-Kiskun County",
                 "translations": {
                     "japanese": "バーチ・キシュクン州",
@@ -23929,8 +23929,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1342439424,
+                "id": 1342439424,
+                "individual_id": 4,
                 "name": "Baranya County",
                 "translations": {
                     "japanese": "バラニャ州",
@@ -23956,8 +23956,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1342504960,
+                "id": 1342504960,
+                "individual_id": 5,
                 "name": "Békés County",
                 "translations": {
                     "japanese": "ベーケーシュ州",
@@ -23983,8 +23983,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1342570496,
+                "id": 1342570496,
+                "individual_id": 6,
                 "name": "Borsod-Abaúj-Zemplén County",
                 "translations": {
                     "japanese": "ボルショド・アバウーイ・ゼンプレーン州",
@@ -24010,8 +24010,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1342636032,
+                "id": 1342636032,
+                "individual_id": 7,
                 "name": "Csongrád County",
                 "translations": {
                     "japanese": "チョングラード州",
@@ -24037,8 +24037,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1342701568,
+                "id": 1342701568,
+                "individual_id": 8,
                 "name": "Fejér County",
                 "translations": {
                     "japanese": "フェイェール州",
@@ -24064,8 +24064,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1342767104,
+                "id": 1342767104,
+                "individual_id": 9,
                 "name": "Győr-Moson-Sopron County",
                 "translations": {
                     "japanese": "ジェール・モション・ショプロン州",
@@ -24091,8 +24091,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1342832640,
+                "id": 1342832640,
+                "individual_id": 10,
                 "name": "Hajdú-Bihar County",
                 "translations": {
                     "japanese": "ハイドゥー・ヒバル州",
@@ -24118,8 +24118,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1342898176,
+                "id": 1342898176,
+                "individual_id": 11,
                 "name": "Heves County",
                 "translations": {
                     "japanese": "ヘヴェシュ州",
@@ -24145,8 +24145,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1342963712,
+                "id": 1342963712,
+                "individual_id": 12,
                 "name": "Jász-Nagykun-Szolnok County",
                 "translations": {
                     "japanese": "ヤース・ナチクン・ソルノク州",
@@ -24172,8 +24172,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1343029248,
+                "id": 1343029248,
+                "individual_id": 13,
                 "name": "Komárom-Esztergom County",
                 "translations": {
                     "japanese": "コマーロム・エステルゴム州",
@@ -24199,8 +24199,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1343094784,
+                "id": 1343094784,
+                "individual_id": 14,
                 "name": "Nógrád County",
                 "translations": {
                     "japanese": "ノーグラード州",
@@ -24226,8 +24226,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1343160320,
+                "id": 1343160320,
+                "individual_id": 15,
                 "name": "Pest County",
                 "translations": {
                     "japanese": "ペシュト州",
@@ -24253,8 +24253,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1343225856,
+                "id": 1343225856,
+                "individual_id": 16,
                 "name": "Somogy County",
                 "translations": {
                     "japanese": "ショモジ州",
@@ -24280,8 +24280,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1343291392,
+                "id": 1343291392,
+                "individual_id": 17,
                 "name": "Szabolcs-Szatmár-Bereg County",
                 "translations": {
                     "japanese": "サボルチ・サトマール・ベレグ州",
@@ -24307,8 +24307,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1343356928,
+                "id": 1343356928,
+                "individual_id": 18,
                 "name": "Tolna County",
                 "translations": {
                     "japanese": "トルナ州",
@@ -24334,8 +24334,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1343422464,
+                "id": 1343422464,
+                "individual_id": 19,
                 "name": "Vas County",
                 "translations": {
                     "japanese": "ヴァシュ州",
@@ -24361,8 +24361,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1343488000,
+                "id": 1343488000,
+                "individual_id": 20,
                 "name": "Veszprém County",
                 "translations": {
                     "japanese": "ベスプレーム州",
@@ -24388,8 +24388,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1343553536,
+                "id": 1343553536,
+                "individual_id": 21,
                 "name": "Zala County",
                 "translations": {
                     "japanese": "ザラ州",
@@ -24440,8 +24440,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1358954496,
+                "id": 1358954496,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -24467,8 +24467,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1359020032,
+                "id": 1359020032,
+                "individual_id": 1,
                 "name": "Iceland",
                 "translations": {
                     "japanese": "アイスランド",
@@ -24519,8 +24519,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1375731712,
+                "id": 1375731712,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -24546,8 +24546,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1375862784,
+                "id": 1375862784,
+                "individual_id": 2,
                 "name": "Dublin",
                 "translations": {
                     "japanese": "ダブリン州",
@@ -24573,8 +24573,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1376387072,
+                "id": 1376387072,
+                "individual_id": 10,
                 "name": "County Carlow",
                 "translations": {
                     "japanese": "カーロウ州",
@@ -24600,8 +24600,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1376452608,
+                "id": 1376452608,
+                "individual_id": 11,
                 "name": "County Cavan",
                 "translations": {
                     "japanese": "キャバン州",
@@ -24627,8 +24627,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1376518144,
+                "id": 1376518144,
+                "individual_id": 12,
                 "name": "County Clare",
                 "translations": {
                     "japanese": "クレア州",
@@ -24654,8 +24654,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1376583680,
+                "id": 1376583680,
+                "individual_id": 13,
                 "name": "County Cork",
                 "translations": {
                     "japanese": "コーク州",
@@ -24681,8 +24681,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1376649216,
+                "id": 1376649216,
+                "individual_id": 14,
                 "name": "County Donegal",
                 "translations": {
                     "japanese": "ドニゴール州",
@@ -24708,8 +24708,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1376714752,
+                "id": 1376714752,
+                "individual_id": 15,
                 "name": "County Galway",
                 "translations": {
                     "japanese": "ゴールウェイ州",
@@ -24735,8 +24735,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1376780288,
+                "id": 1376780288,
+                "individual_id": 16,
                 "name": "County Kerry",
                 "translations": {
                     "japanese": "ケリー州",
@@ -24762,8 +24762,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1376845824,
+                "id": 1376845824,
+                "individual_id": 17,
                 "name": "County Kildare",
                 "translations": {
                     "japanese": "キルデア州",
@@ -24789,8 +24789,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1376911360,
+                "id": 1376911360,
+                "individual_id": 18,
                 "name": "County Kilkenny",
                 "translations": {
                     "japanese": "キルケニー州",
@@ -24816,8 +24816,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1376976896,
+                "id": 1376976896,
+                "individual_id": 19,
                 "name": "County Laois",
                 "translations": {
                     "japanese": "リーシュ州",
@@ -24843,8 +24843,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1377042432,
+                "id": 1377042432,
+                "individual_id": 20,
                 "name": "County Leitrim",
                 "translations": {
                     "japanese": "リートリム州",
@@ -24870,8 +24870,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1377107968,
+                "id": 1377107968,
+                "individual_id": 21,
                 "name": "County Limerick",
                 "translations": {
                     "japanese": "リムリック州",
@@ -24897,8 +24897,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1377173504,
+                "id": 1377173504,
+                "individual_id": 22,
                 "name": "County Longford",
                 "translations": {
                     "japanese": "ロングフォード州",
@@ -24924,8 +24924,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1377239040,
+                "id": 1377239040,
+                "individual_id": 23,
                 "name": "County Louth",
                 "translations": {
                     "japanese": "ラウス州",
@@ -24951,8 +24951,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1377304576,
+                "id": 1377304576,
+                "individual_id": 24,
                 "name": "County Mayo",
                 "translations": {
                     "japanese": "メイヨー州",
@@ -24978,8 +24978,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1377370112,
+                "id": 1377370112,
+                "individual_id": 25,
                 "name": "County Meath",
                 "translations": {
                     "japanese": "ミース州",
@@ -25005,8 +25005,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1377435648,
+                "id": 1377435648,
+                "individual_id": 26,
                 "name": "County Monaghan",
                 "translations": {
                     "japanese": "モナハン州",
@@ -25032,8 +25032,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1377501184,
+                "id": 1377501184,
+                "individual_id": 27,
                 "name": "County Offaly",
                 "translations": {
                     "japanese": "オファリー州",
@@ -25059,8 +25059,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1377566720,
+                "id": 1377566720,
+                "individual_id": 28,
                 "name": "County Roscommon",
                 "translations": {
                     "japanese": "ロスコモン州",
@@ -25086,8 +25086,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 1377632256,
+                "id": 1377632256,
+                "individual_id": 29,
                 "name": "County Sligo",
                 "translations": {
                     "japanese": "スライゴ州",
@@ -25113,8 +25113,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 1377697792,
+                "id": 1377697792,
+                "individual_id": 30,
                 "name": "County Tipperary",
                 "translations": {
                     "japanese": "ティペラリー州",
@@ -25140,8 +25140,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 1377763328,
+                "id": 1377763328,
+                "individual_id": 31,
                 "name": "County Waterford",
                 "translations": {
                     "japanese": "ウォーターフォード州",
@@ -25167,8 +25167,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1377828864,
+                "id": 1377828864,
+                "individual_id": 32,
                 "name": "County Westmeath",
                 "translations": {
                     "japanese": "ウェストミース州",
@@ -25194,8 +25194,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 1377894400,
+                "id": 1377894400,
+                "individual_id": 33,
                 "name": "County Wexford",
                 "translations": {
                     "japanese": "ウェックスフォード州",
@@ -25221,8 +25221,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 1377959936,
+                "id": 1377959936,
+                "individual_id": 34,
                 "name": "County Wicklow",
                 "translations": {
                     "japanese": "ウィックロー州",
@@ -25273,8 +25273,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1392508928,
+                "id": 1392508928,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25300,8 +25300,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1392640000,
+                "id": 1392640000,
+                "individual_id": 2,
                 "name": "Lazio",
                 "translations": {
                     "japanese": "ラツィオ州",
@@ -25327,8 +25327,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1392705536,
+                "id": 1392705536,
+                "individual_id": 3,
                 "name": "Aosta Valley",
                 "translations": {
                     "japanese": "バッレ・ダオスタ州",
@@ -25354,8 +25354,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1392771072,
+                "id": 1392771072,
+                "individual_id": 4,
                 "name": "Piedmont",
                 "translations": {
                     "japanese": "ピエモンテ州",
@@ -25381,8 +25381,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1392836608,
+                "id": 1392836608,
+                "individual_id": 5,
                 "name": "Liguria",
                 "translations": {
                     "japanese": "リグリア州",
@@ -25408,8 +25408,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1392902144,
+                "id": 1392902144,
+                "individual_id": 6,
                 "name": "Lombardy",
                 "translations": {
                     "japanese": "ロンバルディア州",
@@ -25435,8 +25435,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1392967680,
+                "id": 1392967680,
+                "individual_id": 7,
                 "name": "Trentino-Alto Adige",
                 "translations": {
                     "japanese": "トレンティノ・アルト・アディジェ州",
@@ -25462,8 +25462,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1393033216,
+                "id": 1393033216,
+                "individual_id": 8,
                 "name": "Veneto",
                 "translations": {
                     "japanese": "ベネト州",
@@ -25489,8 +25489,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1393098752,
+                "id": 1393098752,
+                "individual_id": 9,
                 "name": "Friuli Venezia Giulia",
                 "translations": {
                     "japanese": "フリウリ・ベネチア・ジュリア州",
@@ -25516,8 +25516,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1393164288,
+                "id": 1393164288,
+                "individual_id": 10,
                 "name": "Emilia-Romagna",
                 "translations": {
                     "japanese": "エミリア・ロマーニャ州",
@@ -25543,8 +25543,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1393229824,
+                "id": 1393229824,
+                "individual_id": 11,
                 "name": "Tuscany",
                 "translations": {
                     "japanese": "トスカナ州",
@@ -25570,8 +25570,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1393295360,
+                "id": 1393295360,
+                "individual_id": 12,
                 "name": "Umbria",
                 "translations": {
                     "japanese": "ウンブリア州",
@@ -25597,8 +25597,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1393360896,
+                "id": 1393360896,
+                "individual_id": 13,
                 "name": "Marche",
                 "translations": {
                     "japanese": "マルケ州",
@@ -25624,8 +25624,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1393426432,
+                "id": 1393426432,
+                "individual_id": 14,
                 "name": "Abruzzo",
                 "translations": {
                     "japanese": "アブルッツィ州",
@@ -25651,8 +25651,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1393491968,
+                "id": 1393491968,
+                "individual_id": 15,
                 "name": "Molise",
                 "translations": {
                     "japanese": "モリーゼ州",
@@ -25678,8 +25678,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1393557504,
+                "id": 1393557504,
+                "individual_id": 16,
                 "name": "Campania",
                 "translations": {
                     "japanese": "カンパニア州",
@@ -25705,8 +25705,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1393623040,
+                "id": 1393623040,
+                "individual_id": 17,
                 "name": "Apulia",
                 "translations": {
                     "japanese": "プーリア州",
@@ -25732,8 +25732,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1393688576,
+                "id": 1393688576,
+                "individual_id": 18,
                 "name": "Basilicata",
                 "translations": {
                     "japanese": "バジリカータ州",
@@ -25759,8 +25759,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1393754112,
+                "id": 1393754112,
+                "individual_id": 19,
                 "name": "Calabria",
                 "translations": {
                     "japanese": "カラブリア州",
@@ -25786,8 +25786,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1393819648,
+                "id": 1393819648,
+                "individual_id": 20,
                 "name": "Sicily",
                 "translations": {
                     "japanese": "シチリア州",
@@ -25813,8 +25813,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1393885184,
+                "id": 1393885184,
+                "individual_id": 21,
                 "name": "Sardinia",
                 "translations": {
                     "japanese": "サルデーニャ州",
@@ -25865,8 +25865,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1409286144,
+                "id": 1409286144,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25892,8 +25892,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1409351680,
+                "id": 1409351680,
+                "individual_id": 1,
                 "name": "Latvia",
                 "translations": {
                     "japanese": "ラトビア",
@@ -25944,8 +25944,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1426063360,
+                "id": 1426063360,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25971,8 +25971,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1426194432,
+                "id": 1426194432,
+                "individual_id": 2,
                 "name": "Maseru",
                 "translations": {
                     "japanese": "マセル県",
@@ -25998,8 +25998,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1426259968,
+                "id": 1426259968,
+                "individual_id": 3,
                 "name": "Berea",
                 "translations": {
                     "japanese": "べレア県",
@@ -26025,8 +26025,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1426325504,
+                "id": 1426325504,
+                "individual_id": 4,
                 "name": "Butha-Buthe",
                 "translations": {
                     "japanese": "ブータ・ブーテ県",
@@ -26052,8 +26052,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1426391040,
+                "id": 1426391040,
+                "individual_id": 5,
                 "name": "Leribe",
                 "translations": {
                     "japanese": "レリベ県",
@@ -26079,8 +26079,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1426456576,
+                "id": 1426456576,
+                "individual_id": 6,
                 "name": "Mafeteng",
                 "translations": {
                     "japanese": "マフェテング県",
@@ -26106,8 +26106,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1426522112,
+                "id": 1426522112,
+                "individual_id": 7,
                 "name": "Mohale's Hoek",
                 "translations": {
                     "japanese": "モハーレスフーク県",
@@ -26133,8 +26133,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1426587648,
+                "id": 1426587648,
+                "individual_id": 8,
                 "name": "Mokhotlong",
                 "translations": {
                     "japanese": "モコトロング県",
@@ -26160,8 +26160,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1426653184,
+                "id": 1426653184,
+                "individual_id": 9,
                 "name": "Qacha's Nek",
                 "translations": {
                     "japanese": "クァクハスネック県",
@@ -26187,8 +26187,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1426718720,
+                "id": 1426718720,
+                "individual_id": 10,
                 "name": "Quthing",
                 "translations": {
                     "japanese": "クティング県",
@@ -26214,8 +26214,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1426784256,
+                "id": 1426784256,
+                "individual_id": 11,
                 "name": "Thaba-Tseka",
                 "translations": {
                     "japanese": "ターバ・ツェーカ県",
@@ -26266,8 +26266,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1442840576,
+                "id": 1442840576,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26293,8 +26293,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1442906112,
+                "id": 1442906112,
+                "individual_id": 1,
                 "name": "Liechtenstein",
                 "translations": {
                     "japanese": "リヒテンシュタイン",
@@ -26345,8 +26345,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1459617792,
+                "id": 1459617792,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26372,8 +26372,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1459748864,
+                "id": 1459748864,
+                "individual_id": 2,
                 "name": "Vilnius",
                 "translations": {
                     "japanese": "ヴィリニュス州",
@@ -26399,8 +26399,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1459814400,
+                "id": 1459814400,
+                "individual_id": 3,
                 "name": "Alytus",
                 "translations": {
                     "japanese": "アリートゥス州",
@@ -26426,8 +26426,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1459879936,
+                "id": 1459879936,
+                "individual_id": 4,
                 "name": "Kaunas",
                 "translations": {
                     "japanese": "カウナス州",
@@ -26453,8 +26453,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1459945472,
+                "id": 1459945472,
+                "individual_id": 5,
                 "name": "Klaipėda",
                 "translations": {
                     "japanese": "クライペダ州",
@@ -26480,8 +26480,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1460011008,
+                "id": 1460011008,
+                "individual_id": 6,
                 "name": "Marijampolė",
                 "translations": {
                     "japanese": "マリヤンポレ州",
@@ -26507,8 +26507,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1460076544,
+                "id": 1460076544,
+                "individual_id": 7,
                 "name": "Panevėžys",
                 "translations": {
                     "japanese": "パネベジス州",
@@ -26534,8 +26534,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1460142080,
+                "id": 1460142080,
+                "individual_id": 8,
                 "name": "Šiauliai",
                 "translations": {
                     "japanese": "シャウレイ州",
@@ -26561,8 +26561,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1460207616,
+                "id": 1460207616,
+                "individual_id": 9,
                 "name": "Taurage",
                 "translations": {
                     "japanese": "タウラゲ州",
@@ -26588,8 +26588,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1460273152,
+                "id": 1460273152,
+                "individual_id": 10,
                 "name": "Telšiai",
                 "translations": {
                     "japanese": "テルシェイ州",
@@ -26615,8 +26615,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1460338688,
+                "id": 1460338688,
+                "individual_id": 11,
                 "name": "Utena",
                 "translations": {
                     "japanese": "ウテナ州",
@@ -26667,8 +26667,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1476395008,
+                "id": 1476395008,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26694,8 +26694,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1476460544,
+                "id": 1476460544,
+                "individual_id": 1,
                 "name": "Luxembourg",
                 "translations": {
                     "japanese": "ルクセンブルク",
@@ -26746,8 +26746,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1493172224,
+                "id": 1493172224,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26773,8 +26773,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1493237760,
+                "id": 1493237760,
+                "individual_id": 1,
                 "name": "Macedonia (Republic of)",
                 "translations": {
                     "japanese": "マケドニア",
@@ -26825,8 +26825,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1509949440,
+                "id": 1509949440,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26852,8 +26852,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1510014976,
+                "id": 1510014976,
+                "individual_id": 1,
                 "name": "Malta",
                 "translations": {
                     "japanese": "マルタ",
@@ -26904,8 +26904,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1526726656,
+                "id": 1526726656,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26931,8 +26931,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1526792192,
+                "id": 1526792192,
+                "individual_id": 1,
                 "name": "Montenegro",
                 "translations": {
                     "japanese": "モンテネグロ",
@@ -26983,8 +26983,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1543503872,
+                "id": 1543503872,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27010,8 +27010,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1543569408,
+                "id": 1543569408,
+                "individual_id": 1,
                 "name": "Mozambique",
                 "translations": {
                     "japanese": "モザンビーク",
@@ -27062,8 +27062,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1560281088,
+                "id": 1560281088,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27089,8 +27089,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1560346624,
+                "id": 1560346624,
+                "individual_id": 1,
                 "name": "Namibia",
                 "translations": {
                     "japanese": "ナミビア",
@@ -27141,8 +27141,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1577058304,
+                "id": 1577058304,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27168,8 +27168,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1577189376,
+                "id": 1577189376,
+                "individual_id": 2,
                 "name": "North Holland",
                 "translations": {
                     "japanese": "ノールト・ホラント州",
@@ -27195,8 +27195,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1577254912,
+                "id": 1577254912,
+                "individual_id": 3,
                 "name": "Drenthe",
                 "translations": {
                     "japanese": "ドレンテ州",
@@ -27222,8 +27222,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1577320448,
+                "id": 1577320448,
+                "individual_id": 4,
                 "name": "Flevoland",
                 "translations": {
                     "japanese": "フレボラント州",
@@ -27249,8 +27249,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1577385984,
+                "id": 1577385984,
+                "individual_id": 5,
                 "name": "Friesland",
                 "translations": {
                     "japanese": "フリースラント州",
@@ -27276,8 +27276,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1577451520,
+                "id": 1577451520,
+                "individual_id": 6,
                 "name": "Gelderland",
                 "translations": {
                     "japanese": "ヘルデンラント州",
@@ -27303,8 +27303,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1577517056,
+                "id": 1577517056,
+                "individual_id": 7,
                 "name": "Groningen",
                 "translations": {
                     "japanese": "フローニンゲン州",
@@ -27330,8 +27330,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1577582592,
+                "id": 1577582592,
+                "individual_id": 8,
                 "name": "Limburg",
                 "translations": {
                     "japanese": "リンビュルフ州",
@@ -27357,8 +27357,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1577648128,
+                "id": 1577648128,
+                "individual_id": 9,
                 "name": "North Brabant",
                 "translations": {
                     "japanese": "ノールト・ブラバント州",
@@ -27384,8 +27384,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1577713664,
+                "id": 1577713664,
+                "individual_id": 10,
                 "name": "Overijssel",
                 "translations": {
                     "japanese": "オーベルアイセル州",
@@ -27411,8 +27411,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1577779200,
+                "id": 1577779200,
+                "individual_id": 11,
                 "name": "South Holland",
                 "translations": {
                     "japanese": "ゾイト・ホラント州",
@@ -27438,8 +27438,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1577844736,
+                "id": 1577844736,
+                "individual_id": 12,
                 "name": "Utrecht",
                 "translations": {
                     "japanese": "ユトレヒト州",
@@ -27465,8 +27465,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1577910272,
+                "id": 1577910272,
+                "individual_id": 13,
                 "name": "Zeeland",
                 "translations": {
                     "japanese": "ゼーラント州",
@@ -27517,8 +27517,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1593835520,
+                "id": 1593835520,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27544,8 +27544,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1593966592,
+                "id": 1593966592,
+                "individual_id": 2,
                 "name": "Wellington",
                 "translations": {
                     "japanese": "ウェリントン",
@@ -27571,8 +27571,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1594032128,
+                "id": 1594032128,
+                "individual_id": 3,
                 "name": "Auckland",
                 "translations": {
                     "japanese": "オークランド",
@@ -27598,8 +27598,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1594097664,
+                "id": 1594097664,
+                "individual_id": 4,
                 "name": "Bay of Plenty",
                 "translations": {
                     "japanese": "ベイ・オブ・プレンティ",
@@ -27625,8 +27625,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1594163200,
+                "id": 1594163200,
+                "individual_id": 5,
                 "name": "Canterbury",
                 "translations": {
                     "japanese": "カンタベリー",
@@ -27652,8 +27652,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1594228736,
+                "id": 1594228736,
+                "individual_id": 6,
                 "name": "Otago",
                 "translations": {
                     "japanese": "ダニーデン",
@@ -27679,8 +27679,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1594294272,
+                "id": 1594294272,
+                "individual_id": 7,
                 "name": "Hawke's Bay",
                 "translations": {
                     "japanese": "ホークスベイ",
@@ -27706,8 +27706,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1594359808,
+                "id": 1594359808,
+                "individual_id": 8,
                 "name": "Manawatu-Wanganui",
                 "translations": {
                     "japanese": "マナワツ・ワンガヌイ",
@@ -27733,8 +27733,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1594425344,
+                "id": 1594425344,
+                "individual_id": 9,
                 "name": "Nelson",
                 "translations": {
                     "japanese": "ネルソン・マールボロ",
@@ -27760,8 +27760,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1594490880,
+                "id": 1594490880,
+                "individual_id": 10,
                 "name": "Northland",
                 "translations": {
                     "japanese": "ノースランド",
@@ -27787,8 +27787,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1594621952,
+                "id": 1594621952,
+                "individual_id": 12,
                 "name": "Southland",
                 "translations": {
                     "japanese": "サウスランド",
@@ -27814,8 +27814,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1594687488,
+                "id": 1594687488,
+                "individual_id": 13,
                 "name": "Taranaki",
                 "translations": {
                     "japanese": "タラナキ",
@@ -27841,8 +27841,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1594753024,
+                "id": 1594753024,
+                "individual_id": 14,
                 "name": "Waikato",
                 "translations": {
                     "japanese": "ワイカト",
@@ -27868,8 +27868,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1594818560,
+                "id": 1594818560,
+                "individual_id": 15,
                 "name": "Gisborne",
                 "translations": {
                     "japanese": "ギズボーン",
@@ -27895,8 +27895,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1594884096,
+                "id": 1594884096,
+                "individual_id": 16,
                 "name": "West Coast",
                 "translations": {
                     "japanese": "ウェストコースト",
@@ -27922,8 +27922,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1594949632,
+                "id": 1594949632,
+                "individual_id": 17,
                 "name": "Marlborough",
                 "translations": {
                     "japanese": "マールボロ",
@@ -27949,8 +27949,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1595015168,
+                "id": 1595015168,
+                "individual_id": 18,
                 "name": "Tasman",
                 "translations": {
                     "japanese": "タスマン",
@@ -28001,8 +28001,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1610612736,
+                "id": 1610612736,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -28028,8 +28028,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1611071488,
+                "id": 1611071488,
+                "individual_id": 7,
                 "name": "Oslo",
                 "translations": {
                     "japanese": "オスロ",
@@ -28055,8 +28055,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1611137024,
+                "id": 1611137024,
+                "individual_id": 8,
                 "name": "Akershus",
                 "translations": {
                     "japanese": "アーケシュフース県",
@@ -28082,8 +28082,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1611202560,
+                "id": 1611202560,
+                "individual_id": 9,
                 "name": "Aust-Agder",
                 "translations": {
                     "japanese": "アウスト・アグデル県",
@@ -28109,8 +28109,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1611268096,
+                "id": 1611268096,
+                "individual_id": 10,
                 "name": "Buskerud",
                 "translations": {
                     "japanese": "ブスケルー県",
@@ -28136,8 +28136,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1611333632,
+                "id": 1611333632,
+                "individual_id": 11,
                 "name": "Finnmark",
                 "translations": {
                     "japanese": "フィンマルク県",
@@ -28163,8 +28163,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1611399168,
+                "id": 1611399168,
+                "individual_id": 12,
                 "name": "Hedmark",
                 "translations": {
                     "japanese": "ヘードマルク県",
@@ -28190,8 +28190,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1611464704,
+                "id": 1611464704,
+                "individual_id": 13,
                 "name": "Hordaland",
                 "translations": {
                     "japanese": "ホルダラン県",
@@ -28217,8 +28217,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1611530240,
+                "id": 1611530240,
+                "individual_id": 14,
                 "name": "Møre og Romsdal",
                 "translations": {
                     "japanese": "ムーレ・オ・ロムスダール県",
@@ -28244,8 +28244,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1611595776,
+                "id": 1611595776,
+                "individual_id": 15,
                 "name": "Nordland",
                 "translations": {
                     "japanese": "ヌールラン県",
@@ -28271,8 +28271,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1611661312,
+                "id": 1611661312,
+                "individual_id": 16,
                 "name": "Nord-Trøndelag",
                 "translations": {
                     "japanese": "ヌール・トロンデラーグ県",
@@ -28298,8 +28298,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1611726848,
+                "id": 1611726848,
+                "individual_id": 17,
                 "name": "Oppland",
                 "translations": {
                     "japanese": "オップラン県",
@@ -28325,8 +28325,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1611792384,
+                "id": 1611792384,
+                "individual_id": 18,
                 "name": "Rogaland",
                 "translations": {
                     "japanese": "ローガラン県",
@@ -28352,8 +28352,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1611857920,
+                "id": 1611857920,
+                "individual_id": 19,
                 "name": "Sogn og Fjordane",
                 "translations": {
                     "japanese": "ソグン・オ・フィヨーラネ県",
@@ -28379,8 +28379,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1611923456,
+                "id": 1611923456,
+                "individual_id": 20,
                 "name": "Sør-Trøndelag",
                 "translations": {
                     "japanese": "ソール・トロンデラーグ県",
@@ -28406,8 +28406,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1611988992,
+                "id": 1611988992,
+                "individual_id": 21,
                 "name": "Telemark",
                 "translations": {
                     "japanese": "テレマルク県",
@@ -28433,8 +28433,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1612054528,
+                "id": 1612054528,
+                "individual_id": 22,
                 "name": "Troms",
                 "translations": {
                     "japanese": "トロムス県",
@@ -28460,8 +28460,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1612120064,
+                "id": 1612120064,
+                "individual_id": 23,
                 "name": "Vest-Agder",
                 "translations": {
                     "japanese": "ヴェスト・アグデル県",
@@ -28487,8 +28487,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1612185600,
+                "id": 1612185600,
+                "individual_id": 24,
                 "name": "Vestfold",
                 "translations": {
                     "japanese": "ヴェストフォル県",
@@ -28514,8 +28514,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1612251136,
+                "id": 1612251136,
+                "individual_id": 25,
                 "name": "Østfold",
                 "translations": {
                     "japanese": "エストフォル県",
@@ -28541,8 +28541,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1612316672,
+                "id": 1612316672,
+                "individual_id": 26,
                 "name": "Svalbard",
                 "translations": {
                     "japanese": "スヴァールバル諸島",
@@ -28593,8 +28593,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1627389952,
+                "id": 1627389952,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -28620,8 +28620,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1627521024,
+                "id": 1627521024,
+                "individual_id": 2,
                 "name": "Masovia",
                 "translations": {
                     "japanese": "マゾフシェ",
@@ -28647,8 +28647,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1627586560,
+                "id": 1627586560,
+                "individual_id": 3,
                 "name": "Lower Silesia",
                 "translations": {
                     "japanese": "ドルヌィ・シロンスク",
@@ -28674,8 +28674,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1627652096,
+                "id": 1627652096,
+                "individual_id": 4,
                 "name": "Kuyavian-Pomeranian Voivodeship",
                 "translations": {
                     "japanese": "クヤヴィ・ポモージェ",
@@ -28701,8 +28701,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1627717632,
+                "id": 1627717632,
+                "individual_id": 5,
                 "name": "Lodz",
                 "translations": {
                     "japanese": "ウッジ",
@@ -28728,8 +28728,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1627783168,
+                "id": 1627783168,
+                "individual_id": 6,
                 "name": "Lublin",
                 "translations": {
                     "japanese": "ルブリン",
@@ -28755,8 +28755,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1627848704,
+                "id": 1627848704,
+                "individual_id": 7,
                 "name": "Lubusz",
                 "translations": {
                     "japanese": "ルブシュ",
@@ -28782,8 +28782,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1627914240,
+                "id": 1627914240,
+                "individual_id": 8,
                 "name": "Lesser Poland",
                 "translations": {
                     "japanese": "マウォポルスカ",
@@ -28809,8 +28809,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1627979776,
+                "id": 1627979776,
+                "individual_id": 9,
                 "name": "Opole",
                 "translations": {
                     "japanese": "オポーレ",
@@ -28836,8 +28836,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1628045312,
+                "id": 1628045312,
+                "individual_id": 10,
                 "name": "Subcarpathia",
                 "translations": {
                     "japanese": "ポトカルパチェ",
@@ -28863,8 +28863,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1628110848,
+                "id": 1628110848,
+                "individual_id": 11,
                 "name": "Podlachia",
                 "translations": {
                     "japanese": "ポドラシェ",
@@ -28890,8 +28890,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1628176384,
+                "id": 1628176384,
+                "individual_id": 12,
                 "name": "Pomerania",
                 "translations": {
                     "japanese": "ポモージェ",
@@ -28917,8 +28917,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1628241920,
+                "id": 1628241920,
+                "individual_id": 13,
                 "name": "Silesia",
                 "translations": {
                     "japanese": "シュレジエン",
@@ -28944,8 +28944,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1628307456,
+                "id": 1628307456,
+                "individual_id": 14,
                 "name": "Świętokrzyskie",
                 "translations": {
                     "japanese": "シフィェンティクシシュ",
@@ -28971,8 +28971,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1628372992,
+                "id": 1628372992,
+                "individual_id": 15,
                 "name": "Warmian-Masurian Voivodeship",
                 "translations": {
                     "japanese": "ヴァルミア・マスールィ",
@@ -28998,8 +28998,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1628438528,
+                "id": 1628438528,
+                "individual_id": 16,
                 "name": "Greater Poland",
                 "translations": {
                     "japanese": "ヴィェルコポルスカ",
@@ -29025,8 +29025,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1628504064,
+                "id": 1628504064,
+                "individual_id": 17,
                 "name": "Western Pomerania",
                 "translations": {
                     "japanese": "西ポモージェ",
@@ -29077,8 +29077,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1644167168,
+                "id": 1644167168,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -29104,8 +29104,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1644298240,
+                "id": 1644298240,
+                "individual_id": 2,
                 "name": "Lisbon",
                 "translations": {
                     "japanese": "リスボン県",
@@ -29131,8 +29131,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1644625920,
+                "id": 1644625920,
+                "individual_id": 7,
                 "name": "Madeira",
                 "translations": {
                     "japanese": "マディラ自治州",
@@ -29158,8 +29158,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1644691456,
+                "id": 1644691456,
+                "individual_id": 8,
                 "name": "Azores",
                 "translations": {
                     "japanese": "アソレス自治州",
@@ -29185,8 +29185,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1644756992,
+                "id": 1644756992,
+                "individual_id": 9,
                 "name": "Aveiro",
                 "translations": {
                     "japanese": "アヴェイロ県",
@@ -29212,8 +29212,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1644822528,
+                "id": 1644822528,
+                "individual_id": 10,
                 "name": "Beja",
                 "translations": {
                     "japanese": "ベージャ県",
@@ -29239,8 +29239,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1644888064,
+                "id": 1644888064,
+                "individual_id": 11,
                 "name": "Braga",
                 "translations": {
                     "japanese": "ブラガ県",
@@ -29266,8 +29266,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1644953600,
+                "id": 1644953600,
+                "individual_id": 12,
                 "name": "Bragança",
                 "translations": {
                     "japanese": "ブラガンサ県",
@@ -29293,8 +29293,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1645019136,
+                "id": 1645019136,
+                "individual_id": 13,
                 "name": "Castelo Branco",
                 "translations": {
                     "japanese": "カステロ・ブランコ県",
@@ -29320,8 +29320,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1645084672,
+                "id": 1645084672,
+                "individual_id": 14,
                 "name": "Coimbra",
                 "translations": {
                     "japanese": "コインブラ県",
@@ -29347,8 +29347,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1645150208,
+                "id": 1645150208,
+                "individual_id": 15,
                 "name": "Évora",
                 "translations": {
                     "japanese": "エヴォラ県",
@@ -29374,8 +29374,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1645215744,
+                "id": 1645215744,
+                "individual_id": 16,
                 "name": "Faro",
                 "translations": {
                     "japanese": "ファーロ県",
@@ -29401,8 +29401,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1645281280,
+                "id": 1645281280,
+                "individual_id": 17,
                 "name": "Guarda",
                 "translations": {
                     "japanese": "グアルダ県",
@@ -29428,8 +29428,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1645346816,
+                "id": 1645346816,
+                "individual_id": 18,
                 "name": "Leiria",
                 "translations": {
                     "japanese": "レイリア県",
@@ -29455,8 +29455,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1645412352,
+                "id": 1645412352,
+                "individual_id": 19,
                 "name": "Portalegre",
                 "translations": {
                     "japanese": "ポルタレグレ県",
@@ -29482,8 +29482,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1645477888,
+                "id": 1645477888,
+                "individual_id": 20,
                 "name": "Porto",
                 "translations": {
                     "japanese": "ポルト県",
@@ -29509,8 +29509,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1645543424,
+                "id": 1645543424,
+                "individual_id": 21,
                 "name": "Santarém",
                 "translations": {
                     "japanese": "サンタレン県",
@@ -29536,8 +29536,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1645608960,
+                "id": 1645608960,
+                "individual_id": 22,
                 "name": "Setúbal",
                 "translations": {
                     "japanese": "セトゥーバル県",
@@ -29563,8 +29563,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1645674496,
+                "id": 1645674496,
+                "individual_id": 23,
                 "name": "Viana do Castelo",
                 "translations": {
                     "japanese": "ヴィアナ・ド・カステロ県",
@@ -29590,8 +29590,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1645740032,
+                "id": 1645740032,
+                "individual_id": 24,
                 "name": "Vila Real",
                 "translations": {
                     "japanese": "ヴィラ・レアル県",
@@ -29617,8 +29617,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1645805568,
+                "id": 1645805568,
+                "individual_id": 25,
                 "name": "Viseu",
                 "translations": {
                     "japanese": "ヴィゼウ県",
@@ -29669,8 +29669,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1660944384,
+                "id": 1660944384,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -29696,8 +29696,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1661075456,
+                "id": 1661075456,
+                "individual_id": 2,
                 "name": "Bucharest",
                 "translations": {
                     "japanese": "ブカレスト州",
@@ -29723,8 +29723,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1661140992,
+                "id": 1661140992,
+                "individual_id": 3,
                 "name": "Alba",
                 "translations": {
                     "japanese": "アルバ州",
@@ -29750,8 +29750,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1661206528,
+                "id": 1661206528,
+                "individual_id": 4,
                 "name": "Arad",
                 "translations": {
                     "japanese": "アラド州",
@@ -29777,8 +29777,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1661272064,
+                "id": 1661272064,
+                "individual_id": 5,
                 "name": "Arges",
                 "translations": {
                     "japanese": "アルジェシュ州",
@@ -29804,8 +29804,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1661337600,
+                "id": 1661337600,
+                "individual_id": 6,
                 "name": "Bacau",
                 "translations": {
                     "japanese": "バカウ州",
@@ -29831,8 +29831,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1661403136,
+                "id": 1661403136,
+                "individual_id": 7,
                 "name": "Bihor",
                 "translations": {
                     "japanese": "ビホル州",
@@ -29858,8 +29858,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1661468672,
+                "id": 1661468672,
+                "individual_id": 8,
                 "name": "Bistrita-Nasaud",
                 "translations": {
                     "japanese": "ビストリツァ・ナサウド州",
@@ -29885,8 +29885,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1661534208,
+                "id": 1661534208,
+                "individual_id": 9,
                 "name": "Botosani",
                 "translations": {
                     "japanese": "ボトシャニ州",
@@ -29912,8 +29912,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1661599744,
+                "id": 1661599744,
+                "individual_id": 10,
                 "name": "Braila",
                 "translations": {
                     "japanese": "ブライラ州",
@@ -29939,8 +29939,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1661665280,
+                "id": 1661665280,
+                "individual_id": 11,
                 "name": "Brasov",
                 "translations": {
                     "japanese": "ブラショヴ州",
@@ -29966,8 +29966,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1661730816,
+                "id": 1661730816,
+                "individual_id": 12,
                 "name": "Buzau",
                 "translations": {
                     "japanese": "ブザウ州",
@@ -29993,8 +29993,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1661796352,
+                "id": 1661796352,
+                "individual_id": 13,
                 "name": "Calarasi",
                 "translations": {
                     "japanese": "カララシ州",
@@ -30020,8 +30020,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1661861888,
+                "id": 1661861888,
+                "individual_id": 14,
                 "name": "Caras-Severin",
                 "translations": {
                     "japanese": "カラシュ・セヴェリン州",
@@ -30047,8 +30047,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1661927424,
+                "id": 1661927424,
+                "individual_id": 15,
                 "name": "Cluj",
                 "translations": {
                     "japanese": "クルージュ州",
@@ -30074,8 +30074,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1661992960,
+                "id": 1661992960,
+                "individual_id": 16,
                 "name": "Constanta",
                 "translations": {
                     "japanese": "コンスタンツァ州",
@@ -30101,8 +30101,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1662058496,
+                "id": 1662058496,
+                "individual_id": 17,
                 "name": "Covasna",
                 "translations": {
                     "japanese": "コヴァスナ州",
@@ -30128,8 +30128,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1662124032,
+                "id": 1662124032,
+                "individual_id": 18,
                 "name": "Dâmbovita",
                 "translations": {
                     "japanese": "ドゥンボビツァ州",
@@ -30155,8 +30155,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1662189568,
+                "id": 1662189568,
+                "individual_id": 19,
                 "name": "Dolj",
                 "translations": {
                     "japanese": "ドルジュ州",
@@ -30182,8 +30182,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1662255104,
+                "id": 1662255104,
+                "individual_id": 20,
                 "name": "Galati",
                 "translations": {
                     "japanese": "ガラツィ州",
@@ -30209,8 +30209,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1662320640,
+                "id": 1662320640,
+                "individual_id": 21,
                 "name": "Giurgiu",
                 "translations": {
                     "japanese": "ジュルジュ州",
@@ -30236,8 +30236,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1662386176,
+                "id": 1662386176,
+                "individual_id": 22,
                 "name": "Gorj",
                 "translations": {
                     "japanese": "ゴルジュ州",
@@ -30263,8 +30263,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1662451712,
+                "id": 1662451712,
+                "individual_id": 23,
                 "name": "Harghita",
                 "translations": {
                     "japanese": "ハルギタ州",
@@ -30290,8 +30290,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1662517248,
+                "id": 1662517248,
+                "individual_id": 24,
                 "name": "Hunedoara",
                 "translations": {
                     "japanese": "フネドアラ州",
@@ -30317,8 +30317,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1662582784,
+                "id": 1662582784,
+                "individual_id": 25,
                 "name": "Ialomita",
                 "translations": {
                     "japanese": "ヤロミツァ州",
@@ -30344,8 +30344,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1662648320,
+                "id": 1662648320,
+                "individual_id": 26,
                 "name": "Iasi",
                 "translations": {
                     "japanese": "ヤシ州",
@@ -30371,8 +30371,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1662713856,
+                "id": 1662713856,
+                "individual_id": 27,
                 "name": "Ilfov",
                 "translations": {
                     "japanese": "イルホヴ州",
@@ -30398,8 +30398,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1662779392,
+                "id": 1662779392,
+                "individual_id": 28,
                 "name": "Maramures",
                 "translations": {
                     "japanese": "マラムレシュ州",
@@ -30425,8 +30425,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 1662844928,
+                "id": 1662844928,
+                "individual_id": 29,
                 "name": "Mehedinti",
                 "translations": {
                     "japanese": "メヘディンツィ州",
@@ -30452,8 +30452,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 1662910464,
+                "id": 1662910464,
+                "individual_id": 30,
                 "name": "Mures",
                 "translations": {
                     "japanese": "ムレシュ州",
@@ -30479,8 +30479,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 1662976000,
+                "id": 1662976000,
+                "individual_id": 31,
                 "name": "Neamt",
                 "translations": {
                     "japanese": "ネアムツ州",
@@ -30506,8 +30506,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1663041536,
+                "id": 1663041536,
+                "individual_id": 32,
                 "name": "Olt",
                 "translations": {
                     "japanese": "オルト州",
@@ -30533,8 +30533,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 1663107072,
+                "id": 1663107072,
+                "individual_id": 33,
                 "name": "Prahova",
                 "translations": {
                     "japanese": "プラホヴァ州",
@@ -30560,8 +30560,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 1663172608,
+                "id": 1663172608,
+                "individual_id": 34,
                 "name": "Salaj",
                 "translations": {
                     "japanese": "サラージュ州",
@@ -30587,8 +30587,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 1663238144,
+                "id": 1663238144,
+                "individual_id": 35,
                 "name": "Satu Mare",
                 "translations": {
                     "japanese": "サトゥ・マーレ州",
@@ -30614,8 +30614,8 @@
                 }
             },
             {
-                "id": 36,
-                "full_id": 1663303680,
+                "id": 1663303680,
+                "individual_id": 36,
                 "name": "Sibiu",
                 "translations": {
                     "japanese": "シビウ州",
@@ -30641,8 +30641,8 @@
                 }
             },
             {
-                "id": 37,
-                "full_id": 1663369216,
+                "id": 1663369216,
+                "individual_id": 37,
                 "name": "Suceava",
                 "translations": {
                     "japanese": "スチャヴァ州",
@@ -30668,8 +30668,8 @@
                 }
             },
             {
-                "id": 38,
-                "full_id": 1663434752,
+                "id": 1663434752,
+                "individual_id": 38,
                 "name": "Teleorman",
                 "translations": {
                     "japanese": "テレオルマン州",
@@ -30695,8 +30695,8 @@
                 }
             },
             {
-                "id": 39,
-                "full_id": 1663500288,
+                "id": 1663500288,
+                "individual_id": 39,
                 "name": "Timis",
                 "translations": {
                     "japanese": "ティミシュ州",
@@ -30722,8 +30722,8 @@
                 }
             },
             {
-                "id": 40,
-                "full_id": 1663565824,
+                "id": 1663565824,
+                "individual_id": 40,
                 "name": "Tulcea",
                 "translations": {
                     "japanese": "トゥルチャ州",
@@ -30749,8 +30749,8 @@
                 }
             },
             {
-                "id": 41,
-                "full_id": 1663631360,
+                "id": 1663631360,
+                "individual_id": 41,
                 "name": "Vâlcea",
                 "translations": {
                     "japanese": "ヴルチャ州",
@@ -30776,8 +30776,8 @@
                 }
             },
             {
-                "id": 42,
-                "full_id": 1663696896,
+                "id": 1663696896,
+                "individual_id": 42,
                 "name": "Vaslui",
                 "translations": {
                     "japanese": "ヴァスルイ州",
@@ -30803,8 +30803,8 @@
                 }
             },
             {
-                "id": 43,
-                "full_id": 1663762432,
+                "id": 1663762432,
+                "individual_id": 43,
                 "name": "Vrancea",
                 "translations": {
                     "japanese": "フランチェア州",
@@ -30855,8 +30855,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1677721600,
+                "id": 1677721600,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -30882,8 +30882,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1678311424,
+                "id": 1678311424,
+                "individual_id": 9,
                 "name": "Moscow City",
                 "translations": {
                     "japanese": "モスクワ市",
@@ -30909,8 +30909,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1678376960,
+                "id": 1678376960,
+                "individual_id": 10,
                 "name": "Adygey",
                 "translations": {
                     "japanese": "アディゲ共和国",
@@ -30936,8 +30936,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1678442496,
+                "id": 1678442496,
+                "individual_id": 11,
                 "name": "Gorno-Altay",
                 "translations": {
                     "japanese": "アルタイ共和国",
@@ -30963,8 +30963,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1678508032,
+                "id": 1678508032,
+                "individual_id": 12,
                 "name": "Altay",
                 "translations": {
                     "japanese": "アルタイ地方",
@@ -30990,8 +30990,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1678573568,
+                "id": 1678573568,
+                "individual_id": 13,
                 "name": "Amur",
                 "translations": {
                     "japanese": "アムール州",
@@ -31017,8 +31017,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1678639104,
+                "id": 1678639104,
+                "individual_id": 14,
                 "name": "Arkhangel'sk",
                 "translations": {
                     "japanese": "アルハンゲリスク州",
@@ -31044,8 +31044,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1678704640,
+                "id": 1678704640,
+                "individual_id": 15,
                 "name": "Astrakhan'",
                 "translations": {
                     "japanese": "アストラハン州",
@@ -31071,8 +31071,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1678770176,
+                "id": 1678770176,
+                "individual_id": 16,
                 "name": "Bashkortostan",
                 "translations": {
                     "japanese": "バシコルトスタン共和国",
@@ -31098,8 +31098,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1678835712,
+                "id": 1678835712,
+                "individual_id": 17,
                 "name": "Belgorod",
                 "translations": {
                     "japanese": "ベルゴロド州",
@@ -31125,8 +31125,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1678901248,
+                "id": 1678901248,
+                "individual_id": 18,
                 "name": "Bryansk",
                 "translations": {
                     "japanese": "ブリャンスク州",
@@ -31152,8 +31152,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1678966784,
+                "id": 1678966784,
+                "individual_id": 19,
                 "name": "Buryat",
                 "translations": {
                     "japanese": "ブリヤート共和国",
@@ -31179,8 +31179,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1679032320,
+                "id": 1679032320,
+                "individual_id": 20,
                 "name": "Chechnya",
                 "translations": {
                     "japanese": "チェチェン共和国",
@@ -31206,8 +31206,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1679097856,
+                "id": 1679097856,
+                "individual_id": 21,
                 "name": "Chelyabinsk",
                 "translations": {
                     "japanese": "チェリャビンスク州",
@@ -31233,8 +31233,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1679163392,
+                "id": 1679163392,
+                "individual_id": 22,
                 "name": "Chukot",
                 "translations": {
                     "japanese": "チュクチ自治管区",
@@ -31260,8 +31260,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1679228928,
+                "id": 1679228928,
+                "individual_id": 23,
                 "name": "Chuvash",
                 "translations": {
                     "japanese": "チュヴァシ共和国",
@@ -31287,8 +31287,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1679294464,
+                "id": 1679294464,
+                "individual_id": 24,
                 "name": "Dagestan",
                 "translations": {
                     "japanese": "ダゲスタン共和国",
@@ -31314,8 +31314,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1679360000,
+                "id": 1679360000,
+                "individual_id": 25,
                 "name": "Ingushetia",
                 "translations": {
                     "japanese": "イングーシ共和国",
@@ -31341,8 +31341,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1679425536,
+                "id": 1679425536,
+                "individual_id": 26,
                 "name": "Irkutsk",
                 "translations": {
                     "japanese": "イルクーツク州",
@@ -31368,8 +31368,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1679491072,
+                "id": 1679491072,
+                "individual_id": 27,
                 "name": "Ivanovo",
                 "translations": {
                     "japanese": "イヴァノヴォ州",
@@ -31395,8 +31395,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1679556608,
+                "id": 1679556608,
+                "individual_id": 28,
                 "name": "Kabardin-Balkar",
                 "translations": {
                     "japanese": "カバルダ・バルカル共和国",
@@ -31422,8 +31422,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 1679622144,
+                "id": 1679622144,
+                "individual_id": 29,
                 "name": "Kaliningrad",
                 "translations": {
                     "japanese": "カリーニングラード州",
@@ -31449,8 +31449,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 1679687680,
+                "id": 1679687680,
+                "individual_id": 30,
                 "name": "Kalmyk",
                 "translations": {
                     "japanese": "カルムイク共和国",
@@ -31476,8 +31476,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 1679753216,
+                "id": 1679753216,
+                "individual_id": 31,
                 "name": "Kaluga",
                 "translations": {
                     "japanese": "カルーガ州",
@@ -31503,8 +31503,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1679818752,
+                "id": 1679818752,
+                "individual_id": 32,
                 "name": "Kamchatka",
                 "translations": {
                     "japanese": "カムチャツカ地方",
@@ -31530,8 +31530,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 1679884288,
+                "id": 1679884288,
+                "individual_id": 33,
                 "name": "Karachay-Cherkess",
                 "translations": {
                     "japanese": "カラチャイ・チェルケス共和国",
@@ -31557,8 +31557,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 1679949824,
+                "id": 1679949824,
+                "individual_id": 34,
                 "name": "Karelia",
                 "translations": {
                     "japanese": "カレリア共和国",
@@ -31584,8 +31584,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 1680015360,
+                "id": 1680015360,
+                "individual_id": 35,
                 "name": "Kemerovo",
                 "translations": {
                     "japanese": "ケメロヴォ州",
@@ -31611,8 +31611,8 @@
                 }
             },
             {
-                "id": 36,
-                "full_id": 1680080896,
+                "id": 1680080896,
+                "individual_id": 36,
                 "name": "Khabarovsk",
                 "translations": {
                     "japanese": "ハバロフスク地方",
@@ -31638,8 +31638,8 @@
                 }
             },
             {
-                "id": 37,
-                "full_id": 1680146432,
+                "id": 1680146432,
+                "individual_id": 37,
                 "name": "Khakassia",
                 "translations": {
                     "japanese": "ハカス共和国",
@@ -31665,8 +31665,8 @@
                 }
             },
             {
-                "id": 38,
-                "full_id": 1680211968,
+                "id": 1680211968,
+                "individual_id": 38,
                 "name": "Khanty-Mansiy",
                 "translations": {
                     "japanese": "ハンティ・マンシ自治管区",
@@ -31692,8 +31692,8 @@
                 }
             },
             {
-                "id": 39,
-                "full_id": 1680277504,
+                "id": 1680277504,
+                "individual_id": 39,
                 "name": "Kirov",
                 "translations": {
                     "japanese": "キーロフ州",
@@ -31719,8 +31719,8 @@
                 }
             },
             {
-                "id": 40,
-                "full_id": 1680343040,
+                "id": 1680343040,
+                "individual_id": 40,
                 "name": "Komi",
                 "translations": {
                     "japanese": "コミ共和国",
@@ -31746,8 +31746,8 @@
                 }
             },
             {
-                "id": 41,
-                "full_id": 1680408576,
+                "id": 1680408576,
+                "individual_id": 41,
                 "name": "Kostroma",
                 "translations": {
                     "japanese": "コストロマ州",
@@ -31773,8 +31773,8 @@
                 }
             },
             {
-                "id": 42,
-                "full_id": 1680474112,
+                "id": 1680474112,
+                "individual_id": 42,
                 "name": "Krasnodar",
                 "translations": {
                     "japanese": "クラスノダール地方",
@@ -31800,8 +31800,8 @@
                 }
             },
             {
-                "id": 43,
-                "full_id": 1680539648,
+                "id": 1680539648,
+                "individual_id": 43,
                 "name": "Krasnoyarsk",
                 "translations": {
                     "japanese": "クラスノヤルスク地方",
@@ -31827,8 +31827,8 @@
                 }
             },
             {
-                "id": 44,
-                "full_id": 1680605184,
+                "id": 1680605184,
+                "individual_id": 44,
                 "name": "Kurgan",
                 "translations": {
                     "japanese": "クルガン州",
@@ -31854,8 +31854,8 @@
                 }
             },
             {
-                "id": 45,
-                "full_id": 1680670720,
+                "id": 1680670720,
+                "individual_id": 45,
                 "name": "Kursk",
                 "translations": {
                     "japanese": "クルスク州",
@@ -31881,8 +31881,8 @@
                 }
             },
             {
-                "id": 46,
-                "full_id": 1680736256,
+                "id": 1680736256,
+                "individual_id": 46,
                 "name": "Leningrad",
                 "translations": {
                     "japanese": "レニングラード州",
@@ -31908,8 +31908,8 @@
                 }
             },
             {
-                "id": 47,
-                "full_id": 1680801792,
+                "id": 1680801792,
+                "individual_id": 47,
                 "name": "Lipetsk",
                 "translations": {
                     "japanese": "リペツク州",
@@ -31935,8 +31935,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1680867328,
+                "id": 1680867328,
+                "individual_id": 48,
                 "name": "Magadan",
                 "translations": {
                     "japanese": "マガダン州",
@@ -31962,8 +31962,8 @@
                 }
             },
             {
-                "id": 49,
-                "full_id": 1680932864,
+                "id": 1680932864,
+                "individual_id": 49,
                 "name": "Mariy-El",
                 "translations": {
                     "japanese": "マリ・エル共和国",
@@ -31989,8 +31989,8 @@
                 }
             },
             {
-                "id": 50,
-                "full_id": 1680998400,
+                "id": 1680998400,
+                "individual_id": 50,
                 "name": "Mordovia",
                 "translations": {
                     "japanese": "モルドヴィア共和国",
@@ -32016,8 +32016,8 @@
                 }
             },
             {
-                "id": 51,
-                "full_id": 1681063936,
+                "id": 1681063936,
+                "individual_id": 51,
                 "name": "Moscow",
                 "translations": {
                     "japanese": "モスクワ州",
@@ -32043,8 +32043,8 @@
                 }
             },
             {
-                "id": 52,
-                "full_id": 1681129472,
+                "id": 1681129472,
+                "individual_id": 52,
                 "name": "Murmansk",
                 "translations": {
                     "japanese": "ムルマンスク州",
@@ -32070,8 +32070,8 @@
                 }
             },
             {
-                "id": 53,
-                "full_id": 1681195008,
+                "id": 1681195008,
+                "individual_id": 53,
                 "name": "Nenets",
                 "translations": {
                     "japanese": "ネネツ自治管区",
@@ -32097,8 +32097,8 @@
                 }
             },
             {
-                "id": 54,
-                "full_id": 1681260544,
+                "id": 1681260544,
+                "individual_id": 54,
                 "name": "Nizhegorod",
                 "translations": {
                     "japanese": "ニジニ・ノヴゴロド州",
@@ -32124,8 +32124,8 @@
                 }
             },
             {
-                "id": 55,
-                "full_id": 1681326080,
+                "id": 1681326080,
+                "individual_id": 55,
                 "name": "Novgorod",
                 "translations": {
                     "japanese": "ノヴゴロド州",
@@ -32151,8 +32151,8 @@
                 }
             },
             {
-                "id": 56,
-                "full_id": 1681391616,
+                "id": 1681391616,
+                "individual_id": 56,
                 "name": "Novosibirsk",
                 "translations": {
                     "japanese": "ノヴォシビルスク州",
@@ -32178,8 +32178,8 @@
                 }
             },
             {
-                "id": 57,
-                "full_id": 1681457152,
+                "id": 1681457152,
+                "individual_id": 57,
                 "name": "Omsk",
                 "translations": {
                     "japanese": "オムスク州",
@@ -32205,8 +32205,8 @@
                 }
             },
             {
-                "id": 58,
-                "full_id": 1681522688,
+                "id": 1681522688,
+                "individual_id": 58,
                 "name": "Orenburg",
                 "translations": {
                     "japanese": "オレンブルク州",
@@ -32232,8 +32232,8 @@
                 }
             },
             {
-                "id": 59,
-                "full_id": 1681588224,
+                "id": 1681588224,
+                "individual_id": 59,
                 "name": "Orel",
                 "translations": {
                     "japanese": "オリョール州",
@@ -32259,8 +32259,8 @@
                 }
             },
             {
-                "id": 60,
-                "full_id": 1681653760,
+                "id": 1681653760,
+                "individual_id": 60,
                 "name": "Penza",
                 "translations": {
                     "japanese": "ペンザ州",
@@ -32286,8 +32286,8 @@
                 }
             },
             {
-                "id": 61,
-                "full_id": 1681719296,
+                "id": 1681719296,
+                "individual_id": 61,
                 "name": "Perm'",
                 "translations": {
                     "japanese": "ペルミ地方",
@@ -32313,8 +32313,8 @@
                 }
             },
             {
-                "id": 62,
-                "full_id": 1681784832,
+                "id": 1681784832,
+                "individual_id": 62,
                 "name": "Primor'ye",
                 "translations": {
                     "japanese": "沿海地方",
@@ -32340,8 +32340,8 @@
                 }
             },
             {
-                "id": 63,
-                "full_id": 1681850368,
+                "id": 1681850368,
+                "individual_id": 63,
                 "name": "Pskov",
                 "translations": {
                     "japanese": "プスコフ州",
@@ -32367,8 +32367,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1681915904,
+                "id": 1681915904,
+                "individual_id": 64,
                 "name": "Rostov",
                 "translations": {
                     "japanese": "ロストフ州",
@@ -32394,8 +32394,8 @@
                 }
             },
             {
-                "id": 65,
-                "full_id": 1681981440,
+                "id": 1681981440,
+                "individual_id": 65,
                 "name": "Ryazan'",
                 "translations": {
                     "japanese": "リャザン州",
@@ -32421,8 +32421,8 @@
                 }
             },
             {
-                "id": 66,
-                "full_id": 1682046976,
+                "id": 1682046976,
+                "individual_id": 66,
                 "name": "Sakha",
                 "translations": {
                     "japanese": "サハ共和国",
@@ -32448,8 +32448,8 @@
                 }
             },
             {
-                "id": 67,
-                "full_id": 1682112512,
+                "id": 1682112512,
+                "individual_id": 67,
                 "name": "Sakhalin",
                 "translations": {
                     "japanese": "サハリン州",
@@ -32475,8 +32475,8 @@
                 }
             },
             {
-                "id": 68,
-                "full_id": 1682178048,
+                "id": 1682178048,
+                "individual_id": 68,
                 "name": "Samara",
                 "translations": {
                     "japanese": "サマラ州",
@@ -32502,8 +32502,8 @@
                 }
             },
             {
-                "id": 69,
-                "full_id": 1682243584,
+                "id": 1682243584,
+                "individual_id": 69,
                 "name": "St. Petersburg",
                 "translations": {
                     "japanese": "サンクトペテルブルク市",
@@ -32529,8 +32529,8 @@
                 }
             },
             {
-                "id": 70,
-                "full_id": 1682309120,
+                "id": 1682309120,
+                "individual_id": 70,
                 "name": "Saratov",
                 "translations": {
                     "japanese": "サラトフ州",
@@ -32556,8 +32556,8 @@
                 }
             },
             {
-                "id": 71,
-                "full_id": 1682374656,
+                "id": 1682374656,
+                "individual_id": 71,
                 "name": "North Ossetia",
                 "translations": {
                     "japanese": "北オセチア共和国",
@@ -32583,8 +32583,8 @@
                 }
             },
             {
-                "id": 72,
-                "full_id": 1682440192,
+                "id": 1682440192,
+                "individual_id": 72,
                 "name": "Smolensk",
                 "translations": {
                     "japanese": "スモレンスク州",
@@ -32610,8 +32610,8 @@
                 }
             },
             {
-                "id": 73,
-                "full_id": 1682505728,
+                "id": 1682505728,
+                "individual_id": 73,
                 "name": "Stavropol'",
                 "translations": {
                     "japanese": "スタヴロポリ地方",
@@ -32637,8 +32637,8 @@
                 }
             },
             {
-                "id": 74,
-                "full_id": 1682571264,
+                "id": 1682571264,
+                "individual_id": 74,
                 "name": "Sverdlovsk",
                 "translations": {
                     "japanese": "スヴェルドロフスク州",
@@ -32664,8 +32664,8 @@
                 }
             },
             {
-                "id": 75,
-                "full_id": 1682636800,
+                "id": 1682636800,
+                "individual_id": 75,
                 "name": "Tambov",
                 "translations": {
                     "japanese": "タンボフ州",
@@ -32691,8 +32691,8 @@
                 }
             },
             {
-                "id": 76,
-                "full_id": 1682702336,
+                "id": 1682702336,
+                "individual_id": 76,
                 "name": "Tatarstan",
                 "translations": {
                     "japanese": "タタールスタン共和国",
@@ -32718,8 +32718,8 @@
                 }
             },
             {
-                "id": 77,
-                "full_id": 1682767872,
+                "id": 1682767872,
+                "individual_id": 77,
                 "name": "Tomsk",
                 "translations": {
                     "japanese": "トムスク州",
@@ -32745,8 +32745,8 @@
                 }
             },
             {
-                "id": 78,
-                "full_id": 1682833408,
+                "id": 1682833408,
+                "individual_id": 78,
                 "name": "Tula",
                 "translations": {
                     "japanese": "トゥーラ州",
@@ -32772,8 +32772,8 @@
                 }
             },
             {
-                "id": 79,
-                "full_id": 1682898944,
+                "id": 1682898944,
+                "individual_id": 79,
                 "name": "Tver'",
                 "translations": {
                     "japanese": "トヴェリ州",
@@ -32799,8 +32799,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1682964480,
+                "id": 1682964480,
+                "individual_id": 80,
                 "name": "Tyumen'",
                 "translations": {
                     "japanese": "チュメニ州",
@@ -32826,8 +32826,8 @@
                 }
             },
             {
-                "id": 81,
-                "full_id": 1683030016,
+                "id": 1683030016,
+                "individual_id": 81,
                 "name": "Tuva",
                 "translations": {
                     "japanese": "トゥヴァ共和国",
@@ -32853,8 +32853,8 @@
                 }
             },
             {
-                "id": 82,
-                "full_id": 1683095552,
+                "id": 1683095552,
+                "individual_id": 82,
                 "name": "Udmurt",
                 "translations": {
                     "japanese": "ウドムルト共和国",
@@ -32880,8 +32880,8 @@
                 }
             },
             {
-                "id": 83,
-                "full_id": 1683161088,
+                "id": 1683161088,
+                "individual_id": 83,
                 "name": "Ul'yanovsk",
                 "translations": {
                     "japanese": "ウリヤノフスク州",
@@ -32907,8 +32907,8 @@
                 }
             },
             {
-                "id": 84,
-                "full_id": 1683226624,
+                "id": 1683226624,
+                "individual_id": 84,
                 "name": "Vladimir",
                 "translations": {
                     "japanese": "ヴラジーミル州",
@@ -32934,8 +32934,8 @@
                 }
             },
             {
-                "id": 85,
-                "full_id": 1683292160,
+                "id": 1683292160,
+                "individual_id": 85,
                 "name": "Volgograd",
                 "translations": {
                     "japanese": "ヴォルゴグラード州",
@@ -32961,8 +32961,8 @@
                 }
             },
             {
-                "id": 86,
-                "full_id": 1683357696,
+                "id": 1683357696,
+                "individual_id": 86,
                 "name": "Vologda",
                 "translations": {
                     "japanese": "ヴォログダ州",
@@ -32988,8 +32988,8 @@
                 }
             },
             {
-                "id": 87,
-                "full_id": 1683423232,
+                "id": 1683423232,
+                "individual_id": 87,
                 "name": "Voronezh",
                 "translations": {
                     "japanese": "ヴォロネジ州",
@@ -33015,8 +33015,8 @@
                 }
             },
             {
-                "id": 88,
-                "full_id": 1683488768,
+                "id": 1683488768,
+                "individual_id": 88,
                 "name": "Yamal-Nenets",
                 "translations": {
                     "japanese": "ヤマロ・ネネツ自治管区",
@@ -33042,8 +33042,8 @@
                 }
             },
             {
-                "id": 89,
-                "full_id": 1683554304,
+                "id": 1683554304,
+                "individual_id": 89,
                 "name": "Yaroslavl'",
                 "translations": {
                     "japanese": "ヤロスラヴリ州",
@@ -33069,8 +33069,8 @@
                 }
             },
             {
-                "id": 90,
-                "full_id": 1683619840,
+                "id": 1683619840,
+                "individual_id": 90,
                 "name": "Yevrey",
                 "translations": {
                     "japanese": "ユダヤ自治州",
@@ -33096,8 +33096,8 @@
                 }
             },
             {
-                "id": 91,
-                "full_id": 1683685376,
+                "id": 1683685376,
+                "individual_id": 91,
                 "name": "Zabaykal'ye",
                 "translations": {
                     "japanese": "ザバイカリエ地方",
@@ -33148,8 +33148,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1694498816,
+                "id": 1694498816,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33175,8 +33175,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1694564352,
+                "id": 1694564352,
+                "individual_id": 1,
                 "name": "Serbia and Kosovo",
                 "translations": {
                     "japanese": "セルビア・コソヴォ",
@@ -33227,8 +33227,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1711276032,
+                "id": 1711276032,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33254,8 +33254,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1711407104,
+                "id": 1711407104,
+                "individual_id": 2,
                 "name": "Bratislava",
                 "translations": {
                     "japanese": "ブラティスラバ",
@@ -33281,8 +33281,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1711472640,
+                "id": 1711472640,
+                "individual_id": 3,
                 "name": "Banská Bystrica",
                 "translations": {
                     "japanese": "バンスカ・ビストリツァ",
@@ -33308,8 +33308,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1711538176,
+                "id": 1711538176,
+                "individual_id": 4,
                 "name": "Košice",
                 "translations": {
                     "japanese": "コシツェ",
@@ -33335,8 +33335,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1711603712,
+                "id": 1711603712,
+                "individual_id": 5,
                 "name": "Nitra",
                 "translations": {
                     "japanese": "二トラ",
@@ -33362,8 +33362,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1711669248,
+                "id": 1711669248,
+                "individual_id": 6,
                 "name": "Prešov",
                 "translations": {
                     "japanese": "プレショフ",
@@ -33389,8 +33389,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1711734784,
+                "id": 1711734784,
+                "individual_id": 7,
                 "name": "Trencín",
                 "translations": {
                     "japanese": "トレンチーン",
@@ -33416,8 +33416,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1711800320,
+                "id": 1711800320,
+                "individual_id": 8,
                 "name": "Trnava",
                 "translations": {
                     "japanese": "トルナバ",
@@ -33443,8 +33443,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1711865856,
+                "id": 1711865856,
+                "individual_id": 9,
                 "name": "Žilina",
                 "translations": {
                     "japanese": "ジリナ",
@@ -33495,8 +33495,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1728053248,
+                "id": 1728053248,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33522,8 +33522,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1728118784,
+                "id": 1728118784,
+                "individual_id": 1,
                 "name": "Slovenia",
                 "translations": {
                     "japanese": "スロベニア",
@@ -33574,8 +33574,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1744830464,
+                "id": 1744830464,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33601,8 +33601,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1744961536,
+                "id": 1744961536,
+                "individual_id": 2,
                 "name": "Gauteng",
                 "translations": {
                     "japanese": "ハウテン州",
@@ -33628,8 +33628,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1745027072,
+                "id": 1745027072,
+                "individual_id": 3,
                 "name": "Western Cape",
                 "translations": {
                     "japanese": "ウェスタン・ケープ州",
@@ -33655,8 +33655,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1745092608,
+                "id": 1745092608,
+                "individual_id": 4,
                 "name": "Northern Cape",
                 "translations": {
                     "japanese": "ノーザン・ケープ州",
@@ -33682,8 +33682,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1745158144,
+                "id": 1745158144,
+                "individual_id": 5,
                 "name": "Eastern Cape",
                 "translations": {
                     "japanese": "イースタン・ケープ州",
@@ -33709,8 +33709,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1745223680,
+                "id": 1745223680,
+                "individual_id": 6,
                 "name": "KwaZulu-Natal",
                 "translations": {
                     "japanese": "クワズールー・ナタール州",
@@ -33736,8 +33736,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1745289216,
+                "id": 1745289216,
+                "individual_id": 7,
                 "name": "Free State",
                 "translations": {
                     "japanese": "フリー・ステート州",
@@ -33763,8 +33763,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1745354752,
+                "id": 1745354752,
+                "individual_id": 8,
                 "name": "North West",
                 "translations": {
                     "japanese": "ノース・ウェスト州",
@@ -33790,8 +33790,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1745420288,
+                "id": 1745420288,
+                "individual_id": 9,
                 "name": "Mpumalanga",
                 "translations": {
                     "japanese": "ムプマランガ州",
@@ -33817,8 +33817,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1745485824,
+                "id": 1745485824,
+                "individual_id": 10,
                 "name": "Limpopo",
                 "translations": {
                     "japanese": "リンポポ州",
@@ -33869,8 +33869,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1761607680,
+                "id": 1761607680,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33896,8 +33896,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1761738752,
+                "id": 1761738752,
+                "individual_id": 2,
                 "name": "Madrid",
                 "translations": {
                     "japanese": "マドリード州",
@@ -33923,8 +33923,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1761804288,
+                "id": 1761804288,
+                "individual_id": 3,
                 "name": "Andalusia",
                 "translations": {
                     "japanese": "アンダルシーア州",
@@ -33950,8 +33950,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1761869824,
+                "id": 1761869824,
+                "individual_id": 4,
                 "name": "Aragon",
                 "translations": {
                     "japanese": "アラゴン州",
@@ -33977,8 +33977,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1761935360,
+                "id": 1761935360,
+                "individual_id": 5,
                 "name": "Principality of Asturias",
                 "translations": {
                     "japanese": "アストゥーリアス州",
@@ -34004,8 +34004,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1762000896,
+                "id": 1762000896,
+                "individual_id": 6,
                 "name": "Balearic Islands",
                 "translations": {
                     "japanese": "バレアーレス諸島",
@@ -34031,8 +34031,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1762066432,
+                "id": 1762066432,
+                "individual_id": 7,
                 "name": "Canary Islands",
                 "translations": {
                     "japanese": "カナリア諸島",
@@ -34058,8 +34058,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1762131968,
+                "id": 1762131968,
+                "individual_id": 8,
                 "name": "Cantabria",
                 "translations": {
                     "japanese": "カンタブリア州",
@@ -34085,8 +34085,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1762197504,
+                "id": 1762197504,
+                "individual_id": 9,
                 "name": "Castile-La Mancha",
                 "translations": {
                     "japanese": "カスティーリャ・ラ・マンチャ",
@@ -34112,8 +34112,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1762263040,
+                "id": 1762263040,
+                "individual_id": 10,
                 "name": "Castilla y León",
                 "translations": {
                     "japanese": "カスティーリャ・レオン",
@@ -34139,8 +34139,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1762328576,
+                "id": 1762328576,
+                "individual_id": 11,
                 "name": "Catalonia",
                 "translations": {
                     "japanese": "カタルーニャ",
@@ -34166,8 +34166,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1762394112,
+                "id": 1762394112,
+                "individual_id": 12,
                 "name": "Valencia",
                 "translations": {
                     "japanese": "バレンシア州",
@@ -34193,8 +34193,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1762459648,
+                "id": 1762459648,
+                "individual_id": 13,
                 "name": "Extremadura",
                 "translations": {
                     "japanese": "エストレマドゥーラ",
@@ -34220,8 +34220,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1762525184,
+                "id": 1762525184,
+                "individual_id": 14,
                 "name": "Galicia",
                 "translations": {
                     "japanese": "ガリーシア",
@@ -34247,8 +34247,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1762590720,
+                "id": 1762590720,
+                "individual_id": 15,
                 "name": "Murcia",
                 "translations": {
                     "japanese": "ムルシア州",
@@ -34274,8 +34274,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1762656256,
+                "id": 1762656256,
+                "individual_id": 16,
                 "name": "Navarre",
                 "translations": {
                     "japanese": "ナバーラ州",
@@ -34301,8 +34301,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1762721792,
+                "id": 1762721792,
+                "individual_id": 17,
                 "name": "Basque Country",
                 "translations": {
                     "japanese": "バスク",
@@ -34328,8 +34328,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1762787328,
+                "id": 1762787328,
+                "individual_id": 18,
                 "name": "La Rioja",
                 "translations": {
                     "japanese": "ラ・リオハ州",
@@ -34355,8 +34355,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1762852864,
+                "id": 1762852864,
+                "individual_id": 19,
                 "name": "Ceuta",
                 "translations": {
                     "japanese": "セウタ",
@@ -34382,8 +34382,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1762918400,
+                "id": 1762918400,
+                "individual_id": 20,
                 "name": "Melilla",
                 "translations": {
                     "japanese": "メリラ",
@@ -34434,8 +34434,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1778384896,
+                "id": 1778384896,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -34461,8 +34461,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1778515968,
+                "id": 1778515968,
+                "individual_id": 2,
                 "name": "Hhohho",
                 "translations": {
                     "japanese": "ホホ",
@@ -34488,8 +34488,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1778581504,
+                "id": 1778581504,
+                "individual_id": 3,
                 "name": "Lubombo",
                 "translations": {
                     "japanese": "ルボンボ",
@@ -34515,8 +34515,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1778647040,
+                "id": 1778647040,
+                "individual_id": 4,
                 "name": "Manzini",
                 "translations": {
                     "japanese": "マンジニ",
@@ -34542,8 +34542,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1778712576,
+                "id": 1778712576,
+                "individual_id": 5,
                 "name": "Shiselweni",
                 "translations": {
                     "japanese": "シセルウェニ",
@@ -34594,8 +34594,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1795162112,
+                "id": 1795162112,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -34621,8 +34621,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1795293184,
+                "id": 1795293184,
+                "individual_id": 2,
                 "name": "Stockholm County",
                 "translations": {
                     "japanese": "ストックホルム州",
@@ -34648,8 +34648,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1795358720,
+                "id": 1795358720,
+                "individual_id": 3,
                 "name": "Skåne County",
                 "translations": {
                     "japanese": "スコーネ州",
@@ -34675,8 +34675,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1795424256,
+                "id": 1795424256,
+                "individual_id": 4,
                 "name": "Västra Götaland County",
                 "translations": {
                     "japanese": "ヴェストラ・イェータランド州",
@@ -34702,8 +34702,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1795489792,
+                "id": 1795489792,
+                "individual_id": 5,
                 "name": "Östergötland County",
                 "translations": {
                     "japanese": "エステルイェトランド州",
@@ -34729,8 +34729,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1795555328,
+                "id": 1795555328,
+                "individual_id": 6,
                 "name": "Södermanland County",
                 "translations": {
                     "japanese": "セーデルマンランド州",
@@ -34756,8 +34756,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1795620864,
+                "id": 1795620864,
+                "individual_id": 7,
                 "name": "Värmland County",
                 "translations": {
                     "japanese": "ベルムランド州",
@@ -34783,8 +34783,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1795686400,
+                "id": 1795686400,
+                "individual_id": 8,
                 "name": "Uppsala County",
                 "translations": {
                     "japanese": "ウプサラ州",
@@ -34810,8 +34810,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1795751936,
+                "id": 1795751936,
+                "individual_id": 9,
                 "name": "Gävleborg County",
                 "translations": {
                     "japanese": "イェーブレボリ州",
@@ -34837,8 +34837,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1795817472,
+                "id": 1795817472,
+                "individual_id": 10,
                 "name": "Västerbotten County",
                 "translations": {
                     "japanese": "ベステルボッテン州",
@@ -34864,8 +34864,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1795883008,
+                "id": 1795883008,
+                "individual_id": 11,
                 "name": "Norrbotten County",
                 "translations": {
                     "japanese": "ノルボッテン州",
@@ -34891,8 +34891,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1795948544,
+                "id": 1795948544,
+                "individual_id": 12,
                 "name": "Gotland Island",
                 "translations": {
                     "japanese": "ゴトランド州",
@@ -34918,8 +34918,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1796014080,
+                "id": 1796014080,
+                "individual_id": 13,
                 "name": "Jämtland County",
                 "translations": {
                     "japanese": "イェムトランド州",
@@ -34945,8 +34945,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1796079616,
+                "id": 1796079616,
+                "individual_id": 14,
                 "name": "Dalarna County",
                 "translations": {
                     "japanese": "ダーラナ州",
@@ -34972,8 +34972,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1796145152,
+                "id": 1796145152,
+                "individual_id": 15,
                 "name": "Blekinge County",
                 "translations": {
                     "japanese": "ブレーキンゲ州",
@@ -34999,8 +34999,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1796210688,
+                "id": 1796210688,
+                "individual_id": 16,
                 "name": "Örebro County",
                 "translations": {
                     "japanese": "エレブルー州",
@@ -35026,8 +35026,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1796276224,
+                "id": 1796276224,
+                "individual_id": 17,
                 "name": "Västernorrland County",
                 "translations": {
                     "japanese": "ベステルノルランド州",
@@ -35053,8 +35053,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1796341760,
+                "id": 1796341760,
+                "individual_id": 18,
                 "name": "Jönköping County",
                 "translations": {
                     "japanese": "イェンチェピング州",
@@ -35080,8 +35080,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1796407296,
+                "id": 1796407296,
+                "individual_id": 19,
                 "name": "Kronoberg County",
                 "translations": {
                     "japanese": "クロノベリ州",
@@ -35107,8 +35107,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1796472832,
+                "id": 1796472832,
+                "individual_id": 20,
                 "name": "Kalmar County",
                 "translations": {
                     "japanese": "カルマル州",
@@ -35134,8 +35134,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1796538368,
+                "id": 1796538368,
+                "individual_id": 21,
                 "name": "Västmanland County",
                 "translations": {
                     "japanese": "ベストマンランド州",
@@ -35161,8 +35161,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1796603904,
+                "id": 1796603904,
+                "individual_id": 22,
                 "name": "Halland County",
                 "translations": {
                     "japanese": "ハランド州",
@@ -35213,8 +35213,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1811939328,
+                "id": 1811939328,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -35240,8 +35240,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1812070400,
+                "id": 1812070400,
+                "individual_id": 2,
                 "name": "Bern",
                 "translations": {
                     "japanese": "ベルン州",
@@ -35267,8 +35267,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1812201472,
+                "id": 1812201472,
+                "individual_id": 4,
                 "name": "Aargau",
                 "translations": {
                     "japanese": "アールガウ州",
@@ -35294,8 +35294,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1812267008,
+                "id": 1812267008,
+                "individual_id": 5,
                 "name": "Basel-City",
                 "translations": {
                     "japanese": "バーゼル＝シュタット準州",
@@ -35321,8 +35321,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1812332544,
+                "id": 1812332544,
+                "individual_id": 6,
                 "name": "Fribourg",
                 "translations": {
                     "japanese": "フリブール州",
@@ -35348,8 +35348,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1812398080,
+                "id": 1812398080,
+                "individual_id": 7,
                 "name": "Geneva",
                 "translations": {
                     "japanese": "ジュネーヴ州",
@@ -35375,8 +35375,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1812463616,
+                "id": 1812463616,
+                "individual_id": 8,
                 "name": "Glarus",
                 "translations": {
                     "japanese": "グラールス州",
@@ -35402,8 +35402,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1812529152,
+                "id": 1812529152,
+                "individual_id": 9,
                 "name": "Graubünden",
                 "translations": {
                     "japanese": "グラウビュンデン州",
@@ -35429,8 +35429,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1812594688,
+                "id": 1812594688,
+                "individual_id": 10,
                 "name": "Jura",
                 "translations": {
                     "japanese": "ジュラ州",
@@ -35456,8 +35456,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1812660224,
+                "id": 1812660224,
+                "individual_id": 11,
                 "name": "Luzern",
                 "translations": {
                     "japanese": "ルツェルン州",
@@ -35483,8 +35483,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1812725760,
+                "id": 1812725760,
+                "individual_id": 12,
                 "name": "Neuchâtel",
                 "translations": {
                     "japanese": "ヌシャテル州",
@@ -35510,8 +35510,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1812791296,
+                "id": 1812791296,
+                "individual_id": 13,
                 "name": "Obwalden",
                 "translations": {
                     "japanese": "オプバルデン準州",
@@ -35537,8 +35537,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1812856832,
+                "id": 1812856832,
+                "individual_id": 14,
                 "name": "St. Gallen",
                 "translations": {
                     "japanese": "ザンクト・ガレン州",
@@ -35564,8 +35564,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1812922368,
+                "id": 1812922368,
+                "individual_id": 15,
                 "name": "Schaffhausen",
                 "translations": {
                     "japanese": "シャフハウゼン州",
@@ -35591,8 +35591,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1812987904,
+                "id": 1812987904,
+                "individual_id": 16,
                 "name": "Schwyz",
                 "translations": {
                     "japanese": "シュビーツ州",
@@ -35618,8 +35618,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1813053440,
+                "id": 1813053440,
+                "individual_id": 17,
                 "name": "Solothurn",
                 "translations": {
                     "japanese": "ゾーロトゥルン州",
@@ -35645,8 +35645,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1813118976,
+                "id": 1813118976,
+                "individual_id": 18,
                 "name": "Thurgau",
                 "translations": {
                     "japanese": "トゥールガウ州",
@@ -35672,8 +35672,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1813184512,
+                "id": 1813184512,
+                "individual_id": 19,
                 "name": "Ticino",
                 "translations": {
                     "japanese": "ティチーノ州",
@@ -35699,8 +35699,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1813250048,
+                "id": 1813250048,
+                "individual_id": 20,
                 "name": "Uri",
                 "translations": {
                     "japanese": "ウーリ州",
@@ -35726,8 +35726,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1813315584,
+                "id": 1813315584,
+                "individual_id": 21,
                 "name": "Valais",
                 "translations": {
                     "japanese": "バレー州",
@@ -35753,8 +35753,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1813381120,
+                "id": 1813381120,
+                "individual_id": 22,
                 "name": "Vaud",
                 "translations": {
                     "japanese": "ボー州",
@@ -35780,8 +35780,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1813446656,
+                "id": 1813446656,
+                "individual_id": 23,
                 "name": "Zug",
                 "translations": {
                     "japanese": "ツーク州",
@@ -35807,8 +35807,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1813512192,
+                "id": 1813512192,
+                "individual_id": 24,
                 "name": "Zurich",
                 "translations": {
                     "japanese": "チューリヒ州",
@@ -35834,8 +35834,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1813577728,
+                "id": 1813577728,
+                "individual_id": 25,
                 "name": "Appenzell Outer Rhodes",
                 "translations": {
                     "japanese": "アッペンツェル・アウサーローデン準州",
@@ -35861,8 +35861,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1813643264,
+                "id": 1813643264,
+                "individual_id": 26,
                 "name": "Appenzell Inner Rhodes",
                 "translations": {
                     "japanese": "アッペンツェル・インナーローデン準州",
@@ -35888,8 +35888,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1813708800,
+                "id": 1813708800,
+                "individual_id": 27,
                 "name": "Basel-Landschaft",
                 "translations": {
                     "japanese": "バーゼル＝ラント準州",
@@ -35915,8 +35915,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1813774336,
+                "id": 1813774336,
+                "individual_id": 28,
                 "name": "Nidwalden",
                 "translations": {
                     "japanese": "ニトバルデン準州",
@@ -35967,8 +35967,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1828716544,
+                "id": 1828716544,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -35994,8 +35994,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1828847616,
+                "id": 1828847616,
+                "individual_id": 2,
                 "name": "Ankara",
                 "translations": {
                     "japanese": "アンカラ県",
@@ -36021,8 +36021,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1828913152,
+                "id": 1828913152,
+                "individual_id": 3,
                 "name": "İstanbul",
                 "translations": {
                     "japanese": "イスタンブル県",
@@ -36048,8 +36048,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1828978688,
+                "id": 1828978688,
+                "individual_id": 4,
                 "name": "İzmir",
                 "translations": {
                     "japanese": "イズミル県",
@@ -36075,8 +36075,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1829044224,
+                "id": 1829044224,
+                "individual_id": 5,
                 "name": "Bursa",
                 "translations": {
                     "japanese": "ブルサ県",
@@ -36102,8 +36102,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1829109760,
+                "id": 1829109760,
+                "individual_id": 6,
                 "name": "Adana",
                 "translations": {
                     "japanese": "アダナ県",
@@ -36129,8 +36129,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1829175296,
+                "id": 1829175296,
+                "individual_id": 7,
                 "name": "Gaziantep",
                 "translations": {
                     "japanese": "ガジアンテプ県",
@@ -36156,8 +36156,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1829240832,
+                "id": 1829240832,
+                "individual_id": 8,
                 "name": "Konya",
                 "translations": {
                     "japanese": "コニヤ県",
@@ -36183,8 +36183,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1829306368,
+                "id": 1829306368,
+                "individual_id": 9,
                 "name": "Antalya",
                 "translations": {
                     "japanese": "アンタリヤ県",
@@ -36210,8 +36210,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1829371904,
+                "id": 1829371904,
+                "individual_id": 10,
                 "name": "Diyarbakır",
                 "translations": {
                     "japanese": "ディヤルバクル県",
@@ -36237,8 +36237,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1829437440,
+                "id": 1829437440,
+                "individual_id": 11,
                 "name": "Mersin",
                 "translations": {
                     "japanese": "メルシン県",
@@ -36264,8 +36264,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1829502976,
+                "id": 1829502976,
+                "individual_id": 12,
                 "name": "Kayseri",
                 "translations": {
                     "japanese": "カイセリ県",
@@ -36291,8 +36291,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1829634048,
+                "id": 1829634048,
+                "individual_id": 14,
                 "name": "Şanlıurfa",
                 "translations": {
                     "japanese": "シャンルウルファ県",
@@ -36318,8 +36318,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1829699584,
+                "id": 1829699584,
+                "individual_id": 15,
                 "name": "Malatya",
                 "translations": {
                     "japanese": "マラティヤ県",
@@ -36345,8 +36345,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1829765120,
+                "id": 1829765120,
+                "individual_id": 16,
                 "name": "Erzurum",
                 "translations": {
                     "japanese": "エルズルム県",
@@ -36372,8 +36372,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 1829830656,
+                "id": 1829830656,
+                "individual_id": 17,
                 "name": "Samsun",
                 "translations": {
                     "japanese": "サムスン県",
@@ -36399,8 +36399,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 1829896192,
+                "id": 1829896192,
+                "individual_id": 18,
                 "name": "Van",
                 "translations": {
                     "japanese": "ワン県",
@@ -36426,8 +36426,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 1829961728,
+                "id": 1829961728,
+                "individual_id": 19,
                 "name": "Kahramanmaraş",
                 "translations": {
                     "japanese": "カフラマンマラシュ県",
@@ -36453,8 +36453,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 1830027264,
+                "id": 1830027264,
+                "individual_id": 20,
                 "name": "Denizli",
                 "translations": {
                     "japanese": "デニズリ県",
@@ -36480,8 +36480,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 1830092800,
+                "id": 1830092800,
+                "individual_id": 21,
                 "name": "Batman",
                 "translations": {
                     "japanese": "バトマン県",
@@ -36507,8 +36507,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 1830158336,
+                "id": 1830158336,
+                "individual_id": 22,
                 "name": "Elazığ",
                 "translations": {
                     "japanese": "エラズー県",
@@ -36534,8 +36534,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 1830223872,
+                "id": 1830223872,
+                "individual_id": 23,
                 "name": "Sakarya",
                 "translations": {
                     "japanese": "サカリヤ県",
@@ -36561,8 +36561,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 1830289408,
+                "id": 1830289408,
+                "individual_id": 24,
                 "name": "Kocaeli",
                 "translations": {
                     "japanese": "コジャエリ県",
@@ -36588,8 +36588,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 1830354944,
+                "id": 1830354944,
+                "individual_id": 25,
                 "name": "Sivas",
                 "translations": {
                     "japanese": "シワス県",
@@ -36615,8 +36615,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 1830420480,
+                "id": 1830420480,
+                "individual_id": 26,
                 "name": "Manisa",
                 "translations": {
                     "japanese": "マニサ県",
@@ -36642,8 +36642,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 1830486016,
+                "id": 1830486016,
+                "individual_id": 27,
                 "name": "Trabzon",
                 "translations": {
                     "japanese": "トラブゾン県",
@@ -36669,8 +36669,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 1830551552,
+                "id": 1830551552,
+                "individual_id": 28,
                 "name": "Balıkesir",
                 "translations": {
                     "japanese": "バルケシル県",
@@ -36696,8 +36696,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 1830617088,
+                "id": 1830617088,
+                "individual_id": 29,
                 "name": "Adıyaman",
                 "translations": {
                     "japanese": "アディヤマン県",
@@ -36723,8 +36723,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 1830682624,
+                "id": 1830682624,
+                "individual_id": 30,
                 "name": "Tekirdağ",
                 "translations": {
                     "japanese": "テキルダー県",
@@ -36750,8 +36750,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 1830748160,
+                "id": 1830748160,
+                "individual_id": 31,
                 "name": "Kırıkkale",
                 "translations": {
                     "japanese": "クルッカレ県",
@@ -36777,8 +36777,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 1830813696,
+                "id": 1830813696,
+                "individual_id": 32,
                 "name": "Osmaniye",
                 "translations": {
                     "japanese": "オスマニエ県",
@@ -36804,8 +36804,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 1830879232,
+                "id": 1830879232,
+                "individual_id": 33,
                 "name": "Kütahya",
                 "translations": {
                     "japanese": "キュターヤ県",
@@ -36831,8 +36831,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 1830944768,
+                "id": 1830944768,
+                "individual_id": 34,
                 "name": "Çorum",
                 "translations": {
                     "japanese": "チョルム県",
@@ -36858,8 +36858,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 1831010304,
+                "id": 1831010304,
+                "individual_id": 35,
                 "name": "Isparta",
                 "translations": {
                     "japanese": "イスパルタ県",
@@ -36885,8 +36885,8 @@
                 }
             },
             {
-                "id": 36,
-                "full_id": 1831075840,
+                "id": 1831075840,
+                "individual_id": 36,
                 "name": "Aydın",
                 "translations": {
                     "japanese": "アイドゥン県",
@@ -36912,8 +36912,8 @@
                 }
             },
             {
-                "id": 37,
-                "full_id": 1831141376,
+                "id": 1831141376,
+                "individual_id": 37,
                 "name": "Hatay",
                 "translations": {
                     "japanese": "ハタイ県",
@@ -36939,8 +36939,8 @@
                 }
             },
             {
-                "id": 38,
-                "full_id": 1831206912,
+                "id": 1831206912,
+                "individual_id": 38,
                 "name": "Mardin",
                 "translations": {
                     "japanese": "マルディン県",
@@ -36966,8 +36966,8 @@
                 }
             },
             {
-                "id": 39,
-                "full_id": 1831272448,
+                "id": 1831272448,
+                "individual_id": 39,
                 "name": "Aksaray",
                 "translations": {
                     "japanese": "アクサライ県",
@@ -36993,8 +36993,8 @@
                 }
             },
             {
-                "id": 40,
-                "full_id": 1831337984,
+                "id": 1831337984,
+                "individual_id": 40,
                 "name": "Afyonkarahisar",
                 "translations": {
                     "japanese": "アフィヨンカラヒサール県",
@@ -37020,8 +37020,8 @@
                 }
             },
             {
-                "id": 41,
-                "full_id": 1831403520,
+                "id": 1831403520,
+                "individual_id": 41,
                 "name": "Tokat",
                 "translations": {
                     "japanese": "トカト県",
@@ -37047,8 +37047,8 @@
                 }
             },
             {
-                "id": 42,
-                "full_id": 1831469056,
+                "id": 1831469056,
+                "individual_id": 42,
                 "name": "Edirne",
                 "translations": {
                     "japanese": "エディルネ県",
@@ -37074,8 +37074,8 @@
                 }
             },
             {
-                "id": 43,
-                "full_id": 1831534592,
+                "id": 1831534592,
+                "individual_id": 43,
                 "name": "Karaman",
                 "translations": {
                     "japanese": "カラマン県",
@@ -37101,8 +37101,8 @@
                 }
             },
             {
-                "id": 44,
-                "full_id": 1831600128,
+                "id": 1831600128,
+                "individual_id": 44,
                 "name": "Ordu",
                 "translations": {
                     "japanese": "オルドゥ県",
@@ -37128,8 +37128,8 @@
                 }
             },
             {
-                "id": 45,
-                "full_id": 1831665664,
+                "id": 1831665664,
+                "individual_id": 45,
                 "name": "Siirt",
                 "translations": {
                     "japanese": "シイルト県",
@@ -37155,8 +37155,8 @@
                 }
             },
             {
-                "id": 46,
-                "full_id": 1831731200,
+                "id": 1831731200,
+                "individual_id": 46,
                 "name": "Erzincan",
                 "translations": {
                     "japanese": "エルジンジャン県",
@@ -37182,8 +37182,8 @@
                 }
             },
             {
-                "id": 47,
-                "full_id": 1831796736,
+                "id": 1831796736,
+                "individual_id": 47,
                 "name": "Çankırı",
                 "translations": {
                     "japanese": "チャンクル県",
@@ -37209,8 +37209,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1831862272,
+                "id": 1831862272,
+                "individual_id": 48,
                 "name": "Zonguldak",
                 "translations": {
                     "japanese": "ゾングルダク県",
@@ -37236,8 +37236,8 @@
                 }
             },
             {
-                "id": 49,
-                "full_id": 1831927808,
+                "id": 1831927808,
+                "individual_id": 49,
                 "name": "Yozgat",
                 "translations": {
                     "japanese": "ヨズガト県",
@@ -37263,8 +37263,8 @@
                 }
             },
             {
-                "id": 50,
-                "full_id": 1831993344,
+                "id": 1831993344,
+                "individual_id": 50,
                 "name": "Uşak",
                 "translations": {
                     "japanese": "ウシャク県",
@@ -37290,8 +37290,8 @@
                 }
             },
             {
-                "id": 51,
-                "full_id": 1832058880,
+                "id": 1832058880,
+                "individual_id": 51,
                 "name": "Ağrı",
                 "translations": {
                     "japanese": "アール県",
@@ -37317,8 +37317,8 @@
                 }
             },
             {
-                "id": 52,
-                "full_id": 1832124416,
+                "id": 1832124416,
+                "individual_id": 52,
                 "name": "Amasya",
                 "translations": {
                     "japanese": "アマシヤ県",
@@ -37344,8 +37344,8 @@
                 }
             },
             {
-                "id": 53,
-                "full_id": 1832189952,
+                "id": 1832189952,
+                "individual_id": 53,
                 "name": "Ardahan",
                 "translations": {
                     "japanese": "アルダハン県",
@@ -37371,8 +37371,8 @@
                 }
             },
             {
-                "id": 54,
-                "full_id": 1832255488,
+                "id": 1832255488,
+                "individual_id": 54,
                 "name": "Artvin",
                 "translations": {
                     "japanese": "アルトウィン県",
@@ -37398,8 +37398,8 @@
                 }
             },
             {
-                "id": 55,
-                "full_id": 1832321024,
+                "id": 1832321024,
+                "individual_id": 55,
                 "name": "Bartın",
                 "translations": {
                     "japanese": "バルトゥン県",
@@ -37425,8 +37425,8 @@
                 }
             },
             {
-                "id": 56,
-                "full_id": 1832386560,
+                "id": 1832386560,
+                "individual_id": 56,
                 "name": "Bayburt",
                 "translations": {
                     "japanese": "バイブルト県",
@@ -37452,8 +37452,8 @@
                 }
             },
             {
-                "id": 57,
-                "full_id": 1832452096,
+                "id": 1832452096,
+                "individual_id": 57,
                 "name": "Bilecik",
                 "translations": {
                     "japanese": "ビレジク県",
@@ -37479,8 +37479,8 @@
                 }
             },
             {
-                "id": 58,
-                "full_id": 1832517632,
+                "id": 1832517632,
+                "individual_id": 58,
                 "name": "Bingöl",
                 "translations": {
                     "japanese": "ビンギョル県",
@@ -37506,8 +37506,8 @@
                 }
             },
             {
-                "id": 59,
-                "full_id": 1832583168,
+                "id": 1832583168,
+                "individual_id": 59,
                 "name": "Bitlis",
                 "translations": {
                     "japanese": "ビトリス県",
@@ -37533,8 +37533,8 @@
                 }
             },
             {
-                "id": 60,
-                "full_id": 1832648704,
+                "id": 1832648704,
+                "individual_id": 60,
                 "name": "Bolu",
                 "translations": {
                     "japanese": "ボル県",
@@ -37560,8 +37560,8 @@
                 }
             },
             {
-                "id": 61,
-                "full_id": 1832714240,
+                "id": 1832714240,
+                "individual_id": 61,
                 "name": "Burdur",
                 "translations": {
                     "japanese": "ブルドゥル県",
@@ -37587,8 +37587,8 @@
                 }
             },
             {
-                "id": 62,
-                "full_id": 1832779776,
+                "id": 1832779776,
+                "individual_id": 62,
                 "name": "Çanakkale",
                 "translations": {
                     "japanese": "チャナッカレ県",
@@ -37614,8 +37614,8 @@
                 }
             },
             {
-                "id": 63,
-                "full_id": 1832845312,
+                "id": 1832845312,
+                "individual_id": 63,
                 "name": "Düzce",
                 "translations": {
                     "japanese": "デュズジェ県",
@@ -37641,8 +37641,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 1832910848,
+                "id": 1832910848,
+                "individual_id": 64,
                 "name": "Eskişehir",
                 "translations": {
                     "japanese": "エスキシェヒル県",
@@ -37668,8 +37668,8 @@
                 }
             },
             {
-                "id": 65,
-                "full_id": 1832976384,
+                "id": 1832976384,
+                "individual_id": 65,
                 "name": "Giresun",
                 "translations": {
                     "japanese": "ギレスン県",
@@ -37695,8 +37695,8 @@
                 }
             },
             {
-                "id": 66,
-                "full_id": 1833041920,
+                "id": 1833041920,
+                "individual_id": 66,
                 "name": "Gümüşhane",
                 "translations": {
                     "japanese": "ギュミュシュハーネ県",
@@ -37722,8 +37722,8 @@
                 }
             },
             {
-                "id": 67,
-                "full_id": 1833107456,
+                "id": 1833107456,
+                "individual_id": 67,
                 "name": "Hakkari",
                 "translations": {
                     "japanese": "ハッキャリ県",
@@ -37749,8 +37749,8 @@
                 }
             },
             {
-                "id": 68,
-                "full_id": 1833172992,
+                "id": 1833172992,
+                "individual_id": 68,
                 "name": "Iğdır",
                 "translations": {
                     "japanese": "ウードゥル県",
@@ -37776,8 +37776,8 @@
                 }
             },
             {
-                "id": 69,
-                "full_id": 1833238528,
+                "id": 1833238528,
+                "individual_id": 69,
                 "name": "Karabük",
                 "translations": {
                     "japanese": "カラビュック県",
@@ -37803,8 +37803,8 @@
                 }
             },
             {
-                "id": 70,
-                "full_id": 1833304064,
+                "id": 1833304064,
+                "individual_id": 70,
                 "name": "Kars",
                 "translations": {
                     "japanese": "カルス県",
@@ -37830,8 +37830,8 @@
                 }
             },
             {
-                "id": 71,
-                "full_id": 1833369600,
+                "id": 1833369600,
+                "individual_id": 71,
                 "name": "Kastamonu",
                 "translations": {
                     "japanese": "カスタモヌ県",
@@ -37857,8 +37857,8 @@
                 }
             },
             {
-                "id": 72,
-                "full_id": 1833435136,
+                "id": 1833435136,
+                "individual_id": 72,
                 "name": "Kilis",
                 "translations": {
                     "japanese": "キリス県",
@@ -37884,8 +37884,8 @@
                 }
             },
             {
-                "id": 73,
-                "full_id": 1833500672,
+                "id": 1833500672,
+                "individual_id": 73,
                 "name": "Kırklareli",
                 "translations": {
                     "japanese": "クルクラーレリ県",
@@ -37911,8 +37911,8 @@
                 }
             },
             {
-                "id": 74,
-                "full_id": 1833566208,
+                "id": 1833566208,
+                "individual_id": 74,
                 "name": "Kırşehir",
                 "translations": {
                     "japanese": "クルシェヒル県",
@@ -37938,8 +37938,8 @@
                 }
             },
             {
-                "id": 75,
-                "full_id": 1833631744,
+                "id": 1833631744,
+                "individual_id": 75,
                 "name": "Muğla",
                 "translations": {
                     "japanese": "ムーラ県",
@@ -37965,8 +37965,8 @@
                 }
             },
             {
-                "id": 76,
-                "full_id": 1833697280,
+                "id": 1833697280,
+                "individual_id": 76,
                 "name": "Muş",
                 "translations": {
                     "japanese": "ムシュ県",
@@ -37992,8 +37992,8 @@
                 }
             },
             {
-                "id": 77,
-                "full_id": 1833762816,
+                "id": 1833762816,
+                "individual_id": 77,
                 "name": "Nevşehir",
                 "translations": {
                     "japanese": "ネヴシェヒル県",
@@ -38019,8 +38019,8 @@
                 }
             },
             {
-                "id": 78,
-                "full_id": 1833828352,
+                "id": 1833828352,
+                "individual_id": 78,
                 "name": "Niğde",
                 "translations": {
                     "japanese": "ニーデ県",
@@ -38046,8 +38046,8 @@
                 }
             },
             {
-                "id": 79,
-                "full_id": 1833893888,
+                "id": 1833893888,
+                "individual_id": 79,
                 "name": "Rize",
                 "translations": {
                     "japanese": "リゼ県",
@@ -38073,8 +38073,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1833959424,
+                "id": 1833959424,
+                "individual_id": 80,
                 "name": "Sinop",
                 "translations": {
                     "japanese": "シノプ県",
@@ -38100,8 +38100,8 @@
                 }
             },
             {
-                "id": 81,
-                "full_id": 1834024960,
+                "id": 1834024960,
+                "individual_id": 81,
                 "name": "Şırnak",
                 "translations": {
                     "japanese": "シュルナク県",
@@ -38127,8 +38127,8 @@
                 }
             },
             {
-                "id": 82,
-                "full_id": 1834090496,
+                "id": 1834090496,
+                "individual_id": 82,
                 "name": "Tunceli",
                 "translations": {
                     "japanese": "トゥンジェリ県",
@@ -38154,8 +38154,8 @@
                 }
             },
             {
-                "id": 83,
-                "full_id": 1834156032,
+                "id": 1834156032,
+                "individual_id": 83,
                 "name": "Yalova",
                 "translations": {
                     "japanese": "ヤロワ県",
@@ -38206,8 +38206,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1845493760,
+                "id": 1845493760,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38233,8 +38233,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 1845690368,
+                "id": 1845690368,
+                "individual_id": 3,
                 "name": "London",
                 "translations": {
                     "japanese": "ロンドン",
@@ -38260,8 +38260,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 1845821440,
+                "id": 1845821440,
+                "individual_id": 5,
                 "name": "Scotland",
                 "translations": {
                     "japanese": "スコットランド",
@@ -38287,8 +38287,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 1845886976,
+                "id": 1845886976,
+                "individual_id": 6,
                 "name": "Wales",
                 "translations": {
                     "japanese": "ウェールズ",
@@ -38314,8 +38314,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 1845952512,
+                "id": 1845952512,
+                "individual_id": 7,
                 "name": "Northern Ireland",
                 "translations": {
                     "japanese": "北アイルランド",
@@ -38341,8 +38341,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 1846018048,
+                "id": 1846018048,
+                "individual_id": 8,
                 "name": "South West",
                 "translations": {
                     "japanese": "南西部地方",
@@ -38368,8 +38368,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 1846083584,
+                "id": 1846083584,
+                "individual_id": 9,
                 "name": "West Midlands",
                 "translations": {
                     "japanese": "ウェスト・ミッドランド地方",
@@ -38395,8 +38395,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 1846149120,
+                "id": 1846149120,
+                "individual_id": 10,
                 "name": "North West",
                 "translations": {
                     "japanese": "北西部地方",
@@ -38422,8 +38422,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 1846214656,
+                "id": 1846214656,
+                "individual_id": 11,
                 "name": "North East",
                 "translations": {
                     "japanese": "北東部地方",
@@ -38449,8 +38449,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 1846280192,
+                "id": 1846280192,
+                "individual_id": 12,
                 "name": "Yorkshire and the Humber",
                 "translations": {
                     "japanese": "ヨークシャー・アンド・ザ・ハンバー地方",
@@ -38476,8 +38476,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 1846345728,
+                "id": 1846345728,
+                "individual_id": 13,
                 "name": "East Midlands",
                 "translations": {
                     "japanese": "イースト・ミッドランド地方",
@@ -38503,8 +38503,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 1846411264,
+                "id": 1846411264,
+                "individual_id": 14,
                 "name": "East of England",
                 "translations": {
                     "japanese": "イングランド東部地方",
@@ -38530,8 +38530,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 1846476800,
+                "id": 1846476800,
+                "individual_id": 15,
                 "name": "South East",
                 "translations": {
                     "japanese": "南東部地方",
@@ -38582,8 +38582,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1862270976,
+                "id": 1862270976,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38609,8 +38609,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1862336512,
+                "id": 1862336512,
+                "individual_id": 1,
                 "name": "Zambia",
                 "translations": {
                     "japanese": "ザンビア",
@@ -38661,8 +38661,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1879048192,
+                "id": 1879048192,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38688,8 +38688,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1879113728,
+                "id": 1879113728,
+                "individual_id": 1,
                 "name": "Zimbabwe",
                 "translations": {
                     "japanese": "ジンバブエ",
@@ -38740,8 +38740,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1895825408,
+                "id": 1895825408,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38767,8 +38767,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1895890944,
+                "id": 1895890944,
+                "individual_id": 1,
                 "name": "Azerbaijan",
                 "translations": {
                     "japanese": "アゼルバイジャン",
@@ -38819,8 +38819,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1912602624,
+                "id": 1912602624,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38846,8 +38846,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1912668160,
+                "id": 1912668160,
+                "individual_id": 1,
                 "name": "Mauritania",
                 "translations": {
                     "japanese": "モーリタニア",
@@ -38898,8 +38898,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1929379840,
+                "id": 1929379840,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38925,8 +38925,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1929445376,
+                "id": 1929445376,
+                "individual_id": 1,
                 "name": "Mali",
                 "translations": {
                     "japanese": "マリ",
@@ -38977,8 +38977,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1946157056,
+                "id": 1946157056,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39004,8 +39004,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1946222592,
+                "id": 1946222592,
+                "individual_id": 1,
                 "name": "Niger",
                 "translations": {
                     "japanese": "ニジェール",
@@ -39056,8 +39056,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1962934272,
+                "id": 1962934272,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39083,8 +39083,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1962999808,
+                "id": 1962999808,
+                "individual_id": 1,
                 "name": "Chad",
                 "translations": {
                     "japanese": "チャド",
@@ -39135,8 +39135,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1979711488,
+                "id": 1979711488,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39162,8 +39162,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1979777024,
+                "id": 1979777024,
+                "individual_id": 1,
                 "name": "Sudan",
                 "translations": {
                     "japanese": "スーダン",
@@ -39214,8 +39214,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 1996488704,
+                "id": 1996488704,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39241,8 +39241,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 1996554240,
+                "id": 1996554240,
+                "individual_id": 1,
                 "name": "Eritrea",
                 "translations": {
                     "japanese": "エリトリア",
@@ -39293,8 +39293,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2013265920,
+                "id": 2013265920,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39320,8 +39320,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2013331456,
+                "id": 2013331456,
+                "individual_id": 1,
                 "name": "Djibouti",
                 "translations": {
                     "japanese": "ジブチ",
@@ -39372,8 +39372,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2030043136,
+                "id": 2030043136,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39399,8 +39399,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2030108672,
+                "id": 2030108672,
+                "individual_id": 1,
                 "name": "Somalia",
                 "translations": {
                     "japanese": "ソマリア",
@@ -39451,8 +39451,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2046820352,
+                "id": 2046820352,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39478,8 +39478,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2046885888,
+                "id": 2046885888,
+                "individual_id": 1,
                 "name": "Andorra",
                 "translations": {
                     "japanese": "アンドラ",
@@ -39530,8 +39530,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2063597568,
+                "id": 2063597568,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39557,8 +39557,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2063663104,
+                "id": 2063663104,
+                "individual_id": 1,
                 "name": "Gibraltar",
                 "translations": {
                     "japanese": "ジブラルタル",
@@ -39609,8 +39609,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2080374784,
+                "id": 2080374784,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39636,8 +39636,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2080440320,
+                "id": 2080440320,
+                "individual_id": 1,
                 "name": "Guernsey",
                 "translations": {
                     "japanese": "ガーンジー島",
@@ -39688,8 +39688,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2097152000,
+                "id": 2097152000,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39715,8 +39715,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2097217536,
+                "id": 2097217536,
+                "individual_id": 1,
                 "name": "Isle of Man",
                 "translations": {
                     "japanese": "マン島",
@@ -39767,8 +39767,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2113929216,
+                "id": 2113929216,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39794,8 +39794,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2113994752,
+                "id": 2113994752,
+                "individual_id": 1,
                 "name": "Jersey",
                 "translations": {
                     "japanese": "ジャージー島",
@@ -39846,8 +39846,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2130706432,
+                "id": 2130706432,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39873,8 +39873,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2130771968,
+                "id": 2130771968,
+                "individual_id": 1,
                 "name": "Monaco",
                 "translations": {
                     "japanese": "モナコ",
@@ -39925,8 +39925,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2147483648,
+                "id": 2147483648,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39952,8 +39952,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2147614720,
+                "id": 2147614720,
+                "individual_id": 2,
                 "name": "Taipei City",
                 "translations": {
                     "japanese": "台北市",
@@ -39979,8 +39979,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2147680256,
+                "id": 2147680256,
+                "individual_id": 3,
                 "name": "Kaohsiung City",
                 "translations": {
                     "japanese": "高雄市",
@@ -40006,8 +40006,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2147745792,
+                "id": 2147745792,
+                "individual_id": 4,
                 "name": "Keelung City",
                 "translations": {
                     "japanese": "基隆市",
@@ -40033,8 +40033,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2147811328,
+                "id": 2147811328,
+                "individual_id": 5,
                 "name": "Hsinchu City",
                 "translations": {
                     "japanese": "新竹市",
@@ -40060,8 +40060,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2147876864,
+                "id": 2147876864,
+                "individual_id": 6,
                 "name": "Taichung City",
                 "translations": {
                     "japanese": "台中市",
@@ -40087,8 +40087,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2147942400,
+                "id": 2147942400,
+                "individual_id": 7,
                 "name": "Chiayi City",
                 "translations": {
                     "japanese": "嘉義市",
@@ -40114,8 +40114,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2148007936,
+                "id": 2148007936,
+                "individual_id": 8,
                 "name": "Tainan City",
                 "translations": {
                     "japanese": "台南市",
@@ -40141,8 +40141,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 2148073472,
+                "id": 2148073472,
+                "individual_id": 9,
                 "name": "New Taipei City",
                 "translations": {
                     "japanese": "新北市",
@@ -40168,8 +40168,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 2148139008,
+                "id": 2148139008,
+                "individual_id": 10,
                 "name": "Taoyuan City",
                 "translations": {
                     "japanese": "桃園市",
@@ -40195,8 +40195,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 2148204544,
+                "id": 2148204544,
+                "individual_id": 11,
                 "name": "HsinChu County",
                 "translations": {
                     "japanese": "新竹県",
@@ -40222,8 +40222,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 2148270080,
+                "id": 2148270080,
+                "individual_id": 12,
                 "name": "Miaoli County",
                 "translations": {
                     "japanese": "苗栗県",
@@ -40249,8 +40249,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 2148335616,
+                "id": 2148335616,
+                "individual_id": 13,
                 "name": "Taichung County",
                 "translations": {
                     "japanese": "台中県",
@@ -40276,8 +40276,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 2148401152,
+                "id": 2148401152,
+                "individual_id": 14,
                 "name": "Changhua County",
                 "translations": {
                     "japanese": "彰化県",
@@ -40303,8 +40303,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 2148466688,
+                "id": 2148466688,
+                "individual_id": 15,
                 "name": "Nantou County",
                 "translations": {
                     "japanese": "南投県",
@@ -40330,8 +40330,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2148532224,
+                "id": 2148532224,
+                "individual_id": 16,
                 "name": "Yunlin County",
                 "translations": {
                     "japanese": "雲林県",
@@ -40357,8 +40357,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 2148597760,
+                "id": 2148597760,
+                "individual_id": 17,
                 "name": "Chiayi County",
                 "translations": {
                     "japanese": "嘉義県",
@@ -40384,8 +40384,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 2148663296,
+                "id": 2148663296,
+                "individual_id": 18,
                 "name": "Tainan County",
                 "translations": {
                     "japanese": "台南県",
@@ -40411,8 +40411,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 2148728832,
+                "id": 2148728832,
+                "individual_id": 19,
                 "name": "Kaohsiung County",
                 "translations": {
                     "japanese": "高雄県",
@@ -40438,8 +40438,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 2148794368,
+                "id": 2148794368,
+                "individual_id": 20,
                 "name": "Pingtung County",
                 "translations": {
                     "japanese": "屏東県",
@@ -40465,8 +40465,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 2148859904,
+                "id": 2148859904,
+                "individual_id": 21,
                 "name": "Yilan County",
                 "translations": {
                     "japanese": "宜蘭県",
@@ -40492,8 +40492,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 2148925440,
+                "id": 2148925440,
+                "individual_id": 22,
                 "name": "Hualien County",
                 "translations": {
                     "japanese": "花蓮県",
@@ -40519,8 +40519,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 2148990976,
+                "id": 2148990976,
+                "individual_id": 23,
                 "name": "Taitung County",
                 "translations": {
                     "japanese": "台東県",
@@ -40546,8 +40546,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 2149056512,
+                "id": 2149056512,
+                "individual_id": 24,
                 "name": "Penghu County",
                 "translations": {
                     "japanese": "澎湖県",
@@ -40573,8 +40573,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 2149122048,
+                "id": 2149122048,
+                "individual_id": 25,
                 "name": "Kinmen County",
                 "translations": {
                     "japanese": "金門県",
@@ -40600,8 +40600,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 2149187584,
+                "id": 2149187584,
+                "individual_id": 26,
                 "name": "Lienchiang County",
                 "translations": {
                     "japanese": "連江県",
@@ -40652,8 +40652,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2281701376,
+                "id": 2281701376,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -40679,8 +40679,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2281832448,
+                "id": 2281832448,
+                "individual_id": 2,
                 "name": "Seoul-teukbyeolsi",
                 "translations": {
                     "japanese": "ソウル特別市",
@@ -40706,8 +40706,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2281897984,
+                "id": 2281897984,
+                "individual_id": 3,
                 "name": "Busan-gwangyeoksi",
                 "translations": {
                     "japanese": "プサン広域市",
@@ -40733,8 +40733,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2281963520,
+                "id": 2281963520,
+                "individual_id": 4,
                 "name": "Daegu-gwangyeoksi",
                 "translations": {
                     "japanese": "テグ広域市",
@@ -40760,8 +40760,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2282029056,
+                "id": 2282029056,
+                "individual_id": 5,
                 "name": "Incheon-gwangyeoksi",
                 "translations": {
                     "japanese": "インチョン広域市",
@@ -40787,8 +40787,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2282094592,
+                "id": 2282094592,
+                "individual_id": 6,
                 "name": "Gwangju-gwangyeoksi",
                 "translations": {
                     "japanese": "クァンジュ広域市",
@@ -40814,8 +40814,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2282160128,
+                "id": 2282160128,
+                "individual_id": 7,
                 "name": "Daejeon-gwangyeoksi",
                 "translations": {
                     "japanese": "テジョン広域市",
@@ -40841,8 +40841,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2282225664,
+                "id": 2282225664,
+                "individual_id": 8,
                 "name": "Ulsan-gwangyeoksi",
                 "translations": {
                     "japanese": "ウルサン広域市",
@@ -40868,8 +40868,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 2282291200,
+                "id": 2282291200,
+                "individual_id": 9,
                 "name": "Gyeonggi-do",
                 "translations": {
                     "japanese": "キョンギ道",
@@ -40895,8 +40895,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 2282356736,
+                "id": 2282356736,
+                "individual_id": 10,
                 "name": "Gangwon-do",
                 "translations": {
                     "japanese": "カンウォン道",
@@ -40922,8 +40922,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 2282422272,
+                "id": 2282422272,
+                "individual_id": 11,
                 "name": "Chungcheongbuk-do",
                 "translations": {
                     "japanese": "チュンチョンブク道",
@@ -40949,8 +40949,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 2282487808,
+                "id": 2282487808,
+                "individual_id": 12,
                 "name": "Chungcheongnam-do",
                 "translations": {
                     "japanese": "チュンチョンナム道",
@@ -40976,8 +40976,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 2282553344,
+                "id": 2282553344,
+                "individual_id": 13,
                 "name": "Jeollabuk-do",
                 "translations": {
                     "japanese": "チョルラブク道",
@@ -41003,8 +41003,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 2282618880,
+                "id": 2282618880,
+                "individual_id": 14,
                 "name": "Jeollanam-do",
                 "translations": {
                     "japanese": "チョルラナム道",
@@ -41030,8 +41030,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 2282684416,
+                "id": 2282684416,
+                "individual_id": 15,
                 "name": "Gyeongsangbuk-do",
                 "translations": {
                     "japanese": "キョンサンブク道",
@@ -41057,8 +41057,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2282749952,
+                "id": 2282749952,
+                "individual_id": 16,
                 "name": "Gyeongsangnam-do",
                 "translations": {
                     "japanese": "キョンサンナム道",
@@ -41084,8 +41084,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 2282815488,
+                "id": 2282815488,
+                "individual_id": 17,
                 "name": "Jeju-teukbyeoljachido",
                 "translations": {
                     "japanese": "チェジュ特別自治道",
@@ -41136,8 +41136,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2415919104,
+                "id": 2415919104,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41163,8 +41163,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2415984640,
+                "id": 2415984640,
+                "individual_id": 1,
                 "name": "Hong Kong",
                 "translations": {
                     "japanese": "ホンコン",
@@ -41215,8 +41215,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2432696320,
+                "id": 2432696320,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41242,8 +41242,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2432761856,
+                "id": 2432761856,
+                "individual_id": 1,
                 "name": "Macao",
                 "translations": {
                     "japanese": "マカオ",
@@ -41294,8 +41294,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2566914048,
+                "id": 2566914048,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41321,8 +41321,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2566979584,
+                "id": 2566979584,
+                "individual_id": 1,
                 "name": "Singapore",
                 "translations": {
                     "japanese": "シンガポール",
@@ -41373,8 +41373,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2617245696,
+                "id": 2617245696,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41400,8 +41400,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2617376768,
+                "id": 2617376768,
+                "individual_id": 2,
                 "name": "Kuala Lumpur",
                 "translations": {
                     "japanese": "クアラ・ルンプール",
@@ -41427,8 +41427,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2617442304,
+                "id": 2617442304,
+                "individual_id": 3,
                 "name": "Johor",
                 "translations": {
                     "japanese": "ジョホール州",
@@ -41454,8 +41454,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2617507840,
+                "id": 2617507840,
+                "individual_id": 4,
                 "name": "Kedah",
                 "translations": {
                     "japanese": "ケダ州",
@@ -41481,8 +41481,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2617573376,
+                "id": 2617573376,
+                "individual_id": 5,
                 "name": "Kelantan",
                 "translations": {
                     "japanese": "ケランタン州",
@@ -41508,8 +41508,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2617638912,
+                "id": 2617638912,
+                "individual_id": 6,
                 "name": "Melaka",
                 "translations": {
                     "japanese": "マラッカ州",
@@ -41535,8 +41535,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2617704448,
+                "id": 2617704448,
+                "individual_id": 7,
                 "name": "Negeri Sembilan",
                 "translations": {
                     "japanese": "ヌグリ・センビラン州",
@@ -41562,8 +41562,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2617769984,
+                "id": 2617769984,
+                "individual_id": 8,
                 "name": "Pahang",
                 "translations": {
                     "japanese": "パハン州",
@@ -41589,8 +41589,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 2617835520,
+                "id": 2617835520,
+                "individual_id": 9,
                 "name": "Perak",
                 "translations": {
                     "japanese": "ペラ州",
@@ -41616,8 +41616,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 2617901056,
+                "id": 2617901056,
+                "individual_id": 10,
                 "name": "Perlis",
                 "translations": {
                     "japanese": "ペルリス州",
@@ -41643,8 +41643,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 2617966592,
+                "id": 2617966592,
+                "individual_id": 11,
                 "name": "Penang",
                 "translations": {
                     "japanese": "ピナン州",
@@ -41670,8 +41670,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 2618032128,
+                "id": 2618032128,
+                "individual_id": 12,
                 "name": "Sarawak",
                 "translations": {
                     "japanese": "サラワク州",
@@ -41697,8 +41697,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 2618097664,
+                "id": 2618097664,
+                "individual_id": 13,
                 "name": "Selangor",
                 "translations": {
                     "japanese": "セランゴール州",
@@ -41724,8 +41724,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 2618163200,
+                "id": 2618163200,
+                "individual_id": 14,
                 "name": "Terengganu",
                 "translations": {
                     "japanese": "トレンガヌ州",
@@ -41751,8 +41751,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 2618228736,
+                "id": 2618228736,
+                "individual_id": 15,
                 "name": "Labuan",
                 "translations": {
                     "japanese": "ラブアン",
@@ -41778,8 +41778,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2618294272,
+                "id": 2618294272,
+                "individual_id": 16,
                 "name": "Sabah",
                 "translations": {
                     "japanese": "サバ州",
@@ -41805,8 +41805,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 2618359808,
+                "id": 2618359808,
+                "individual_id": 17,
                 "name": "Putrajaya",
                 "translations": {
                     "japanese": "プトラジャヤ",
@@ -41857,8 +41857,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2684354560,
+                "id": 2684354560,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41884,8 +41884,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2684485632,
+                "id": 2684485632,
+                "individual_id": 2,
                 "name": "Beijing",
                 "translations": {
                     "japanese": "北京市",
@@ -41911,8 +41911,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2684551168,
+                "id": 2684551168,
+                "individual_id": 3,
                 "name": "Chongqing",
                 "translations": {
                     "japanese": "重慶市",
@@ -41938,8 +41938,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2684616704,
+                "id": 2684616704,
+                "individual_id": 4,
                 "name": "Shanghai",
                 "translations": {
                     "japanese": "上海市",
@@ -41965,8 +41965,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2684682240,
+                "id": 2684682240,
+                "individual_id": 5,
                 "name": "Tianjin",
                 "translations": {
                     "japanese": "天津市",
@@ -41992,8 +41992,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2684747776,
+                "id": 2684747776,
+                "individual_id": 6,
                 "name": "Anhui",
                 "translations": {
                     "japanese": "安徽省",
@@ -42019,8 +42019,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2684813312,
+                "id": 2684813312,
+                "individual_id": 7,
                 "name": "Fujian",
                 "translations": {
                     "japanese": "福建省",
@@ -42046,8 +42046,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2684878848,
+                "id": 2684878848,
+                "individual_id": 8,
                 "name": "Gansu",
                 "translations": {
                     "japanese": "甘粛省",
@@ -42073,8 +42073,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 2684944384,
+                "id": 2684944384,
+                "individual_id": 9,
                 "name": "Guangdong",
                 "translations": {
                     "japanese": "広東省",
@@ -42100,8 +42100,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 2685009920,
+                "id": 2685009920,
+                "individual_id": 10,
                 "name": "Guizhou",
                 "translations": {
                     "japanese": "貴州省",
@@ -42127,8 +42127,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 2685075456,
+                "id": 2685075456,
+                "individual_id": 11,
                 "name": "Hainan",
                 "translations": {
                     "japanese": "海南省",
@@ -42154,8 +42154,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 2685140992,
+                "id": 2685140992,
+                "individual_id": 12,
                 "name": "Hebei",
                 "translations": {
                     "japanese": "河北省",
@@ -42181,8 +42181,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 2685206528,
+                "id": 2685206528,
+                "individual_id": 13,
                 "name": "Heilongjiang",
                 "translations": {
                     "japanese": "黒龍江省",
@@ -42208,8 +42208,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 2685272064,
+                "id": 2685272064,
+                "individual_id": 14,
                 "name": "Henan",
                 "translations": {
                     "japanese": "河南省",
@@ -42235,8 +42235,8 @@
                 }
             },
             {
-                "id": 15,
-                "full_id": 2685337600,
+                "id": 2685337600,
+                "individual_id": 15,
                 "name": "Hubei",
                 "translations": {
                     "japanese": "湖北省",
@@ -42262,8 +42262,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 2685403136,
+                "id": 2685403136,
+                "individual_id": 16,
                 "name": "Húnán",
                 "translations": {
                     "japanese": "湖南省",
@@ -42289,8 +42289,8 @@
                 }
             },
             {
-                "id": 17,
-                "full_id": 2685468672,
+                "id": 2685468672,
+                "individual_id": 17,
                 "name": "Jiangsu",
                 "translations": {
                     "japanese": "江蘇省",
@@ -42316,8 +42316,8 @@
                 }
             },
             {
-                "id": 18,
-                "full_id": 2685534208,
+                "id": 2685534208,
+                "individual_id": 18,
                 "name": "Jiangxi",
                 "translations": {
                     "japanese": "江西省",
@@ -42343,8 +42343,8 @@
                 }
             },
             {
-                "id": 19,
-                "full_id": 2685599744,
+                "id": 2685599744,
+                "individual_id": 19,
                 "name": "Jilin",
                 "translations": {
                     "japanese": "吉林省",
@@ -42370,8 +42370,8 @@
                 }
             },
             {
-                "id": 20,
-                "full_id": 2685665280,
+                "id": 2685665280,
+                "individual_id": 20,
                 "name": "Liaoning",
                 "translations": {
                     "japanese": "遼寧省",
@@ -42397,8 +42397,8 @@
                 }
             },
             {
-                "id": 21,
-                "full_id": 2685730816,
+                "id": 2685730816,
+                "individual_id": 21,
                 "name": "Qinghai",
                 "translations": {
                     "japanese": "青海省",
@@ -42424,8 +42424,8 @@
                 }
             },
             {
-                "id": 22,
-                "full_id": 2685796352,
+                "id": 2685796352,
+                "individual_id": 22,
                 "name": "Shanxi",
                 "translations": {
                     "japanese": "陝西省",
@@ -42451,8 +42451,8 @@
                 }
             },
             {
-                "id": 23,
-                "full_id": 2685861888,
+                "id": 2685861888,
+                "individual_id": 23,
                 "name": "Shandong",
                 "translations": {
                     "japanese": "山東省",
@@ -42478,8 +42478,8 @@
                 }
             },
             {
-                "id": 24,
-                "full_id": 2685927424,
+                "id": 2685927424,
+                "individual_id": 24,
                 "name": "Shanxi",
                 "translations": {
                     "japanese": "山西省",
@@ -42505,8 +42505,8 @@
                 }
             },
             {
-                "id": 25,
-                "full_id": 2685992960,
+                "id": 2685992960,
+                "individual_id": 25,
                 "name": "Sichuan",
                 "translations": {
                     "japanese": "四川省",
@@ -42532,8 +42532,8 @@
                 }
             },
             {
-                "id": 26,
-                "full_id": 2686058496,
+                "id": 2686058496,
+                "individual_id": 26,
                 "name": "Yunnan",
                 "translations": {
                     "japanese": "雲南省",
@@ -42559,8 +42559,8 @@
                 }
             },
             {
-                "id": 27,
-                "full_id": 2686124032,
+                "id": 2686124032,
+                "individual_id": 27,
                 "name": "Zhejiang",
                 "translations": {
                     "japanese": "浙江省",
@@ -42586,8 +42586,8 @@
                 }
             },
             {
-                "id": 28,
-                "full_id": 2686189568,
+                "id": 2686189568,
+                "individual_id": 28,
                 "name": "Taiwan",
                 "translations": {
                     "japanese": "台湾省",
@@ -42613,8 +42613,8 @@
                 }
             },
             {
-                "id": 29,
-                "full_id": 2686255104,
+                "id": 2686255104,
+                "individual_id": 29,
                 "name": "Guangxi-Zhuangzu",
                 "translations": {
                     "japanese": "広西チワン族自治区",
@@ -42640,8 +42640,8 @@
                 }
             },
             {
-                "id": 30,
-                "full_id": 2686320640,
+                "id": 2686320640,
+                "individual_id": 30,
                 "name": "Nei-Menggu",
                 "translations": {
                     "japanese": "内モンゴル自治区",
@@ -42667,8 +42667,8 @@
                 }
             },
             {
-                "id": 31,
-                "full_id": 2686386176,
+                "id": 2686386176,
+                "individual_id": 31,
                 "name": "Ningxia-huizu",
                 "translations": {
                     "japanese": "寧夏回族自治区",
@@ -42694,8 +42694,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2686451712,
+                "id": 2686451712,
+                "individual_id": 32,
                 "name": "Xinjiang-Weiwu'er-zu",
                 "translations": {
                     "japanese": "新疆ウイグル自治区",
@@ -42721,8 +42721,8 @@
                 }
             },
             {
-                "id": 33,
-                "full_id": 2686517248,
+                "id": 2686517248,
+                "individual_id": 33,
                 "name": "Xizang",
                 "translations": {
                     "japanese": "チベット自治区",
@@ -42748,8 +42748,8 @@
                 }
             },
             {
-                "id": 34,
-                "full_id": 2686582784,
+                "id": 2686582784,
+                "individual_id": 34,
                 "name": "Macao",
                 "translations": {
                     "japanese": "マカオ",
@@ -42775,8 +42775,8 @@
                 }
             },
             {
-                "id": 35,
-                "full_id": 2686648320,
+                "id": 2686648320,
+                "individual_id": 35,
                 "name": "Hong Kong",
                 "translations": {
                     "japanese": "ホンコン",
@@ -42827,8 +42827,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2818572288,
+                "id": 2818572288,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -42854,8 +42854,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2818703360,
+                "id": 2818703360,
+                "individual_id": 2,
                 "name": "Abu Dhabi",
                 "translations": {
                     "japanese": "アブダビ",
@@ -42881,8 +42881,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2818768896,
+                "id": 2818768896,
+                "individual_id": 3,
                 "name": "Ajman",
                 "translations": {
                     "japanese": "アジュマン",
@@ -42908,8 +42908,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2818834432,
+                "id": 2818834432,
+                "individual_id": 4,
                 "name": "Ash Shariqah",
                 "translations": {
                     "japanese": "シャルジャ",
@@ -42935,8 +42935,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2818899968,
+                "id": 2818899968,
+                "individual_id": 5,
                 "name": "Ras al-Khaimah",
                 "translations": {
                     "japanese": "ラアス・アル・カイマー",
@@ -42962,8 +42962,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2818965504,
+                "id": 2818965504,
+                "individual_id": 6,
                 "name": "Dubai",
                 "translations": {
                     "japanese": "ドゥバイ",
@@ -42989,8 +42989,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2819031040,
+                "id": 2819031040,
+                "individual_id": 7,
                 "name": "Al Fujayrah",
                 "translations": {
                     "japanese": "フジャイラー",
@@ -43016,8 +43016,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2819096576,
+                "id": 2819096576,
+                "individual_id": 8,
                 "name": "Umm al Qaywayn",
                 "translations": {
                     "japanese": "ウム・アル・カイワイン",
@@ -43068,8 +43068,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 2919235584,
+                "id": 2919235584,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -43095,8 +43095,8 @@
                 }
             },
             {
-                "id": 2,
-                "full_id": 2919366656,
+                "id": 2919366656,
+                "individual_id": 2,
                 "name": "Ar Riyad",
                 "translations": {
                     "japanese": "リヤド州",
@@ -43122,8 +43122,8 @@
                 }
             },
             {
-                "id": 3,
-                "full_id": 2919432192,
+                "id": 2919432192,
+                "individual_id": 3,
                 "name": "Al Bahah",
                 "translations": {
                     "japanese": "バーハ州",
@@ -43149,8 +43149,8 @@
                 }
             },
             {
-                "id": 4,
-                "full_id": 2919497728,
+                "id": 2919497728,
+                "individual_id": 4,
                 "name": "Al Madinah",
                 "translations": {
                     "japanese": "メディナ州",
@@ -43176,8 +43176,8 @@
                 }
             },
             {
-                "id": 5,
-                "full_id": 2919563264,
+                "id": 2919563264,
+                "individual_id": 5,
                 "name": "Ash Sharqiyah",
                 "translations": {
                     "japanese": "東部州",
@@ -43203,8 +43203,8 @@
                 }
             },
             {
-                "id": 6,
-                "full_id": 2919628800,
+                "id": 2919628800,
+                "individual_id": 6,
                 "name": "Al Qasim",
                 "translations": {
                     "japanese": "カスィーム州",
@@ -43230,8 +43230,8 @@
                 }
             },
             {
-                "id": 7,
-                "full_id": 2919694336,
+                "id": 2919694336,
+                "individual_id": 7,
                 "name": "'Asir",
                 "translations": {
                     "japanese": "アシール州",
@@ -43257,8 +43257,8 @@
                 }
             },
             {
-                "id": 8,
-                "full_id": 2919759872,
+                "id": 2919759872,
+                "individual_id": 8,
                 "name": "Ha'il",
                 "translations": {
                     "japanese": "ハーイル州",
@@ -43284,8 +43284,8 @@
                 }
             },
             {
-                "id": 9,
-                "full_id": 2919825408,
+                "id": 2919825408,
+                "individual_id": 9,
                 "name": "Makkah",
                 "translations": {
                     "japanese": "メッカ州",
@@ -43311,8 +43311,8 @@
                 }
             },
             {
-                "id": 10,
-                "full_id": 2919890944,
+                "id": 2919890944,
+                "individual_id": 10,
                 "name": "Al Hudud ash Shamaliyah",
                 "translations": {
                     "japanese": "北部国境州",
@@ -43338,8 +43338,8 @@
                 }
             },
             {
-                "id": 11,
-                "full_id": 2919956480,
+                "id": 2919956480,
+                "individual_id": 11,
                 "name": "Najran",
                 "translations": {
                     "japanese": "ナジュラーン州",
@@ -43365,8 +43365,8 @@
                 }
             },
             {
-                "id": 12,
-                "full_id": 2920022016,
+                "id": 2920022016,
+                "individual_id": 12,
                 "name": "Jizan",
                 "translations": {
                     "japanese": "ジーザーン州",
@@ -43392,8 +43392,8 @@
                 }
             },
             {
-                "id": 13,
-                "full_id": 2920087552,
+                "id": 2920087552,
+                "individual_id": 13,
                 "name": "Tabuk",
                 "translations": {
                     "japanese": "タブーク州",
@@ -43419,8 +43419,8 @@
                 }
             },
             {
-                "id": 14,
-                "full_id": 2920153088,
+                "id": 2920153088,
+                "individual_id": 14,
                 "name": "Al Jawf",
                 "translations": {
                     "japanese": "ジャウフ州",
@@ -43471,8 +43471,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 3087007744,
+                "id": 3087007744,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -43498,8 +43498,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 3087073280,
+                "id": 3087073280,
+                "individual_id": 1,
                 "name": "San Marino",
                 "translations": {
                     "japanese": "サンマリノ",
@@ -43550,8 +43550,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 3103784960,
+                "id": 3103784960,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -43577,8 +43577,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 3103850496,
+                "id": 3103850496,
+                "individual_id": 1,
                 "name": "Vatican City",
                 "translations": {
                     "japanese": "バチカン",
@@ -43629,8 +43629,8 @@
         },
         "regions": [
             {
-                "id": 0,
-                "full_id": 3120562176,
+                "id": 3120562176,
+                "individual_id": 0,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -43656,8 +43656,8 @@
                 }
             },
             {
-                "id": 1,
-                "full_id": 3120627712,
+                "id": 3120627712,
+                "individual_id": 1,
                 "name": "Bermuda",
                 "translations": {
                     "japanese": "バーミューダ",

--- a/regions.json
+++ b/regions.json
@@ -23,7 +23,8 @@
         },
         "regions": [
             {
-                "id": 16777216,
+                "id": 0,
+                "full_id": 16777216,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -49,7 +50,8 @@
                 }
             },
             {
-                "id": 16908288,
+                "id": 2,
+                "full_id": 16908288,
                 "name": "Tokyo",
                 "translations": {
                     "japanese": "東京都",
@@ -75,7 +77,8 @@
                 }
             },
             {
-                "id": 16973824,
+                "id": 3,
+                "full_id": 16973824,
                 "name": "Hokkaido",
                 "translations": {
                     "japanese": "北海道",
@@ -101,7 +104,8 @@
                 }
             },
             {
-                "id": 17039360,
+                "id": 4,
+                "full_id": 17039360,
                 "name": "Aomori",
                 "translations": {
                     "japanese": "青森県",
@@ -127,7 +131,8 @@
                 }
             },
             {
-                "id": 17104896,
+                "id": 5,
+                "full_id": 17104896,
                 "name": "Iwate",
                 "translations": {
                     "japanese": "岩手県",
@@ -153,7 +158,8 @@
                 }
             },
             {
-                "id": 17170432,
+                "id": 6,
+                "full_id": 17170432,
                 "name": "Miyagi",
                 "translations": {
                     "japanese": "宮城県",
@@ -179,7 +185,8 @@
                 }
             },
             {
-                "id": 17235968,
+                "id": 7,
+                "full_id": 17235968,
                 "name": "Akita",
                 "translations": {
                     "japanese": "秋田県",
@@ -205,7 +212,8 @@
                 }
             },
             {
-                "id": 17301504,
+                "id": 8,
+                "full_id": 17301504,
                 "name": "Yamagata",
                 "translations": {
                     "japanese": "山形県",
@@ -231,7 +239,8 @@
                 }
             },
             {
-                "id": 17367040,
+                "id": 9,
+                "full_id": 17367040,
                 "name": "Fukushima",
                 "translations": {
                     "japanese": "福島県",
@@ -257,7 +266,8 @@
                 }
             },
             {
-                "id": 17432576,
+                "id": 10,
+                "full_id": 17432576,
                 "name": "Ibaraki",
                 "translations": {
                     "japanese": "茨城県",
@@ -283,7 +293,8 @@
                 }
             },
             {
-                "id": 17498112,
+                "id": 11,
+                "full_id": 17498112,
                 "name": "Tochigi",
                 "translations": {
                     "japanese": "栃木県",
@@ -309,7 +320,8 @@
                 }
             },
             {
-                "id": 17563648,
+                "id": 12,
+                "full_id": 17563648,
                 "name": "Gunma",
                 "translations": {
                     "japanese": "群馬県",
@@ -335,7 +347,8 @@
                 }
             },
             {
-                "id": 17629184,
+                "id": 13,
+                "full_id": 17629184,
                 "name": "Saitama",
                 "translations": {
                     "japanese": "埼玉県",
@@ -361,7 +374,8 @@
                 }
             },
             {
-                "id": 17694720,
+                "id": 14,
+                "full_id": 17694720,
                 "name": "Chiba",
                 "translations": {
                     "japanese": "千葉県",
@@ -387,7 +401,8 @@
                 }
             },
             {
-                "id": 17760256,
+                "id": 15,
+                "full_id": 17760256,
                 "name": "Kanagawa",
                 "translations": {
                     "japanese": "神奈川県",
@@ -413,7 +428,8 @@
                 }
             },
             {
-                "id": 17825792,
+                "id": 1,
+                "full_id": 17825792,
                 "name": "Toyama",
                 "translations": {
                     "japanese": "富山県",
@@ -439,7 +455,8 @@
                 }
             },
             {
-                "id": 17891328,
+                "id": 17,
+                "full_id": 17891328,
                 "name": "Ishikawa",
                 "translations": {
                     "japanese": "石川県",
@@ -465,7 +482,8 @@
                 }
             },
             {
-                "id": 17956864,
+                "id": 18,
+                "full_id": 17956864,
                 "name": "Fukui",
                 "translations": {
                     "japanese": "福井県",
@@ -491,7 +509,8 @@
                 }
             },
             {
-                "id": 18022400,
+                "id": 19,
+                "full_id": 18022400,
                 "name": "Yamanashi",
                 "translations": {
                     "japanese": "山梨県",
@@ -517,7 +536,8 @@
                 }
             },
             {
-                "id": 18087936,
+                "id": 20,
+                "full_id": 18087936,
                 "name": "Nagano",
                 "translations": {
                     "japanese": "長野県",
@@ -543,7 +563,8 @@
                 }
             },
             {
-                "id": 18153472,
+                "id": 21,
+                "full_id": 18153472,
                 "name": "Niigata",
                 "translations": {
                     "japanese": "新潟県",
@@ -569,7 +590,8 @@
                 }
             },
             {
-                "id": 18219008,
+                "id": 22,
+                "full_id": 18219008,
                 "name": "Gifu",
                 "translations": {
                     "japanese": "岐阜県",
@@ -595,7 +617,8 @@
                 }
             },
             {
-                "id": 18284544,
+                "id": 23,
+                "full_id": 18284544,
                 "name": "Shizuoka",
                 "translations": {
                     "japanese": "静岡県",
@@ -621,7 +644,8 @@
                 }
             },
             {
-                "id": 18350080,
+                "id": 24,
+                "full_id": 18350080,
                 "name": "Aichi",
                 "translations": {
                     "japanese": "愛知県",
@@ -647,7 +671,8 @@
                 }
             },
             {
-                "id": 18415616,
+                "id": 25,
+                "full_id": 18415616,
                 "name": "Mie",
                 "translations": {
                     "japanese": "三重県",
@@ -673,7 +698,8 @@
                 }
             },
             {
-                "id": 18481152,
+                "id": 26,
+                "full_id": 18481152,
                 "name": "Shiga",
                 "translations": {
                     "japanese": "滋賀県",
@@ -699,7 +725,8 @@
                 }
             },
             {
-                "id": 18546688,
+                "id": 27,
+                "full_id": 18546688,
                 "name": "Kyoto",
                 "translations": {
                     "japanese": "京都府",
@@ -725,7 +752,8 @@
                 }
             },
             {
-                "id": 18612224,
+                "id": 28,
+                "full_id": 18612224,
                 "name": "Osaka",
                 "translations": {
                     "japanese": "大阪府",
@@ -751,7 +779,8 @@
                 }
             },
             {
-                "id": 18677760,
+                "id": 29,
+                "full_id": 18677760,
                 "name": "Hyogo",
                 "translations": {
                     "japanese": "兵庫県",
@@ -777,7 +806,8 @@
                 }
             },
             {
-                "id": 18743296,
+                "id": 30,
+                "full_id": 18743296,
                 "name": "Nara",
                 "translations": {
                     "japanese": "奈良県",
@@ -803,7 +833,8 @@
                 }
             },
             {
-                "id": 18808832,
+                "id": 31,
+                "full_id": 18808832,
                 "name": "Wakayama",
                 "translations": {
                     "japanese": "和歌山県",
@@ -829,7 +860,8 @@
                 }
             },
             {
-                "id": 18874368,
+                "id": 2,
+                "full_id": 18874368,
                 "name": "Tottori",
                 "translations": {
                     "japanese": "鳥取県",
@@ -855,7 +887,8 @@
                 }
             },
             {
-                "id": 18939904,
+                "id": 33,
+                "full_id": 18939904,
                 "name": "Shimane",
                 "translations": {
                     "japanese": "島根県",
@@ -881,7 +914,8 @@
                 }
             },
             {
-                "id": 19005440,
+                "id": 34,
+                "full_id": 19005440,
                 "name": "Okayama",
                 "translations": {
                     "japanese": "岡山県",
@@ -907,7 +941,8 @@
                 }
             },
             {
-                "id": 19070976,
+                "id": 35,
+                "full_id": 19070976,
                 "name": "Hiroshima",
                 "translations": {
                     "japanese": "広島県",
@@ -933,7 +968,8 @@
                 }
             },
             {
-                "id": 19136512,
+                "id": 36,
+                "full_id": 19136512,
                 "name": "Yamaguchi",
                 "translations": {
                     "japanese": "山口県",
@@ -959,7 +995,8 @@
                 }
             },
             {
-                "id": 19202048,
+                "id": 37,
+                "full_id": 19202048,
                 "name": "Tokushima",
                 "translations": {
                     "japanese": "徳島県",
@@ -985,7 +1022,8 @@
                 }
             },
             {
-                "id": 19267584,
+                "id": 38,
+                "full_id": 19267584,
                 "name": "Kagawa",
                 "translations": {
                     "japanese": "香川県",
@@ -1011,7 +1049,8 @@
                 }
             },
             {
-                "id": 19333120,
+                "id": 39,
+                "full_id": 19333120,
                 "name": "Ehime",
                 "translations": {
                     "japanese": "愛媛県",
@@ -1037,7 +1076,8 @@
                 }
             },
             {
-                "id": 19398656,
+                "id": 40,
+                "full_id": 19398656,
                 "name": "Kochi",
                 "translations": {
                     "japanese": "高知県",
@@ -1063,7 +1103,8 @@
                 }
             },
             {
-                "id": 19464192,
+                "id": 41,
+                "full_id": 19464192,
                 "name": "Fukuoka",
                 "translations": {
                     "japanese": "福岡県",
@@ -1089,7 +1130,8 @@
                 }
             },
             {
-                "id": 19529728,
+                "id": 42,
+                "full_id": 19529728,
                 "name": "Saga",
                 "translations": {
                     "japanese": "佐賀県",
@@ -1115,7 +1157,8 @@
                 }
             },
             {
-                "id": 19595264,
+                "id": 43,
+                "full_id": 19595264,
                 "name": "Nagasaki",
                 "translations": {
                     "japanese": "長崎県",
@@ -1141,7 +1184,8 @@
                 }
             },
             {
-                "id": 19660800,
+                "id": 44,
+                "full_id": 19660800,
                 "name": "Kumamoto",
                 "translations": {
                     "japanese": "熊本県",
@@ -1167,7 +1211,8 @@
                 }
             },
             {
-                "id": 19726336,
+                "id": 45,
+                "full_id": 19726336,
                 "name": "Oita",
                 "translations": {
                     "japanese": "大分県",
@@ -1193,7 +1238,8 @@
                 }
             },
             {
-                "id": 19791872,
+                "id": 46,
+                "full_id": 19791872,
                 "name": "Miyazaki",
                 "translations": {
                     "japanese": "宮崎県",
@@ -1219,7 +1265,8 @@
                 }
             },
             {
-                "id": 19857408,
+                "id": 47,
+                "full_id": 19857408,
                 "name": "Kagoshima",
                 "translations": {
                     "japanese": "鹿児島県",
@@ -1245,7 +1292,8 @@
                 }
             },
             {
-                "id": 19922944,
+                "id": 3,
+                "full_id": 19922944,
                 "name": "Okinawa",
                 "translations": {
                     "japanese": "沖縄県",
@@ -1296,7 +1344,8 @@
         },
         "regions": [
             {
-                "id": 134217728,
+                "id": 0,
+                "full_id": 134217728,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1322,7 +1371,8 @@
                 }
             },
             {
-                "id": 134283264,
+                "id": 1,
+                "full_id": 134283264,
                 "name": "Anguilla",
                 "translations": {
                     "japanese": "アンギラ",
@@ -1373,7 +1423,8 @@
         },
         "regions": [
             {
-                "id": 150994944,
+                "id": 0,
+                "full_id": 150994944,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1399,7 +1450,8 @@
                 }
             },
             {
-                "id": 151126016,
+                "id": 2,
+                "full_id": 151126016,
                 "name": "Saint John",
                 "translations": {
                     "japanese": "セント・ジョン",
@@ -1425,7 +1477,8 @@
                 }
             },
             {
-                "id": 151191552,
+                "id": 3,
+                "full_id": 151191552,
                 "name": "Barbuda",
                 "translations": {
                     "japanese": "バーブーダ島",
@@ -1451,7 +1504,8 @@
                 }
             },
             {
-                "id": 151257088,
+                "id": 4,
+                "full_id": 151257088,
                 "name": "Saint George",
                 "translations": {
                     "japanese": "セント・ジョージ",
@@ -1477,7 +1531,8 @@
                 }
             },
             {
-                "id": 151322624,
+                "id": 5,
+                "full_id": 151322624,
                 "name": "Saint Mary",
                 "translations": {
                     "japanese": "セント・メアリー",
@@ -1503,7 +1558,8 @@
                 }
             },
             {
-                "id": 151388160,
+                "id": 6,
+                "full_id": 151388160,
                 "name": "Saint Paul",
                 "translations": {
                     "japanese": "セント・ポール",
@@ -1529,7 +1585,8 @@
                 }
             },
             {
-                "id": 151453696,
+                "id": 7,
+                "full_id": 151453696,
                 "name": "Saint Peter",
                 "translations": {
                     "japanese": "セント・ピーター",
@@ -1555,7 +1612,8 @@
                 }
             },
             {
-                "id": 151519232,
+                "id": 8,
+                "full_id": 151519232,
                 "name": "Saint Philip",
                 "translations": {
                     "japanese": "セント・フィリップ",
@@ -1606,7 +1664,8 @@
         },
         "regions": [
             {
-                "id": 167772160,
+                "id": 0,
+                "full_id": 167772160,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -1632,7 +1691,8 @@
                 }
             },
             {
-                "id": 167903232,
+                "id": 2,
+                "full_id": 167903232,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "特別区",
@@ -1658,7 +1718,8 @@
                 }
             },
             {
-                "id": 167968768,
+                "id": 3,
+                "full_id": 167968768,
                 "name": "Buenos Aires",
                 "translations": {
                     "japanese": "ブエノスアイレス州",
@@ -1684,7 +1745,8 @@
                 }
             },
             {
-                "id": 168034304,
+                "id": 4,
+                "full_id": 168034304,
                 "name": "Catamarca",
                 "translations": {
                     "japanese": "カタマルカ州",
@@ -1710,7 +1772,8 @@
                 }
             },
             {
-                "id": 168099840,
+                "id": 5,
+                "full_id": 168099840,
                 "name": "Chaco",
                 "translations": {
                     "japanese": "チャコ州",
@@ -1736,7 +1799,8 @@
                 }
             },
             {
-                "id": 168165376,
+                "id": 6,
+                "full_id": 168165376,
                 "name": "Chubut",
                 "translations": {
                     "japanese": "チュブト州",
@@ -1762,7 +1826,8 @@
                 }
             },
             {
-                "id": 168230912,
+                "id": 7,
+                "full_id": 168230912,
                 "name": "Córdoba",
                 "translations": {
                     "japanese": "コルドバ州",
@@ -1788,7 +1853,8 @@
                 }
             },
             {
-                "id": 168296448,
+                "id": 8,
+                "full_id": 168296448,
                 "name": "Corrientes",
                 "translations": {
                     "japanese": "コリエンテス州",
@@ -1814,7 +1880,8 @@
                 }
             },
             {
-                "id": 168361984,
+                "id": 9,
+                "full_id": 168361984,
                 "name": "Entre Ríos",
                 "translations": {
                     "japanese": "エントレ・リオス州",
@@ -1840,7 +1907,8 @@
                 }
             },
             {
-                "id": 168427520,
+                "id": 10,
+                "full_id": 168427520,
                 "name": "Formosa",
                 "translations": {
                     "japanese": "フォルモサ州",
@@ -1866,7 +1934,8 @@
                 }
             },
             {
-                "id": 168493056,
+                "id": 11,
+                "full_id": 168493056,
                 "name": "Jujuy",
                 "translations": {
                     "japanese": "フフイ州",
@@ -1892,7 +1961,8 @@
                 }
             },
             {
-                "id": 168558592,
+                "id": 12,
+                "full_id": 168558592,
                 "name": "La Pampa",
                 "translations": {
                     "japanese": "ラ・パンパ州",
@@ -1918,7 +1988,8 @@
                 }
             },
             {
-                "id": 168624128,
+                "id": 13,
+                "full_id": 168624128,
                 "name": "La Rioja",
                 "translations": {
                     "japanese": "ラ・リオハ州",
@@ -1944,7 +2015,8 @@
                 }
             },
             {
-                "id": 168689664,
+                "id": 14,
+                "full_id": 168689664,
                 "name": "Mendoza",
                 "translations": {
                     "japanese": "メンドーサ州",
@@ -1970,7 +2042,8 @@
                 }
             },
             {
-                "id": 168755200,
+                "id": 15,
+                "full_id": 168755200,
                 "name": "Misiones",
                 "translations": {
                     "japanese": "ミシオネス州",
@@ -1996,7 +2069,8 @@
                 }
             },
             {
-                "id": 168820736,
+                "id": 1,
+                "full_id": 168820736,
                 "name": "Neuquén",
                 "translations": {
                     "japanese": "ネウケン州",
@@ -2022,7 +2096,8 @@
                 }
             },
             {
-                "id": 168886272,
+                "id": 17,
+                "full_id": 168886272,
                 "name": "Río Negro",
                 "translations": {
                     "japanese": "リオネグロ州",
@@ -2048,7 +2123,8 @@
                 }
             },
             {
-                "id": 168951808,
+                "id": 18,
+                "full_id": 168951808,
                 "name": "Salta",
                 "translations": {
                     "japanese": "サルタ州",
@@ -2074,7 +2150,8 @@
                 }
             },
             {
-                "id": 169017344,
+                "id": 19,
+                "full_id": 169017344,
                 "name": "San Juan",
                 "translations": {
                     "japanese": "サン・フアン州",
@@ -2100,7 +2177,8 @@
                 }
             },
             {
-                "id": 169082880,
+                "id": 20,
+                "full_id": 169082880,
                 "name": "San Luis",
                 "translations": {
                     "japanese": "サン・ルイス州",
@@ -2126,7 +2204,8 @@
                 }
             },
             {
-                "id": 169148416,
+                "id": 21,
+                "full_id": 169148416,
                 "name": "Santa Cruz",
                 "translations": {
                     "japanese": "サンタ・クルス州",
@@ -2152,7 +2231,8 @@
                 }
             },
             {
-                "id": 169213952,
+                "id": 22,
+                "full_id": 169213952,
                 "name": "Santa Fe",
                 "translations": {
                     "japanese": "サンタ・フェ州",
@@ -2178,7 +2258,8 @@
                 }
             },
             {
-                "id": 169279488,
+                "id": 23,
+                "full_id": 169279488,
                 "name": "Santiago del Estero",
                 "translations": {
                     "japanese": "サンティアゴ・デル・エステロ州",
@@ -2204,7 +2285,8 @@
                 }
             },
             {
-                "id": 169345024,
+                "id": 24,
+                "full_id": 169345024,
                 "name": "Tierra del Fuego, Antártida e Islas del Atlántico Sur",
                 "translations": {
                     "japanese": "ティエラ・デル・フエゴ州",
@@ -2230,7 +2312,8 @@
                 }
             },
             {
-                "id": 169410560,
+                "id": 25,
+                "full_id": 169410560,
                 "name": "Tucumán",
                 "translations": {
                     "japanese": "トゥクマン州",
@@ -2281,7 +2364,8 @@
         },
         "regions": [
             {
-                "id": 184549376,
+                "id": 0,
+                "full_id": 184549376,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2307,7 +2391,8 @@
                 }
             },
             {
-                "id": 184614912,
+                "id": 1,
+                "full_id": 184614912,
                 "name": "Aruba",
                 "translations": {
                     "japanese": "アルバ",
@@ -2358,7 +2443,8 @@
         },
         "regions": [
             {
-                "id": 201326592,
+                "id": 0,
+                "full_id": 201326592,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2384,7 +2470,8 @@
                 }
             },
             {
-                "id": 201392128,
+                "id": 1,
+                "full_id": 201392128,
                 "name": "Bahamas",
                 "translations": {
                     "japanese": "バハマ",
@@ -2435,7 +2522,8 @@
         },
         "regions": [
             {
-                "id": 218103808,
+                "id": 0,
+                "full_id": 218103808,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2461,7 +2549,8 @@
                 }
             },
             {
-                "id": 218169344,
+                "id": 1,
+                "full_id": 218169344,
                 "name": "Barbados",
                 "translations": {
                     "japanese": "バルバドス",
@@ -2512,7 +2601,8 @@
         },
         "regions": [
             {
-                "id": 234881024,
+                "id": 0,
+                "full_id": 234881024,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2538,7 +2628,8 @@
                 }
             },
             {
-                "id": 235012096,
+                "id": 2,
+                "full_id": 235012096,
                 "name": "Cayo",
                 "translations": {
                     "japanese": "カヨー州",
@@ -2564,7 +2655,8 @@
                 }
             },
             {
-                "id": 235077632,
+                "id": 3,
+                "full_id": 235077632,
                 "name": "Belize",
                 "translations": {
                     "japanese": "ベリーズ州",
@@ -2590,7 +2682,8 @@
                 }
             },
             {
-                "id": 235143168,
+                "id": 4,
+                "full_id": 235143168,
                 "name": "Corozal",
                 "translations": {
                     "japanese": "コロサル州",
@@ -2616,7 +2709,8 @@
                 }
             },
             {
-                "id": 235208704,
+                "id": 5,
+                "full_id": 235208704,
                 "name": "Orange Walk",
                 "translations": {
                     "japanese": "オレンジウォーク州",
@@ -2642,7 +2736,8 @@
                 }
             },
             {
-                "id": 235274240,
+                "id": 6,
+                "full_id": 235274240,
                 "name": "Stann Creek",
                 "translations": {
                     "japanese": "スタンクリーク州",
@@ -2668,7 +2763,8 @@
                 }
             },
             {
-                "id": 235339776,
+                "id": 7,
+                "full_id": 235339776,
                 "name": "Toledo",
                 "translations": {
                     "japanese": "トレド州",
@@ -2719,7 +2815,8 @@
         },
         "regions": [
             {
-                "id": 251658240,
+                "id": 0,
+                "full_id": 251658240,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -2745,7 +2842,8 @@
                 }
             },
             {
-                "id": 251789312,
+                "id": 2,
+                "full_id": 251789312,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラパス県",
@@ -2771,7 +2869,8 @@
                 }
             },
             {
-                "id": 251854848,
+                "id": 3,
+                "full_id": 251854848,
                 "name": "Chuquisaca",
                 "translations": {
                     "japanese": "チュキサカ県",
@@ -2797,7 +2896,8 @@
                 }
             },
             {
-                "id": 251920384,
+                "id": 4,
+                "full_id": 251920384,
                 "name": "Cochabamba",
                 "translations": {
                     "japanese": "コチャバンバ県",
@@ -2823,7 +2923,8 @@
                 }
             },
             {
-                "id": 251985920,
+                "id": 5,
+                "full_id": 251985920,
                 "name": "El Beni",
                 "translations": {
                     "japanese": "ベニ県",
@@ -2849,7 +2950,8 @@
                 }
             },
             {
-                "id": 252051456,
+                "id": 6,
+                "full_id": 252051456,
                 "name": "Oruro",
                 "translations": {
                     "japanese": "オルロ県",
@@ -2875,7 +2977,8 @@
                 }
             },
             {
-                "id": 252116992,
+                "id": 7,
+                "full_id": 252116992,
                 "name": "Pando",
                 "translations": {
                     "japanese": "パンド県",
@@ -2901,7 +3004,8 @@
                 }
             },
             {
-                "id": 252182528,
+                "id": 8,
+                "full_id": 252182528,
                 "name": "Potosí",
                 "translations": {
                     "japanese": "ポトシ県",
@@ -2927,7 +3031,8 @@
                 }
             },
             {
-                "id": 252248064,
+                "id": 9,
+                "full_id": 252248064,
                 "name": "Santa Cruz",
                 "translations": {
                     "japanese": "サンタ・クルス県",
@@ -2953,7 +3058,8 @@
                 }
             },
             {
-                "id": 252313600,
+                "id": 10,
+                "full_id": 252313600,
                 "name": "Tarija",
                 "translations": {
                     "japanese": "タリハ県",
@@ -3004,7 +3110,8 @@
         },
         "regions": [
             {
-                "id": 268435456,
+                "id": 0,
+                "full_id": 268435456,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3030,7 +3137,8 @@
                 }
             },
             {
-                "id": 268566528,
+                "id": 2,
+                "full_id": 268566528,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト・フェデラル州",
@@ -3056,7 +3164,8 @@
                 }
             },
             {
-                "id": 268632064,
+                "id": 3,
+                "full_id": 268632064,
                 "name": "Acre",
                 "translations": {
                     "japanese": "アクレ州",
@@ -3082,7 +3191,8 @@
                 }
             },
             {
-                "id": 268697600,
+                "id": 4,
+                "full_id": 268697600,
                 "name": "Alagoas",
                 "translations": {
                     "japanese": "アラゴアス州",
@@ -3108,7 +3218,8 @@
                 }
             },
             {
-                "id": 268763136,
+                "id": 5,
+                "full_id": 268763136,
                 "name": "Amapá",
                 "translations": {
                     "japanese": "アマパー州",
@@ -3134,7 +3245,8 @@
                 }
             },
             {
-                "id": 268828672,
+                "id": 6,
+                "full_id": 268828672,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマゾナス州",
@@ -3160,7 +3272,8 @@
                 }
             },
             {
-                "id": 268894208,
+                "id": 7,
+                "full_id": 268894208,
                 "name": "Bahia",
                 "translations": {
                     "japanese": "バイア州",
@@ -3186,7 +3299,8 @@
                 }
             },
             {
-                "id": 268959744,
+                "id": 8,
+                "full_id": 268959744,
                 "name": "Ceará",
                 "translations": {
                     "japanese": "セアラ州",
@@ -3212,7 +3326,8 @@
                 }
             },
             {
-                "id": 269025280,
+                "id": 9,
+                "full_id": 269025280,
                 "name": "Espírito Santo",
                 "translations": {
                     "japanese": "エスピリト・サント州",
@@ -3238,7 +3353,8 @@
                 }
             },
             {
-                "id": 269090816,
+                "id": 10,
+                "full_id": 269090816,
                 "name": "Mato Grosso do Sul",
                 "translations": {
                     "japanese": "マット・グロッソ・ド・スル州",
@@ -3264,7 +3380,8 @@
                 }
             },
             {
-                "id": 269156352,
+                "id": 11,
+                "full_id": 269156352,
                 "name": "Maranhão",
                 "translations": {
                     "japanese": "マラニョン州",
@@ -3290,7 +3407,8 @@
                 }
             },
             {
-                "id": 269221888,
+                "id": 12,
+                "full_id": 269221888,
                 "name": "Mato Grosso",
                 "translations": {
                     "japanese": "マット・グロッソ州",
@@ -3316,7 +3434,8 @@
                 }
             },
             {
-                "id": 269287424,
+                "id": 13,
+                "full_id": 269287424,
                 "name": "Minas Gerais",
                 "translations": {
                     "japanese": "ミナス・ジェライス州",
@@ -3342,7 +3461,8 @@
                 }
             },
             {
-                "id": 269352960,
+                "id": 14,
+                "full_id": 269352960,
                 "name": "Pará",
                 "translations": {
                     "japanese": "パラー州",
@@ -3368,7 +3488,8 @@
                 }
             },
             {
-                "id": 269418496,
+                "id": 15,
+                "full_id": 269418496,
                 "name": "Paraíba",
                 "translations": {
                     "japanese": "パライーバ州",
@@ -3394,7 +3515,8 @@
                 }
             },
             {
-                "id": 269484032,
+                "id": 1,
+                "full_id": 269484032,
                 "name": "Paraná",
                 "translations": {
                     "japanese": "パラナ州",
@@ -3420,7 +3542,8 @@
                 }
             },
             {
-                "id": 269549568,
+                "id": 17,
+                "full_id": 269549568,
                 "name": "Piauí",
                 "translations": {
                     "japanese": "ピアウイー州",
@@ -3446,7 +3569,8 @@
                 }
             },
             {
-                "id": 269615104,
+                "id": 18,
+                "full_id": 269615104,
                 "name": "Rio de Janeiro",
                 "translations": {
                     "japanese": "リオ・デ・ジャネイロ州",
@@ -3472,7 +3596,8 @@
                 }
             },
             {
-                "id": 269680640,
+                "id": 19,
+                "full_id": 269680640,
                 "name": "Rio Grande do Norte",
                 "translations": {
                     "japanese": "リオ・グランデ・ド・ノルテ州",
@@ -3498,7 +3623,8 @@
                 }
             },
             {
-                "id": 269746176,
+                "id": 20,
+                "full_id": 269746176,
                 "name": "Rio Grande do Sul",
                 "translations": {
                     "japanese": "リオ・グランデ・ド・スル州",
@@ -3524,7 +3650,8 @@
                 }
             },
             {
-                "id": 269811712,
+                "id": 21,
+                "full_id": 269811712,
                 "name": "Rondônia",
                 "translations": {
                     "japanese": "ロンドニア州",
@@ -3550,7 +3677,8 @@
                 }
             },
             {
-                "id": 269877248,
+                "id": 22,
+                "full_id": 269877248,
                 "name": "Roraima",
                 "translations": {
                     "japanese": "ロライマ州",
@@ -3576,7 +3704,8 @@
                 }
             },
             {
-                "id": 269942784,
+                "id": 23,
+                "full_id": 269942784,
                 "name": "Santa Catarina",
                 "translations": {
                     "japanese": "サンタ・カタリーナ州",
@@ -3602,7 +3731,8 @@
                 }
             },
             {
-                "id": 270008320,
+                "id": 24,
+                "full_id": 270008320,
                 "name": "São Paulo",
                 "translations": {
                     "japanese": "サン・パウロ州",
@@ -3628,7 +3758,8 @@
                 }
             },
             {
-                "id": 270073856,
+                "id": 25,
+                "full_id": 270073856,
                 "name": "Sergipe",
                 "translations": {
                     "japanese": "セルジッペ州",
@@ -3654,7 +3785,8 @@
                 }
             },
             {
-                "id": 270139392,
+                "id": 26,
+                "full_id": 270139392,
                 "name": "Goiás",
                 "translations": {
                     "japanese": "ゴイアス州",
@@ -3680,7 +3812,8 @@
                 }
             },
             {
-                "id": 270204928,
+                "id": 27,
+                "full_id": 270204928,
                 "name": "Pernambuco",
                 "translations": {
                     "japanese": "ペルナンブコ州",
@@ -3706,7 +3839,8 @@
                 }
             },
             {
-                "id": 270270464,
+                "id": 28,
+                "full_id": 270270464,
                 "name": "Tocantins",
                 "translations": {
                     "japanese": "トカンティンス州",
@@ -3757,7 +3891,8 @@
         },
         "regions": [
             {
-                "id": 285212672,
+                "id": 0,
+                "full_id": 285212672,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3783,7 +3918,8 @@
                 }
             },
             {
-                "id": 285278208,
+                "id": 1,
+                "full_id": 285278208,
                 "name": "British Virgin Islands",
                 "translations": {
                     "japanese": "英領ヴァージン諸島",
@@ -3834,7 +3970,8 @@
         },
         "regions": [
             {
-                "id": 301989888,
+                "id": 0,
+                "full_id": 301989888,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -3860,7 +3997,8 @@
                 }
             },
             {
-                "id": 302120960,
+                "id": 2,
+                "full_id": 302120960,
                 "name": "Ontario",
                 "translations": {
                     "japanese": "オンタリオ州",
@@ -3886,7 +4024,8 @@
                 }
             },
             {
-                "id": 302186496,
+                "id": 3,
+                "full_id": 302186496,
                 "name": "Alberta",
                 "translations": {
                     "japanese": "アルバータ州",
@@ -3912,7 +4051,8 @@
                 }
             },
             {
-                "id": 302252032,
+                "id": 4,
+                "full_id": 302252032,
                 "name": "British Columbia",
                 "translations": {
                     "japanese": "ブリティッシュ・コロンビア州",
@@ -3938,7 +4078,8 @@
                 }
             },
             {
-                "id": 302317568,
+                "id": 5,
+                "full_id": 302317568,
                 "name": "Manitoba",
                 "translations": {
                     "japanese": "マニトバ州",
@@ -3964,7 +4105,8 @@
                 }
             },
             {
-                "id": 302383104,
+                "id": 6,
+                "full_id": 302383104,
                 "name": "New Brunswick",
                 "translations": {
                     "japanese": "ニュー・ブランズウィック州",
@@ -3990,7 +4132,8 @@
                 }
             },
             {
-                "id": 302448640,
+                "id": 7,
+                "full_id": 302448640,
                 "name": "Newfoundland and Labrador",
                 "translations": {
                     "japanese": "ニューファンドランド・ラブラドール州",
@@ -4016,7 +4159,8 @@
                 }
             },
             {
-                "id": 302514176,
+                "id": 8,
+                "full_id": 302514176,
                 "name": "Nova Scotia",
                 "translations": {
                     "japanese": "ノバ・スコシア州",
@@ -4042,7 +4186,8 @@
                 }
             },
             {
-                "id": 302579712,
+                "id": 9,
+                "full_id": 302579712,
                 "name": "Prince Edward Island",
                 "translations": {
                     "japanese": "プリンス・エドワード・アイランド州",
@@ -4068,7 +4213,8 @@
                 }
             },
             {
-                "id": 302645248,
+                "id": 10,
+                "full_id": 302645248,
                 "name": "Quebec",
                 "translations": {
                     "japanese": "ケベック州",
@@ -4094,7 +4240,8 @@
                 }
             },
             {
-                "id": 302710784,
+                "id": 11,
+                "full_id": 302710784,
                 "name": "Saskatchewan",
                 "translations": {
                     "japanese": "サスカチュワン州",
@@ -4120,7 +4267,8 @@
                 }
             },
             {
-                "id": 302776320,
+                "id": 12,
+                "full_id": 302776320,
                 "name": "Yukon",
                 "translations": {
                     "japanese": "ユーコン準州",
@@ -4146,7 +4294,8 @@
                 }
             },
             {
-                "id": 302841856,
+                "id": 13,
+                "full_id": 302841856,
                 "name": "Northwest Territories",
                 "translations": {
                     "japanese": "ノースウェスト準州",
@@ -4172,7 +4321,8 @@
                 }
             },
             {
-                "id": 302907392,
+                "id": 14,
+                "full_id": 302907392,
                 "name": "Nunavut",
                 "translations": {
                     "japanese": "ヌナブト準州",
@@ -4223,7 +4373,8 @@
         },
         "regions": [
             {
-                "id": 318767104,
+                "id": 0,
+                "full_id": 318767104,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4249,7 +4400,8 @@
                 }
             },
             {
-                "id": 318832640,
+                "id": 1,
+                "full_id": 318832640,
                 "name": "Cayman Islands",
                 "translations": {
                     "japanese": "ケイマン諸島",
@@ -4300,7 +4452,8 @@
         },
         "regions": [
             {
-                "id": 335544320,
+                "id": 0,
+                "full_id": 335544320,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4326,7 +4479,8 @@
                 }
             },
             {
-                "id": 335675392,
+                "id": 2,
+                "full_id": 335675392,
                 "name": "Región Metropolitana",
                 "translations": {
                     "japanese": "レジョン・メトロポリタナ州",
@@ -4352,7 +4506,8 @@
                 }
             },
             {
-                "id": 335740928,
+                "id": 3,
+                "full_id": 335740928,
                 "name": "Valparaíso",
                 "translations": {
                     "japanese": "バルパライソ州",
@@ -4378,7 +4533,8 @@
                 }
             },
             {
-                "id": 335806464,
+                "id": 4,
+                "full_id": 335806464,
                 "name": "Aisén del General Carlos Ibáñez del Campo",
                 "translations": {
                     "japanese": "アイセン・デル・Ｇ・カルロス・イバニェス・デル・カンポ州",
@@ -4404,7 +4560,8 @@
                 }
             },
             {
-                "id": 335872000,
+                "id": 5,
+                "full_id": 335872000,
                 "name": "Antofagasta",
                 "translations": {
                     "japanese": "アントファガスタ州",
@@ -4430,7 +4587,8 @@
                 }
             },
             {
-                "id": 335937536,
+                "id": 6,
+                "full_id": 335937536,
                 "name": "Araucanía",
                 "translations": {
                     "japanese": "アラウカニア州",
@@ -4456,7 +4614,8 @@
                 }
             },
             {
-                "id": 336003072,
+                "id": 7,
+                "full_id": 336003072,
                 "name": "Atacama",
                 "translations": {
                     "japanese": "アタカマ州",
@@ -4482,7 +4641,8 @@
                 }
             },
             {
-                "id": 336068608,
+                "id": 8,
+                "full_id": 336068608,
                 "name": "Bío-Bío",
                 "translations": {
                     "japanese": "ビオビオ州",
@@ -4508,7 +4668,8 @@
                 }
             },
             {
-                "id": 336134144,
+                "id": 9,
+                "full_id": 336134144,
                 "name": "Coquimbo",
                 "translations": {
                     "japanese": "コキンボ州",
@@ -4534,7 +4695,8 @@
                 }
             },
             {
-                "id": 336199680,
+                "id": 10,
+                "full_id": 336199680,
                 "name": "Libertador General Bernardo O'Higgins",
                 "translations": {
                     "japanese": "L・ベルナルド・オヒギンス州",
@@ -4560,7 +4722,8 @@
                 }
             },
             {
-                "id": 336265216,
+                "id": 11,
+                "full_id": 336265216,
                 "name": "Los Lagos",
                 "translations": {
                     "japanese": "ロス・ラゴス州",
@@ -4586,7 +4749,8 @@
                 }
             },
             {
-                "id": 336330752,
+                "id": 12,
+                "full_id": 336330752,
                 "name": "Magallanes y Antártica Chilena",
                 "translations": {
                     "japanese": "マガリャネス州",
@@ -4612,7 +4776,8 @@
                 }
             },
             {
-                "id": 336396288,
+                "id": 13,
+                "full_id": 336396288,
                 "name": "Maule",
                 "translations": {
                     "japanese": "マウレ州",
@@ -4638,7 +4803,8 @@
                 }
             },
             {
-                "id": 336461824,
+                "id": 14,
+                "full_id": 336461824,
                 "name": "Tarapacá",
                 "translations": {
                     "japanese": "タラパカ州",
@@ -4689,7 +4855,8 @@
         },
         "regions": [
             {
-                "id": 352321536,
+                "id": 0,
+                "full_id": 352321536,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -4715,7 +4882,8 @@
                 }
             },
             {
-                "id": 352452608,
+                "id": 2,
+                "full_id": 352452608,
                 "name": "Distrito Capital",
                 "translations": {
                     "japanese": "ディストリト・キャピタル",
@@ -4741,7 +4909,8 @@
                 }
             },
             {
-                "id": 352518144,
+                "id": 3,
+                "full_id": 352518144,
                 "name": "Cundinamarca",
                 "translations": {
                     "japanese": "クンディナマルカ県",
@@ -4767,7 +4936,8 @@
                 }
             },
             {
-                "id": 352583680,
+                "id": 4,
+                "full_id": 352583680,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス県",
@@ -4793,7 +4963,8 @@
                 }
             },
             {
-                "id": 352649216,
+                "id": 5,
+                "full_id": 352649216,
                 "name": "Antioquia",
                 "translations": {
                     "japanese": "アンティオキア県",
@@ -4819,7 +4990,8 @@
                 }
             },
             {
-                "id": 352714752,
+                "id": 6,
+                "full_id": 352714752,
                 "name": "Arauca",
                 "translations": {
                     "japanese": "アラウカ県",
@@ -4845,7 +5017,8 @@
                 }
             },
             {
-                "id": 352780288,
+                "id": 7,
+                "full_id": 352780288,
                 "name": "Atlántico",
                 "translations": {
                     "japanese": "アトランティコ県",
@@ -4871,7 +5044,8 @@
                 }
             },
             {
-                "id": 352845824,
+                "id": 8,
+                "full_id": 352845824,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル県",
@@ -4897,7 +5071,8 @@
                 }
             },
             {
-                "id": 352911360,
+                "id": 9,
+                "full_id": 352911360,
                 "name": "Boyacá",
                 "translations": {
                     "japanese": "ボヤカ県",
@@ -4923,7 +5098,8 @@
                 }
             },
             {
-                "id": 352976896,
+                "id": 10,
+                "full_id": 352976896,
                 "name": "Caldas",
                 "translations": {
                     "japanese": "カルダス県",
@@ -4949,7 +5125,8 @@
                 }
             },
             {
-                "id": 353042432,
+                "id": 11,
+                "full_id": 353042432,
                 "name": "Caquetá",
                 "translations": {
                     "japanese": "カケタ県",
@@ -4975,7 +5152,8 @@
                 }
             },
             {
-                "id": 353107968,
+                "id": 12,
+                "full_id": 353107968,
                 "name": "Cauca",
                 "translations": {
                     "japanese": "カウカ県",
@@ -5001,7 +5179,8 @@
                 }
             },
             {
-                "id": 353173504,
+                "id": 13,
+                "full_id": 353173504,
                 "name": "Cesar",
                 "translations": {
                     "japanese": "セサル県",
@@ -5027,7 +5206,8 @@
                 }
             },
             {
-                "id": 353239040,
+                "id": 14,
+                "full_id": 353239040,
                 "name": "Chocó",
                 "translations": {
                     "japanese": "チョコ県",
@@ -5053,7 +5233,8 @@
                 }
             },
             {
-                "id": 353304576,
+                "id": 15,
+                "full_id": 353304576,
                 "name": "Córdoba",
                 "translations": {
                     "japanese": "コルドバ県",
@@ -5079,7 +5260,8 @@
                 }
             },
             {
-                "id": 353370112,
+                "id": 1,
+                "full_id": 353370112,
                 "name": "Guaviare",
                 "translations": {
                     "japanese": "グアビアレ県",
@@ -5105,7 +5287,8 @@
                 }
             },
             {
-                "id": 353435648,
+                "id": 17,
+                "full_id": 353435648,
                 "name": "Guainía",
                 "translations": {
                     "japanese": "グアイニア県",
@@ -5131,7 +5314,8 @@
                 }
             },
             {
-                "id": 353501184,
+                "id": 18,
+                "full_id": 353501184,
                 "name": "Huila",
                 "translations": {
                     "japanese": "ウィラ県",
@@ -5157,7 +5341,8 @@
                 }
             },
             {
-                "id": 353566720,
+                "id": 19,
+                "full_id": 353566720,
                 "name": "La Guajira",
                 "translations": {
                     "japanese": "グアヒーラ県",
@@ -5183,7 +5368,8 @@
                 }
             },
             {
-                "id": 353632256,
+                "id": 20,
+                "full_id": 353632256,
                 "name": "Magdalena",
                 "translations": {
                     "japanese": "マグダレーナ県",
@@ -5209,7 +5395,8 @@
                 }
             },
             {
-                "id": 353697792,
+                "id": 21,
+                "full_id": 353697792,
                 "name": "Meta",
                 "translations": {
                     "japanese": "メタ県",
@@ -5235,7 +5422,8 @@
                 }
             },
             {
-                "id": 353763328,
+                "id": 22,
+                "full_id": 353763328,
                 "name": "Nariño",
                 "translations": {
                     "japanese": "ナリーニョ県",
@@ -5261,7 +5449,8 @@
                 }
             },
             {
-                "id": 353828864,
+                "id": 23,
+                "full_id": 353828864,
                 "name": "Norte de Santander",
                 "translations": {
                     "japanese": "ノルテ・デ・サンタンデル県",
@@ -5287,7 +5476,8 @@
                 }
             },
             {
-                "id": 353894400,
+                "id": 24,
+                "full_id": 353894400,
                 "name": "Putumayo",
                 "translations": {
                     "japanese": "プトゥマイオ県",
@@ -5313,7 +5503,8 @@
                 }
             },
             {
-                "id": 353959936,
+                "id": 25,
+                "full_id": 353959936,
                 "name": "Quindío",
                 "translations": {
                     "japanese": "キンディオ県",
@@ -5339,7 +5530,8 @@
                 }
             },
             {
-                "id": 354025472,
+                "id": 26,
+                "full_id": 354025472,
                 "name": "Risaralda",
                 "translations": {
                     "japanese": "リサラルダ県",
@@ -5365,7 +5557,8 @@
                 }
             },
             {
-                "id": 354091008,
+                "id": 27,
+                "full_id": 354091008,
                 "name": "Archipiélago de San Andrés, Providencia y Santa Catalina",
                 "translations": {
                     "japanese": "サン・アンドレス・イ・プロビデンシア県",
@@ -5391,7 +5584,8 @@
                 }
             },
             {
-                "id": 354156544,
+                "id": 28,
+                "full_id": 354156544,
                 "name": "Santander",
                 "translations": {
                     "japanese": "サンタンデル県",
@@ -5417,7 +5611,8 @@
                 }
             },
             {
-                "id": 354222080,
+                "id": 29,
+                "full_id": 354222080,
                 "name": "Sucre",
                 "translations": {
                     "japanese": "スクレ県",
@@ -5443,7 +5638,8 @@
                 }
             },
             {
-                "id": 354287616,
+                "id": 30,
+                "full_id": 354287616,
                 "name": "Tolima",
                 "translations": {
                     "japanese": "トリマ県",
@@ -5469,7 +5665,8 @@
                 }
             },
             {
-                "id": 354353152,
+                "id": 31,
+                "full_id": 354353152,
                 "name": "Valle del Cauca",
                 "translations": {
                     "japanese": "バジェ・デル・カウカ県",
@@ -5495,7 +5692,8 @@
                 }
             },
             {
-                "id": 354418688,
+                "id": 2,
+                "full_id": 354418688,
                 "name": "Vaupés",
                 "translations": {
                     "japanese": "バウペス県",
@@ -5521,7 +5719,8 @@
                 }
             },
             {
-                "id": 354484224,
+                "id": 33,
+                "full_id": 354484224,
                 "name": "Vichada",
                 "translations": {
                     "japanese": "ビチャダ県",
@@ -5547,7 +5746,8 @@
                 }
             },
             {
-                "id": 354549760,
+                "id": 34,
+                "full_id": 354549760,
                 "name": "Casanare",
                 "translations": {
                     "japanese": "カサナレ県",
@@ -5598,7 +5798,8 @@
         },
         "regions": [
             {
-                "id": 369098752,
+                "id": 0,
+                "full_id": 369098752,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -5624,7 +5825,8 @@
                 }
             },
             {
-                "id": 369229824,
+                "id": 2,
+                "full_id": 369229824,
                 "name": "San José",
                 "translations": {
                     "japanese": "サン・ホセ州",
@@ -5650,7 +5852,8 @@
                 }
             },
             {
-                "id": 369295360,
+                "id": 3,
+                "full_id": 369295360,
                 "name": "Alajuela",
                 "translations": {
                     "japanese": "アラフエラ州",
@@ -5676,7 +5879,8 @@
                 }
             },
             {
-                "id": 369360896,
+                "id": 4,
+                "full_id": 369360896,
                 "name": "Cartago",
                 "translations": {
                     "japanese": "カルタゴ州",
@@ -5702,7 +5906,8 @@
                 }
             },
             {
-                "id": 369426432,
+                "id": 5,
+                "full_id": 369426432,
                 "name": "Guanacaste",
                 "translations": {
                     "japanese": "グアナカステ州",
@@ -5728,7 +5933,8 @@
                 }
             },
             {
-                "id": 369491968,
+                "id": 6,
+                "full_id": 369491968,
                 "name": "Heredia",
                 "translations": {
                     "japanese": "エレディア州",
@@ -5754,7 +5960,8 @@
                 }
             },
             {
-                "id": 369557504,
+                "id": 7,
+                "full_id": 369557504,
                 "name": "Limón",
                 "translations": {
                     "japanese": "リモン州",
@@ -5780,7 +5987,8 @@
                 }
             },
             {
-                "id": 369623040,
+                "id": 8,
+                "full_id": 369623040,
                 "name": "Puntarenas",
                 "translations": {
                     "japanese": "プンタレナス州",
@@ -5831,7 +6039,8 @@
         },
         "regions": [
             {
-                "id": 385875968,
+                "id": 0,
+                "full_id": 385875968,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -5857,7 +6066,8 @@
                 }
             },
             {
-                "id": 385941504,
+                "id": 1,
+                "full_id": 385941504,
                 "name": "Dominica",
                 "translations": {
                     "japanese": "ドミニカ国",
@@ -5908,7 +6118,8 @@
         },
         "regions": [
             {
-                "id": 402653184,
+                "id": 0,
+                "full_id": 402653184,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -5934,7 +6145,8 @@
                 }
             },
             {
-                "id": 402784256,
+                "id": 2,
+                "full_id": 402784256,
                 "name": "Distrito Nacional",
                 "translations": {
                     "japanese": "ディストリト・ナショナル首都圏",
@@ -5960,7 +6172,8 @@
                 }
             },
             {
-                "id": 402849792,
+                "id": 3,
+                "full_id": 402849792,
                 "name": "Azua",
                 "translations": {
                     "japanese": "アスア",
@@ -5986,7 +6199,8 @@
                 }
             },
             {
-                "id": 402915328,
+                "id": 4,
+                "full_id": 402915328,
                 "name": "Baoruco",
                 "translations": {
                     "japanese": "バオルコ",
@@ -6012,7 +6226,8 @@
                 }
             },
             {
-                "id": 402980864,
+                "id": 5,
+                "full_id": 402980864,
                 "name": "Barahona",
                 "translations": {
                     "japanese": "バラオナ",
@@ -6038,7 +6253,8 @@
                 }
             },
             {
-                "id": 403046400,
+                "id": 6,
+                "full_id": 403046400,
                 "name": "Dajabón",
                 "translations": {
                     "japanese": "ダハボン",
@@ -6064,7 +6280,8 @@
                 }
             },
             {
-                "id": 403111936,
+                "id": 7,
+                "full_id": 403111936,
                 "name": "Duarte",
                 "translations": {
                     "japanese": "ドゥアルテ",
@@ -6090,7 +6307,8 @@
                 }
             },
             {
-                "id": 403177472,
+                "id": 8,
+                "full_id": 403177472,
                 "name": "Espaillat",
                 "translations": {
                     "japanese": "エスパイジャト",
@@ -6116,7 +6334,8 @@
                 }
             },
             {
-                "id": 403243008,
+                "id": 9,
+                "full_id": 403243008,
                 "name": "Independencia",
                 "translations": {
                     "japanese": "インデペンデンシア",
@@ -6142,7 +6361,8 @@
                 }
             },
             {
-                "id": 403308544,
+                "id": 10,
+                "full_id": 403308544,
                 "name": "La Altagracia",
                 "translations": {
                     "japanese": "ラ・アルタグラシア",
@@ -6168,7 +6388,8 @@
                 }
             },
             {
-                "id": 403374080,
+                "id": 11,
+                "full_id": 403374080,
                 "name": "Elías Piña",
                 "translations": {
                     "japanese": "エリアス・ピーニャ",
@@ -6194,7 +6415,8 @@
                 }
             },
             {
-                "id": 403439616,
+                "id": 12,
+                "full_id": 403439616,
                 "name": "La Romana",
                 "translations": {
                     "japanese": "ラ・ロマーナ",
@@ -6220,7 +6442,8 @@
                 }
             },
             {
-                "id": 403505152,
+                "id": 13,
+                "full_id": 403505152,
                 "name": "María Trinidad Sánchez",
                 "translations": {
                     "japanese": "マリア・トリニダー・サンチェス",
@@ -6246,7 +6469,8 @@
                 }
             },
             {
-                "id": 403570688,
+                "id": 14,
+                "full_id": 403570688,
                 "name": "Monte Cristi",
                 "translations": {
                     "japanese": "モンテ・クリスティ",
@@ -6272,7 +6496,8 @@
                 }
             },
             {
-                "id": 403636224,
+                "id": 15,
+                "full_id": 403636224,
                 "name": "Pedernales",
                 "translations": {
                     "japanese": "ペデルナレス",
@@ -6298,7 +6523,8 @@
                 }
             },
             {
-                "id": 403701760,
+                "id": 1,
+                "full_id": 403701760,
                 "name": "Peravia",
                 "translations": {
                     "japanese": "ペラビア",
@@ -6324,7 +6550,8 @@
                 }
             },
             {
-                "id": 403767296,
+                "id": 17,
+                "full_id": 403767296,
                 "name": "Puerto Plata",
                 "translations": {
                     "japanese": "プエルト・プラタ",
@@ -6350,7 +6577,8 @@
                 }
             },
             {
-                "id": 403832832,
+                "id": 18,
+                "full_id": 403832832,
                 "name": "Salcedo",
                 "translations": {
                     "japanese": "サルセド",
@@ -6376,7 +6604,8 @@
                 }
             },
             {
-                "id": 403898368,
+                "id": 19,
+                "full_id": 403898368,
                 "name": "Samaná",
                 "translations": {
                     "japanese": "セマナ",
@@ -6402,7 +6631,8 @@
                 }
             },
             {
-                "id": 403963904,
+                "id": 20,
+                "full_id": 403963904,
                 "name": "Sánchez Ramírez",
                 "translations": {
                     "japanese": "サンチェス・ラミレス",
@@ -6428,7 +6658,8 @@
                 }
             },
             {
-                "id": 404029440,
+                "id": 21,
+                "full_id": 404029440,
                 "name": "San Juan",
                 "translations": {
                     "japanese": "サン・フアン",
@@ -6454,7 +6685,8 @@
                 }
             },
             {
-                "id": 404094976,
+                "id": 22,
+                "full_id": 404094976,
                 "name": "San Pedro de Macorís",
                 "translations": {
                     "japanese": "サン・ペドロ・デ・マコリス",
@@ -6480,7 +6712,8 @@
                 }
             },
             {
-                "id": 404160512,
+                "id": 23,
+                "full_id": 404160512,
                 "name": "Santiago",
                 "translations": {
                     "japanese": "サンティアゴ",
@@ -6506,7 +6739,8 @@
                 }
             },
             {
-                "id": 404226048,
+                "id": 24,
+                "full_id": 404226048,
                 "name": "Santiago Rodríguez",
                 "translations": {
                     "japanese": "サンティアゴ・ロドリゲス",
@@ -6532,7 +6766,8 @@
                 }
             },
             {
-                "id": 404291584,
+                "id": 25,
+                "full_id": 404291584,
                 "name": "Valverde",
                 "translations": {
                     "japanese": "バルベルデ",
@@ -6558,7 +6793,8 @@
                 }
             },
             {
-                "id": 404357120,
+                "id": 26,
+                "full_id": 404357120,
                 "name": "El Seíbo",
                 "translations": {
                     "japanese": "エル・セイボ",
@@ -6584,7 +6820,8 @@
                 }
             },
             {
-                "id": 404422656,
+                "id": 27,
+                "full_id": 404422656,
                 "name": "Hato Mayor",
                 "translations": {
                     "japanese": "アト・マジョール",
@@ -6610,7 +6847,8 @@
                 }
             },
             {
-                "id": 404488192,
+                "id": 28,
+                "full_id": 404488192,
                 "name": "La Vega",
                 "translations": {
                     "japanese": "ラ・ベガ",
@@ -6636,7 +6874,8 @@
                 }
             },
             {
-                "id": 404553728,
+                "id": 29,
+                "full_id": 404553728,
                 "name": "Monseñor Nouel",
                 "translations": {
                     "japanese": "モンセニョール・ノウエル",
@@ -6662,7 +6901,8 @@
                 }
             },
             {
-                "id": 404619264,
+                "id": 30,
+                "full_id": 404619264,
                 "name": "Monte Plata",
                 "translations": {
                     "japanese": "モンテ・プラタ",
@@ -6688,7 +6928,8 @@
                 }
             },
             {
-                "id": 404684800,
+                "id": 31,
+                "full_id": 404684800,
                 "name": "San Cristóbal",
                 "translations": {
                     "japanese": "サン・クリストバル",
@@ -6739,7 +6980,8 @@
         },
         "regions": [
             {
-                "id": 419430400,
+                "id": 0,
+                "full_id": 419430400,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -6765,7 +7007,8 @@
                 }
             },
             {
-                "id": 419561472,
+                "id": 2,
+                "full_id": 419561472,
                 "name": "Pichincha",
                 "translations": {
                     "japanese": "ピチンチャ",
@@ -6791,7 +7034,8 @@
                 }
             },
             {
-                "id": 419627008,
+                "id": 3,
+                "full_id": 419627008,
                 "name": "Galápagos",
                 "translations": {
                     "japanese": "ガラパゴス",
@@ -6817,7 +7061,8 @@
                 }
             },
             {
-                "id": 419692544,
+                "id": 4,
+                "full_id": 419692544,
                 "name": "Azuay",
                 "translations": {
                     "japanese": "アスアイ",
@@ -6843,7 +7088,8 @@
                 }
             },
             {
-                "id": 419758080,
+                "id": 5,
+                "full_id": 419758080,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル",
@@ -6869,7 +7115,8 @@
                 }
             },
             {
-                "id": 419823616,
+                "id": 6,
+                "full_id": 419823616,
                 "name": "Cañar",
                 "translations": {
                     "japanese": "カニャル",
@@ -6895,7 +7142,8 @@
                 }
             },
             {
-                "id": 419889152,
+                "id": 7,
+                "full_id": 419889152,
                 "name": "Carchi",
                 "translations": {
                     "japanese": "カルチ",
@@ -6921,7 +7169,8 @@
                 }
             },
             {
-                "id": 419954688,
+                "id": 8,
+                "full_id": 419954688,
                 "name": "Chimborazo",
                 "translations": {
                     "japanese": "チンボラソ",
@@ -6947,7 +7196,8 @@
                 }
             },
             {
-                "id": 420020224,
+                "id": 9,
+                "full_id": 420020224,
                 "name": "Cotopaxi",
                 "translations": {
                     "japanese": "コトパクシ",
@@ -6973,7 +7223,8 @@
                 }
             },
             {
-                "id": 420085760,
+                "id": 10,
+                "full_id": 420085760,
                 "name": "El Oro",
                 "translations": {
                     "japanese": "エル・オロ",
@@ -6999,7 +7250,8 @@
                 }
             },
             {
-                "id": 420151296,
+                "id": 11,
+                "full_id": 420151296,
                 "name": "Esmeraldas",
                 "translations": {
                     "japanese": "エスメラルダス",
@@ -7025,7 +7277,8 @@
                 }
             },
             {
-                "id": 420216832,
+                "id": 12,
+                "full_id": 420216832,
                 "name": "Guayas",
                 "translations": {
                     "japanese": "グアヤス",
@@ -7051,7 +7304,8 @@
                 }
             },
             {
-                "id": 420282368,
+                "id": 13,
+                "full_id": 420282368,
                 "name": "Imbabura",
                 "translations": {
                     "japanese": "インバブラ",
@@ -7077,7 +7331,8 @@
                 }
             },
             {
-                "id": 420347904,
+                "id": 14,
+                "full_id": 420347904,
                 "name": "Loja",
                 "translations": {
                     "japanese": "ロハ",
@@ -7103,7 +7358,8 @@
                 }
             },
             {
-                "id": 420413440,
+                "id": 15,
+                "full_id": 420413440,
                 "name": "Los Ríos",
                 "translations": {
                     "japanese": "ロス・リオス",
@@ -7129,7 +7385,8 @@
                 }
             },
             {
-                "id": 420478976,
+                "id": 1,
+                "full_id": 420478976,
                 "name": "Manabí",
                 "translations": {
                     "japanese": "マナビ",
@@ -7155,7 +7412,8 @@
                 }
             },
             {
-                "id": 420544512,
+                "id": 17,
+                "full_id": 420544512,
                 "name": "Morona-Santiago",
                 "translations": {
                     "japanese": "モロナ・サンティアゴ",
@@ -7181,7 +7439,8 @@
                 }
             },
             {
-                "id": 420610048,
+                "id": 18,
+                "full_id": 420610048,
                 "name": "Pastaza",
                 "translations": {
                     "japanese": "パスタサ",
@@ -7207,7 +7466,8 @@
                 }
             },
             {
-                "id": 420675584,
+                "id": 19,
+                "full_id": 420675584,
                 "name": "Tungurahua",
                 "translations": {
                     "japanese": "トゥングラワ",
@@ -7233,7 +7493,8 @@
                 }
             },
             {
-                "id": 420741120,
+                "id": 20,
+                "full_id": 420741120,
                 "name": "Zamora-Chinchipe",
                 "translations": {
                     "japanese": "サモラ・チンチペ",
@@ -7259,7 +7520,8 @@
                 }
             },
             {
-                "id": 420806656,
+                "id": 21,
+                "full_id": 420806656,
                 "name": "Sucumbios",
                 "translations": {
                     "japanese": "スクンビオス",
@@ -7285,7 +7547,8 @@
                 }
             },
             {
-                "id": 420872192,
+                "id": 22,
+                "full_id": 420872192,
                 "name": "Napo",
                 "translations": {
                     "japanese": "ナポ",
@@ -7311,7 +7574,8 @@
                 }
             },
             {
-                "id": 420937728,
+                "id": 23,
+                "full_id": 420937728,
                 "name": "Orellana",
                 "translations": {
                     "japanese": "オレリャナ",
@@ -7337,7 +7601,8 @@
                 }
             },
             {
-                "id": 421003264,
+                "id": 24,
+                "full_id": 421003264,
                 "name": "Santa Elena",
                 "translations": {
                     "japanese": "サンタ・エレーナ",
@@ -7363,7 +7628,8 @@
                 }
             },
             {
-                "id": 421068800,
+                "id": 25,
+                "full_id": 421068800,
                 "name": "Santo Domingo de los Tsáchilas",
                 "translations": {
                     "japanese": "サント・ドミンゴ・デ・ロス・ツァチラス",
@@ -7414,7 +7680,8 @@
         },
         "regions": [
             {
-                "id": 436207616,
+                "id": 0,
+                "full_id": 436207616,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -7440,7 +7707,8 @@
                 }
             },
             {
-                "id": 436338688,
+                "id": 2,
+                "full_id": 436338688,
                 "name": "San Salvador",
                 "translations": {
                     "japanese": "サン・サルバドル県",
@@ -7466,7 +7734,8 @@
                 }
             },
             {
-                "id": 436404224,
+                "id": 3,
+                "full_id": 436404224,
                 "name": "Ahuachapán",
                 "translations": {
                     "japanese": "アワチャパン県",
@@ -7492,7 +7761,8 @@
                 }
             },
             {
-                "id": 436469760,
+                "id": 4,
+                "full_id": 436469760,
                 "name": "Cabañas",
                 "translations": {
                     "japanese": "カバニャス県",
@@ -7518,7 +7788,8 @@
                 }
             },
             {
-                "id": 436535296,
+                "id": 5,
+                "full_id": 436535296,
                 "name": "Chalatenango",
                 "translations": {
                     "japanese": "チャラテナンゴ県",
@@ -7534,7 +7805,7 @@
                     "russian": "Чалатенанго",
                     "chinese_traditional": "Chalatenango",
                     "unknown1": "Chalatenango",
-                    "unknown2": "Chal얆徇᥄\udac7슃\udfd9榩",
+                    "unknown2": "Chalatenango",
                     "unknown3": "Chalatenango",
                     "unknown4": "Chalatenango"
                 },
@@ -7544,7 +7815,8 @@
                 }
             },
             {
-                "id": 436600832,
+                "id": 6,
+                "full_id": 436600832,
                 "name": "Cuscatlán",
                 "translations": {
                     "japanese": "クスカトラン県",
@@ -7570,7 +7842,8 @@
                 }
             },
             {
-                "id": 436666368,
+                "id": 7,
+                "full_id": 436666368,
                 "name": "La Libertad",
                 "translations": {
                     "japanese": "ラ・リベルター県",
@@ -7596,7 +7869,8 @@
                 }
             },
             {
-                "id": 436731904,
+                "id": 8,
+                "full_id": 436731904,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラパス県",
@@ -7622,7 +7896,8 @@
                 }
             },
             {
-                "id": 436797440,
+                "id": 9,
+                "full_id": 436797440,
                 "name": "La Unión",
                 "translations": {
                     "japanese": "ラ・ウニオン県",
@@ -7648,7 +7923,8 @@
                 }
             },
             {
-                "id": 436862976,
+                "id": 10,
+                "full_id": 436862976,
                 "name": "Morazán",
                 "translations": {
                     "japanese": "モラサン県",
@@ -7674,7 +7950,8 @@
                 }
             },
             {
-                "id": 436928512,
+                "id": 11,
+                "full_id": 436928512,
                 "name": "San Miguel",
                 "translations": {
                     "japanese": "サン・ミゲル県",
@@ -7700,7 +7977,8 @@
                 }
             },
             {
-                "id": 436994048,
+                "id": 12,
+                "full_id": 436994048,
                 "name": "Santa Ana",
                 "translations": {
                     "japanese": "サンタ・アナ県",
@@ -7726,7 +8004,8 @@
                 }
             },
             {
-                "id": 437059584,
+                "id": 13,
+                "full_id": 437059584,
                 "name": "San Vicente",
                 "translations": {
                     "japanese": "サンビセンテ県",
@@ -7752,7 +8031,8 @@
                 }
             },
             {
-                "id": 437125120,
+                "id": 14,
+                "full_id": 437125120,
                 "name": "Sonsonate",
                 "translations": {
                     "japanese": "ソンソナテ県",
@@ -7778,7 +8058,8 @@
                 }
             },
             {
-                "id": 437190656,
+                "id": 15,
+                "full_id": 437190656,
                 "name": "Usulután",
                 "translations": {
                     "japanese": "ウスルタン県",
@@ -7829,7 +8110,8 @@
         },
         "regions": [
             {
-                "id": 452984832,
+                "id": 0,
+                "full_id": 452984832,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -7855,7 +8137,8 @@
                 }
             },
             {
-                "id": 453050368,
+                "id": 1,
+                "full_id": 453050368,
                 "name": "French Guiana",
                 "translations": {
                     "japanese": "フランス領ギアナ",
@@ -7906,7 +8189,8 @@
         },
         "regions": [
             {
-                "id": 469762048,
+                "id": 0,
+                "full_id": 469762048,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -7932,7 +8216,8 @@
                 }
             },
             {
-                "id": 469827584,
+                "id": 1,
+                "full_id": 469827584,
                 "name": "Grenada",
                 "translations": {
                     "japanese": "グレナダ",
@@ -7983,7 +8268,8 @@
         },
         "regions": [
             {
-                "id": 486539264,
+                "id": 0,
+                "full_id": 486539264,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8009,7 +8295,8 @@
                 }
             },
             {
-                "id": 486604800,
+                "id": 1,
+                "full_id": 486604800,
                 "name": "Guadeloupe",
                 "translations": {
                     "japanese": "グアドループ",
@@ -8060,7 +8347,8 @@
         },
         "regions": [
             {
-                "id": 503316480,
+                "id": 0,
+                "full_id": 503316480,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8086,7 +8374,8 @@
                 }
             },
             {
-                "id": 503447552,
+                "id": 2,
+                "full_id": 503447552,
                 "name": "Guatemala",
                 "translations": {
                     "japanese": "グアテマラ県",
@@ -8112,7 +8401,8 @@
                 }
             },
             {
-                "id": 503513088,
+                "id": 3,
+                "full_id": 503513088,
                 "name": "Alta Verapaz",
                 "translations": {
                     "japanese": "アルタ・べラパス県",
@@ -8138,7 +8428,8 @@
                 }
             },
             {
-                "id": 503578624,
+                "id": 4,
+                "full_id": 503578624,
                 "name": "Baja Verapaz",
                 "translations": {
                     "japanese": "バハ・べラパス県",
@@ -8164,7 +8455,8 @@
                 }
             },
             {
-                "id": 503644160,
+                "id": 5,
+                "full_id": 503644160,
                 "name": "Chimaltenango",
                 "translations": {
                     "japanese": "チマルテナンゴ県",
@@ -8190,7 +8482,8 @@
                 }
             },
             {
-                "id": 503709696,
+                "id": 6,
+                "full_id": 503709696,
                 "name": "Chiquimula",
                 "translations": {
                     "japanese": "チキムラ県",
@@ -8216,7 +8509,8 @@
                 }
             },
             {
-                "id": 503775232,
+                "id": 7,
+                "full_id": 503775232,
                 "name": "El Progreso",
                 "translations": {
                     "japanese": "エル・プログレソ県",
@@ -8242,7 +8536,8 @@
                 }
             },
             {
-                "id": 503840768,
+                "id": 8,
+                "full_id": 503840768,
                 "name": "Escuintla",
                 "translations": {
                     "japanese": "エスクィントラ県",
@@ -8268,7 +8563,8 @@
                 }
             },
             {
-                "id": 503906304,
+                "id": 9,
+                "full_id": 503906304,
                 "name": "Huehuetenango",
                 "translations": {
                     "japanese": "ウェウェテナンゴ県",
@@ -8294,7 +8590,8 @@
                 }
             },
             {
-                "id": 503971840,
+                "id": 10,
+                "full_id": 503971840,
                 "name": "Izabal",
                 "translations": {
                     "japanese": "イザバル県",
@@ -8320,7 +8617,8 @@
                 }
             },
             {
-                "id": 504037376,
+                "id": 11,
+                "full_id": 504037376,
                 "name": "Jalapa",
                 "translations": {
                     "japanese": "ハラパ県",
@@ -8346,7 +8644,8 @@
                 }
             },
             {
-                "id": 504102912,
+                "id": 12,
+                "full_id": 504102912,
                 "name": "Jutiapa",
                 "translations": {
                     "japanese": "フティアパ県",
@@ -8372,7 +8671,8 @@
                 }
             },
             {
-                "id": 504168448,
+                "id": 13,
+                "full_id": 504168448,
                 "name": "Petén",
                 "translations": {
                     "japanese": "エル・ペテン県",
@@ -8398,7 +8698,8 @@
                 }
             },
             {
-                "id": 504233984,
+                "id": 14,
+                "full_id": 504233984,
                 "name": "Quetzaltenango",
                 "translations": {
                     "japanese": "ケツァルテナンゴ県",
@@ -8424,7 +8725,8 @@
                 }
             },
             {
-                "id": 504299520,
+                "id": 15,
+                "full_id": 504299520,
                 "name": "Quiché",
                 "translations": {
                     "japanese": "エル・キチェ県",
@@ -8450,7 +8752,8 @@
                 }
             },
             {
-                "id": 504365056,
+                "id": 1,
+                "full_id": 504365056,
                 "name": "Retalhuleu",
                 "translations": {
                     "japanese": "レタルーレウ県",
@@ -8476,7 +8779,8 @@
                 }
             },
             {
-                "id": 504430592,
+                "id": 17,
+                "full_id": 504430592,
                 "name": "Sacatepéquez",
                 "translations": {
                     "japanese": "サカテペケス県",
@@ -8502,7 +8806,8 @@
                 }
             },
             {
-                "id": 504496128,
+                "id": 18,
+                "full_id": 504496128,
                 "name": "San Marcos",
                 "translations": {
                     "japanese": "サン・マルコス県",
@@ -8528,7 +8833,8 @@
                 }
             },
             {
-                "id": 504561664,
+                "id": 19,
+                "full_id": 504561664,
                 "name": "Santa Rosa",
                 "translations": {
                     "japanese": "サンタ・ローサ県",
@@ -8554,7 +8860,8 @@
                 }
             },
             {
-                "id": 504627200,
+                "id": 20,
+                "full_id": 504627200,
                 "name": "Sololá",
                 "translations": {
                     "japanese": "ソロラ県",
@@ -8580,7 +8887,8 @@
                 }
             },
             {
-                "id": 504692736,
+                "id": 21,
+                "full_id": 504692736,
                 "name": "Suchitepéquez",
                 "translations": {
                     "japanese": "スチテペケス県",
@@ -8606,7 +8914,8 @@
                 }
             },
             {
-                "id": 504758272,
+                "id": 22,
+                "full_id": 504758272,
                 "name": "Totonicapán",
                 "translations": {
                     "japanese": "トトニカパン県",
@@ -8632,7 +8941,8 @@
                 }
             },
             {
-                "id": 504823808,
+                "id": 23,
+                "full_id": 504823808,
                 "name": "Zacapa",
                 "translations": {
                     "japanese": "サカパ県",
@@ -8683,7 +8993,8 @@
         },
         "regions": [
             {
-                "id": 520093696,
+                "id": 0,
+                "full_id": 520093696,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -8709,7 +9020,8 @@
                 }
             },
             {
-                "id": 520224768,
+                "id": 2,
+                "full_id": 520224768,
                 "name": "Demerara-Mahaica",
                 "translations": {
                     "japanese": "デメララ・マハイカ州",
@@ -8735,7 +9047,8 @@
                 }
             },
             {
-                "id": 520290304,
+                "id": 3,
+                "full_id": 520290304,
                 "name": "Barima-Waini",
                 "translations": {
                     "japanese": "バリマ・ワイニ州",
@@ -8761,7 +9074,8 @@
                 }
             },
             {
-                "id": 520355840,
+                "id": 4,
+                "full_id": 520355840,
                 "name": "Cuyuni-Mazaruni",
                 "translations": {
                     "japanese": "クユニ・マザルニ州",
@@ -8787,7 +9101,8 @@
                 }
             },
             {
-                "id": 520421376,
+                "id": 5,
+                "full_id": 520421376,
                 "name": "East Berbice-Corentyne",
                 "translations": {
                     "japanese": "東ベルビセ・コレンティネ州",
@@ -8813,7 +9128,8 @@
                 }
             },
             {
-                "id": 520486912,
+                "id": 6,
+                "full_id": 520486912,
                 "name": "Essequibo Islands-West Demerara",
                 "translations": {
                     "japanese": "エセキボ諸島・西デメララ州",
@@ -8839,7 +9155,8 @@
                 }
             },
             {
-                "id": 520552448,
+                "id": 7,
+                "full_id": 520552448,
                 "name": "Mahaica-Berbice",
                 "translations": {
                     "japanese": "マハイカ・ベルビセ州",
@@ -8865,7 +9182,8 @@
                 }
             },
             {
-                "id": 520617984,
+                "id": 8,
+                "full_id": 520617984,
                 "name": "Pomeroon-Supenaam",
                 "translations": {
                     "japanese": "ポメローン・スペナーム州",
@@ -8891,7 +9209,8 @@
                 }
             },
             {
-                "id": 520683520,
+                "id": 9,
+                "full_id": 520683520,
                 "name": "Potaro-Siparuni",
                 "translations": {
                     "japanese": "ポタロ・シパルニ州",
@@ -8917,7 +9236,8 @@
                 }
             },
             {
-                "id": 520749056,
+                "id": 10,
+                "full_id": 520749056,
                 "name": "Upper Demerara-Berbice",
                 "translations": {
                     "japanese": "アッパー・デメララ・ベルビセ州",
@@ -8943,7 +9263,8 @@
                 }
             },
             {
-                "id": 520814592,
+                "id": 11,
+                "full_id": 520814592,
                 "name": "Upper Takutu-Upper Essequibo",
                 "translations": {
                     "japanese": "アッパー・タクトゥ・アッパー・エセキボ州",
@@ -8994,7 +9315,8 @@
         },
         "regions": [
             {
-                "id": 536870912,
+                "id": 0,
+                "full_id": 536870912,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9020,7 +9342,8 @@
                 }
             },
             {
-                "id": 537001984,
+                "id": 2,
+                "full_id": 537001984,
                 "name": "Ouest",
                 "translations": {
                     "japanese": "西県",
@@ -9046,7 +9369,8 @@
                 }
             },
             {
-                "id": 537067520,
+                "id": 3,
+                "full_id": 537067520,
                 "name": "Nord-Ouest",
                 "translations": {
                     "japanese": "北西県",
@@ -9072,7 +9396,8 @@
                 }
             },
             {
-                "id": 537133056,
+                "id": 4,
+                "full_id": 537133056,
                 "name": "Artibonite",
                 "translations": {
                     "japanese": "アルティボニット県",
@@ -9098,7 +9423,8 @@
                 }
             },
             {
-                "id": 537198592,
+                "id": 5,
+                "full_id": 537198592,
                 "name": "Centre",
                 "translations": {
                     "japanese": "中央県",
@@ -9124,7 +9450,8 @@
                 }
             },
             {
-                "id": 537264128,
+                "id": 6,
+                "full_id": 537264128,
                 "name": "Grand'Anse",
                 "translations": {
                     "japanese": "湾岸県",
@@ -9150,7 +9477,8 @@
                 }
             },
             {
-                "id": 537329664,
+                "id": 7,
+                "full_id": 537329664,
                 "name": "Nord",
                 "translations": {
                     "japanese": "北県",
@@ -9176,7 +9504,8 @@
                 }
             },
             {
-                "id": 537395200,
+                "id": 8,
+                "full_id": 537395200,
                 "name": "Nord-Est",
                 "translations": {
                     "japanese": "北東県",
@@ -9202,7 +9531,8 @@
                 }
             },
             {
-                "id": 537460736,
+                "id": 9,
+                "full_id": 537460736,
                 "name": "Sud",
                 "translations": {
                     "japanese": "南県",
@@ -9228,7 +9558,8 @@
                 }
             },
             {
-                "id": 537526272,
+                "id": 10,
+                "full_id": 537526272,
                 "name": "Sud-Est",
                 "translations": {
                     "japanese": "南東県",
@@ -9254,7 +9585,8 @@
                 }
             },
             {
-                "id": 537591808,
+                "id": 11,
+                "full_id": 537591808,
                 "name": "Nippes",
                 "translations": {
                     "japanese": "ニップ県",
@@ -9305,7 +9637,8 @@
         },
         "regions": [
             {
-                "id": 553648128,
+                "id": 0,
+                "full_id": 553648128,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9331,11 +9664,12 @@
                 }
             },
             {
-                "id": 553779200,
-                "name": "Fr얆徇᥄\udac7슃\udfd9榩\ud822ﰕ\udcca䮍輝n",
+                "id": 2,
+                "full_id": 553779200,
+                "name": "Francisco Morazán",
                 "translations": {
                     "japanese": "フランシスコ・モラサン",
-                    "english": "Fr얆徇᥄\udac7슃\udfd9榩\ud822ﰕ\udcca䮍輝n",
+                    "english": "Francisco Morazán",
                     "french": "Francisco Morazán",
                     "german": "Francisco Morazán",
                     "italian": "Francisco Morazán",
@@ -9357,7 +9691,8 @@
                 }
             },
             {
-                "id": 553844736,
+                "id": 3,
+                "full_id": 553844736,
                 "name": "Atlántida",
                 "translations": {
                     "japanese": "アトランティダ",
@@ -9383,7 +9718,8 @@
                 }
             },
             {
-                "id": 553910272,
+                "id": 4,
+                "full_id": 553910272,
                 "name": "Choluteca",
                 "translations": {
                     "japanese": "チョルテカ",
@@ -9409,7 +9745,8 @@
                 }
             },
             {
-                "id": 553975808,
+                "id": 5,
+                "full_id": 553975808,
                 "name": "Colón",
                 "translations": {
                     "japanese": "コロン",
@@ -9435,7 +9772,8 @@
                 }
             },
             {
-                "id": 554041344,
+                "id": 6,
+                "full_id": 554041344,
                 "name": "Comayagua",
                 "translations": {
                     "japanese": "コマヤグア",
@@ -9461,7 +9799,8 @@
                 }
             },
             {
-                "id": 554106880,
+                "id": 7,
+                "full_id": 554106880,
                 "name": "Copán",
                 "translations": {
                     "japanese": "コパン",
@@ -9487,7 +9826,8 @@
                 }
             },
             {
-                "id": 554172416,
+                "id": 8,
+                "full_id": 554172416,
                 "name": "Cortés",
                 "translations": {
                     "japanese": "コルテス",
@@ -9513,7 +9853,8 @@
                 }
             },
             {
-                "id": 554237952,
+                "id": 9,
+                "full_id": 554237952,
                 "name": "El Paraíso",
                 "translations": {
                     "japanese": "エル・パライソ",
@@ -9539,7 +9880,8 @@
                 }
             },
             {
-                "id": 554303488,
+                "id": 10,
+                "full_id": 554303488,
                 "name": "Gracias a Dios",
                 "translations": {
                     "japanese": "グラシアス・ア・ディオス",
@@ -9565,7 +9907,8 @@
                 }
             },
             {
-                "id": 554369024,
+                "id": 11,
+                "full_id": 554369024,
                 "name": "Intibucá",
                 "translations": {
                     "japanese": "インティブカ",
@@ -9591,7 +9934,8 @@
                 }
             },
             {
-                "id": 554434560,
+                "id": 12,
+                "full_id": 554434560,
                 "name": "Islas de la Bahía",
                 "translations": {
                     "japanese": "イスラス・デ・ラ・バイア",
@@ -9617,7 +9961,8 @@
                 }
             },
             {
-                "id": 554500096,
+                "id": 13,
+                "full_id": 554500096,
                 "name": "La Paz",
                 "translations": {
                     "japanese": "ラ・パス",
@@ -9643,7 +9988,8 @@
                 }
             },
             {
-                "id": 554565632,
+                "id": 14,
+                "full_id": 554565632,
                 "name": "Lempira",
                 "translations": {
                     "japanese": "レンピラ",
@@ -9669,7 +10015,8 @@
                 }
             },
             {
-                "id": 554631168,
+                "id": 15,
+                "full_id": 554631168,
                 "name": "Ocotepeque",
                 "translations": {
                     "japanese": "オコテペケ",
@@ -9695,7 +10042,8 @@
                 }
             },
             {
-                "id": 554696704,
+                "id": 1,
+                "full_id": 554696704,
                 "name": "Olancho",
                 "translations": {
                     "japanese": "オランチョ",
@@ -9721,7 +10069,8 @@
                 }
             },
             {
-                "id": 554762240,
+                "id": 17,
+                "full_id": 554762240,
                 "name": "Santa Bárbara",
                 "translations": {
                     "japanese": "サンタ・バルバラ",
@@ -9747,7 +10096,8 @@
                 }
             },
             {
-                "id": 554827776,
+                "id": 18,
+                "full_id": 554827776,
                 "name": "Valle",
                 "translations": {
                     "japanese": "バジェ",
@@ -9773,7 +10123,8 @@
                 }
             },
             {
-                "id": 554893312,
+                "id": 19,
+                "full_id": 554893312,
                 "name": "Yoro",
                 "translations": {
                     "japanese": "ヨロ",
@@ -9824,7 +10175,8 @@
         },
         "regions": [
             {
-                "id": 570425344,
+                "id": 0,
+                "full_id": 570425344,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -9850,7 +10202,8 @@
                 }
             },
             {
-                "id": 570556416,
+                "id": 2,
+                "full_id": 570556416,
                 "name": "Saint Thomas",
                 "translations": {
                     "japanese": "セント・トーマス",
@@ -9876,7 +10229,8 @@
                 }
             },
             {
-                "id": 570621952,
+                "id": 3,
+                "full_id": 570621952,
                 "name": "Clarendon",
                 "translations": {
                     "japanese": "クラレンドン",
@@ -9902,7 +10256,8 @@
                 }
             },
             {
-                "id": 570687488,
+                "id": 4,
+                "full_id": 570687488,
                 "name": "Hanover",
                 "translations": {
                     "japanese": "ハノーバー",
@@ -9928,7 +10283,8 @@
                 }
             },
             {
-                "id": 570753024,
+                "id": 5,
+                "full_id": 570753024,
                 "name": "Manchester",
                 "translations": {
                     "japanese": "マンチェスター",
@@ -9954,7 +10310,8 @@
                 }
             },
             {
-                "id": 570818560,
+                "id": 6,
+                "full_id": 570818560,
                 "name": "Portland",
                 "translations": {
                     "japanese": "ポートランド",
@@ -9980,7 +10337,8 @@
                 }
             },
             {
-                "id": 570884096,
+                "id": 7,
+                "full_id": 570884096,
                 "name": "Saint Andrew",
                 "translations": {
                     "japanese": "セント・アンドリュー",
@@ -10006,7 +10364,8 @@
                 }
             },
             {
-                "id": 570949632,
+                "id": 8,
+                "full_id": 570949632,
                 "name": "Saint Ann",
                 "translations": {
                     "japanese": "セント・アン",
@@ -10032,7 +10391,8 @@
                 }
             },
             {
-                "id": 571015168,
+                "id": 9,
+                "full_id": 571015168,
                 "name": "Saint Catherine",
                 "translations": {
                     "japanese": "セント・キャサリン",
@@ -10058,7 +10418,8 @@
                 }
             },
             {
-                "id": 571080704,
+                "id": 10,
+                "full_id": 571080704,
                 "name": "Saint Elizabeth",
                 "translations": {
                     "japanese": "セント・エリザベス",
@@ -10084,7 +10445,8 @@
                 }
             },
             {
-                "id": 571146240,
+                "id": 11,
+                "full_id": 571146240,
                 "name": "Saint James",
                 "translations": {
                     "japanese": "セント・ジェームズ",
@@ -10110,7 +10472,8 @@
                 }
             },
             {
-                "id": 571211776,
+                "id": 12,
+                "full_id": 571211776,
                 "name": "Saint Mary",
                 "translations": {
                     "japanese": "セント・メアリー",
@@ -10136,7 +10499,8 @@
                 }
             },
             {
-                "id": 571277312,
+                "id": 13,
+                "full_id": 571277312,
                 "name": "Trelawny",
                 "translations": {
                     "japanese": "トレローニー",
@@ -10162,13 +10526,14 @@
                 }
             },
             {
-                "id": 571342848,
+                "id": 14,
+                "full_id": 571342848,
                 "name": "Westmoreland",
                 "translations": {
                     "japanese": "ウェストモアランド",
                     "english": "Westmoreland",
                     "french": "Westmoreland",
-                    "german": "Westmoreland얆徇᥄\udac7",
+                    "german": "Westmoreland",
                     "italian": "Westmoreland",
                     "spanish": "Westmoreland",
                     "chinese_simple": "西摩兰区",
@@ -10188,7 +10553,8 @@
                 }
             },
             {
-                "id": 571408384,
+                "id": 15,
+                "full_id": 571408384,
                 "name": "Kingston",
                 "translations": {
                     "japanese": "キングストン",
@@ -10239,7 +10605,8 @@
         },
         "regions": [
             {
-                "id": 587202560,
+                "id": 0,
+                "full_id": 587202560,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -10265,7 +10632,8 @@
                 }
             },
             {
-                "id": 587268096,
+                "id": 1,
+                "full_id": 587268096,
                 "name": "Martinique",
                 "translations": {
                     "japanese": "マルティニーク",
@@ -10316,7 +10684,8 @@
         },
         "regions": [
             {
-                "id": 603979776,
+                "id": 0,
+                "full_id": 603979776,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -10342,7 +10711,8 @@
                 }
             },
             {
-                "id": 604110848,
+                "id": 2,
+                "full_id": 604110848,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト・フェデラル連邦区",
@@ -10368,7 +10738,8 @@
                 }
             },
             {
-                "id": 604176384,
+                "id": 3,
+                "full_id": 604176384,
                 "name": "Aguascalientes",
                 "translations": {
                     "japanese": "アグアスカリエンテス州",
@@ -10394,7 +10765,8 @@
                 }
             },
             {
-                "id": 604241920,
+                "id": 4,
+                "full_id": 604241920,
                 "name": "Baja California",
                 "translations": {
                     "japanese": "バハ・カリフォルニア州",
@@ -10420,7 +10792,8 @@
                 }
             },
             {
-                "id": 604307456,
+                "id": 5,
+                "full_id": 604307456,
                 "name": "Baja California Sur",
                 "translations": {
                     "japanese": "バハ・カリフォルニア・スル州",
@@ -10446,7 +10819,8 @@
                 }
             },
             {
-                "id": 604372992,
+                "id": 6,
+                "full_id": 604372992,
                 "name": "Campeche",
                 "translations": {
                     "japanese": "カンペチェ州",
@@ -10472,7 +10846,8 @@
                 }
             },
             {
-                "id": 604438528,
+                "id": 7,
+                "full_id": 604438528,
                 "name": "Chiapas",
                 "translations": {
                     "japanese": "チアパス州",
@@ -10498,7 +10873,8 @@
                 }
             },
             {
-                "id": 604504064,
+                "id": 8,
+                "full_id": 604504064,
                 "name": "Chihuahua",
                 "translations": {
                     "japanese": "チワワ州",
@@ -10524,7 +10900,8 @@
                 }
             },
             {
-                "id": 604569600,
+                "id": 9,
+                "full_id": 604569600,
                 "name": "Coahuila de Zaragoza",
                 "translations": {
                     "japanese": "コアウイラ州",
@@ -10550,7 +10927,8 @@
                 }
             },
             {
-                "id": 604635136,
+                "id": 10,
+                "full_id": 604635136,
                 "name": "Colima",
                 "translations": {
                     "japanese": "コリマ州",
@@ -10576,7 +10954,8 @@
                 }
             },
             {
-                "id": 604700672,
+                "id": 11,
+                "full_id": 604700672,
                 "name": "Durango",
                 "translations": {
                     "japanese": "ドゥランゴ州",
@@ -10602,7 +10981,8 @@
                 }
             },
             {
-                "id": 604766208,
+                "id": 12,
+                "full_id": 604766208,
                 "name": "Guanajuato",
                 "translations": {
                     "japanese": "グアナフアト州",
@@ -10628,7 +11008,8 @@
                 }
             },
             {
-                "id": 604831744,
+                "id": 13,
+                "full_id": 604831744,
                 "name": "Guerrero",
                 "translations": {
                     "japanese": "ゲレロ州",
@@ -10654,7 +11035,8 @@
                 }
             },
             {
-                "id": 604897280,
+                "id": 14,
+                "full_id": 604897280,
                 "name": "Hidalgo",
                 "translations": {
                     "japanese": "イダルゴ州",
@@ -10680,7 +11062,8 @@
                 }
             },
             {
-                "id": 604962816,
+                "id": 15,
+                "full_id": 604962816,
                 "name": "Jalisco",
                 "translations": {
                     "japanese": "ハリスコ州",
@@ -10706,7 +11089,8 @@
                 }
             },
             {
-                "id": 605028352,
+                "id": 1,
+                "full_id": 605028352,
                 "name": "México",
                 "translations": {
                     "japanese": "メヒコ州",
@@ -10732,7 +11116,8 @@
                 }
             },
             {
-                "id": 605093888,
+                "id": 17,
+                "full_id": 605093888,
                 "name": "Michoacán de Ocampo",
                 "translations": {
                     "japanese": "ミチョアカン州",
@@ -10758,7 +11143,8 @@
                 }
             },
             {
-                "id": 605159424,
+                "id": 18,
+                "full_id": 605159424,
                 "name": "Morelos",
                 "translations": {
                     "japanese": "モレロス州",
@@ -10784,7 +11170,8 @@
                 }
             },
             {
-                "id": 605224960,
+                "id": 19,
+                "full_id": 605224960,
                 "name": "Nayarit",
                 "translations": {
                     "japanese": "ナヤリット州",
@@ -10810,7 +11197,8 @@
                 }
             },
             {
-                "id": 605290496,
+                "id": 20,
+                "full_id": 605290496,
                 "name": "Nuevo León",
                 "translations": {
                     "japanese": "ヌエボ・レオン州",
@@ -10836,7 +11224,8 @@
                 }
             },
             {
-                "id": 605356032,
+                "id": 21,
+                "full_id": 605356032,
                 "name": "Oaxaca",
                 "translations": {
                     "japanese": "オアハカ州",
@@ -10862,7 +11251,8 @@
                 }
             },
             {
-                "id": 605421568,
+                "id": 22,
+                "full_id": 605421568,
                 "name": "Puebla",
                 "translations": {
                     "japanese": "プエブラ州",
@@ -10888,7 +11278,8 @@
                 }
             },
             {
-                "id": 605487104,
+                "id": 23,
+                "full_id": 605487104,
                 "name": "Querétaro de Arteaga",
                 "translations": {
                     "japanese": "ケレタロ州",
@@ -10914,7 +11305,8 @@
                 }
             },
             {
-                "id": 605552640,
+                "id": 24,
+                "full_id": 605552640,
                 "name": "Quintana Roo",
                 "translations": {
                     "japanese": "キンタナ・ロー州",
@@ -10940,7 +11332,8 @@
                 }
             },
             {
-                "id": 605618176,
+                "id": 25,
+                "full_id": 605618176,
                 "name": "San Luis Potosí",
                 "translations": {
                     "japanese": "サン・ルイス・ポトシ州",
@@ -10966,7 +11359,8 @@
                 }
             },
             {
-                "id": 605683712,
+                "id": 26,
+                "full_id": 605683712,
                 "name": "Sinaloa",
                 "translations": {
                     "japanese": "シナロア州",
@@ -10992,7 +11386,8 @@
                 }
             },
             {
-                "id": 605749248,
+                "id": 27,
+                "full_id": 605749248,
                 "name": "Sonora",
                 "translations": {
                     "japanese": "ソノラ州",
@@ -11018,7 +11413,8 @@
                 }
             },
             {
-                "id": 605814784,
+                "id": 28,
+                "full_id": 605814784,
                 "name": "Tabasco",
                 "translations": {
                     "japanese": "タバスコ州",
@@ -11044,7 +11440,8 @@
                 }
             },
             {
-                "id": 605880320,
+                "id": 29,
+                "full_id": 605880320,
                 "name": "Tamaulipas",
                 "translations": {
                     "japanese": "タマウリパス州",
@@ -11070,7 +11467,8 @@
                 }
             },
             {
-                "id": 605945856,
+                "id": 30,
+                "full_id": 605945856,
                 "name": "Tlaxcala",
                 "translations": {
                     "japanese": "トラスカラ州",
@@ -11096,7 +11494,8 @@
                 }
             },
             {
-                "id": 606011392,
+                "id": 31,
+                "full_id": 606011392,
                 "name": "Veracruz-Llave",
                 "translations": {
                     "japanese": "ベラクルス州",
@@ -11122,7 +11521,8 @@
                 }
             },
             {
-                "id": 606076928,
+                "id": 2,
+                "full_id": 606076928,
                 "name": "Yucatán",
                 "translations": {
                     "japanese": "ユカタン州",
@@ -11148,7 +11548,8 @@
                 }
             },
             {
-                "id": 606142464,
+                "id": 33,
+                "full_id": 606142464,
                 "name": "Zacatecas",
                 "translations": {
                     "japanese": "サカテカス州",
@@ -11199,7 +11600,8 @@
         },
         "regions": [
             {
-                "id": 620756992,
+                "id": 0,
+                "full_id": 620756992,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11225,7 +11627,8 @@
                 }
             },
             {
-                "id": 620822528,
+                "id": 1,
+                "full_id": 620822528,
                 "name": "Montserrat",
                 "translations": {
                     "japanese": "モントセラト",
@@ -11276,7 +11679,8 @@
         },
         "regions": [
             {
-                "id": 637534208,
+                "id": 0,
+                "full_id": 637534208,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11302,7 +11706,8 @@
                 }
             },
             {
-                "id": 637599744,
+                "id": 1,
+                "full_id": 637599744,
                 "name": "Netherlands Antilles",
                 "translations": {
                     "japanese": "オランダ領アンティル",
@@ -11353,7 +11758,8 @@
         },
         "regions": [
             {
-                "id": 654311424,
+                "id": 0,
+                "full_id": 654311424,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11379,7 +11785,8 @@
                 }
             },
             {
-                "id": 654442496,
+                "id": 2,
+                "full_id": 654442496,
                 "name": "Managua",
                 "translations": {
                     "japanese": "マナグア",
@@ -11405,7 +11812,8 @@
                 }
             },
             {
-                "id": 654508032,
+                "id": 3,
+                "full_id": 654508032,
                 "name": "Boaco",
                 "translations": {
                     "japanese": "ボアコ",
@@ -11431,7 +11839,8 @@
                 }
             },
             {
-                "id": 654573568,
+                "id": 4,
+                "full_id": 654573568,
                 "name": "Carazo",
                 "translations": {
                     "japanese": "カラソ",
@@ -11457,7 +11866,8 @@
                 }
             },
             {
-                "id": 654639104,
+                "id": 5,
+                "full_id": 654639104,
                 "name": "Chinandega",
                 "translations": {
                     "japanese": "チナンデガ",
@@ -11483,7 +11893,8 @@
                 }
             },
             {
-                "id": 654704640,
+                "id": 6,
+                "full_id": 654704640,
                 "name": "Chontales",
                 "translations": {
                     "japanese": "チョンタレス",
@@ -11509,7 +11920,8 @@
                 }
             },
             {
-                "id": 654770176,
+                "id": 7,
+                "full_id": 654770176,
                 "name": "Estelí",
                 "translations": {
                     "japanese": "エステリ",
@@ -11535,7 +11947,8 @@
                 }
             },
             {
-                "id": 654835712,
+                "id": 8,
+                "full_id": 654835712,
                 "name": "Granada",
                 "translations": {
                     "japanese": "グラナダ",
@@ -11561,7 +11974,8 @@
                 }
             },
             {
-                "id": 654901248,
+                "id": 9,
+                "full_id": 654901248,
                 "name": "Jinotega",
                 "translations": {
                     "japanese": "ヒノテガ",
@@ -11587,7 +12001,8 @@
                 }
             },
             {
-                "id": 654966784,
+                "id": 10,
+                "full_id": 654966784,
                 "name": "León",
                 "translations": {
                     "japanese": "レオン",
@@ -11613,7 +12028,8 @@
                 }
             },
             {
-                "id": 655032320,
+                "id": 11,
+                "full_id": 655032320,
                 "name": "Madriz",
                 "translations": {
                     "japanese": "マドリス",
@@ -11639,7 +12055,8 @@
                 }
             },
             {
-                "id": 655097856,
+                "id": 12,
+                "full_id": 655097856,
                 "name": "Masaya",
                 "translations": {
                     "japanese": "マサヤ",
@@ -11665,7 +12082,8 @@
                 }
             },
             {
-                "id": 655163392,
+                "id": 13,
+                "full_id": 655163392,
                 "name": "Matagalpa",
                 "translations": {
                     "japanese": "マタガルパ",
@@ -11691,7 +12109,8 @@
                 }
             },
             {
-                "id": 655228928,
+                "id": 14,
+                "full_id": 655228928,
                 "name": "Nueva Segovia",
                 "translations": {
                     "japanese": "ヌエバ・セゴビア",
@@ -11717,7 +12136,8 @@
                 }
             },
             {
-                "id": 655294464,
+                "id": 15,
+                "full_id": 655294464,
                 "name": "Río San Juan",
                 "translations": {
                     "japanese": "リオ・サン・フアン",
@@ -11743,7 +12163,8 @@
                 }
             },
             {
-                "id": 655360000,
+                "id": 1,
+                "full_id": 655360000,
                 "name": "Rivas",
                 "translations": {
                     "japanese": "リバス",
@@ -11769,7 +12190,8 @@
                 }
             },
             {
-                "id": 655425536,
+                "id": 17,
+                "full_id": 655425536,
                 "name": "Atlántico Norte",
                 "translations": {
                     "japanese": "北アトランティコ自治地域",
@@ -11795,7 +12217,8 @@
                 }
             },
             {
-                "id": 655491072,
+                "id": 18,
+                "full_id": 655491072,
                 "name": "Atlántico Sur",
                 "translations": {
                     "japanese": "南アトランティコ自治地域",
@@ -11846,7 +12269,8 @@
         },
         "regions": [
             {
-                "id": 671088640,
+                "id": 0,
+                "full_id": 671088640,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -11872,7 +12296,8 @@
                 }
             },
             {
-                "id": 671219712,
+                "id": 2,
+                "full_id": 671219712,
                 "name": "Panamá",
                 "translations": {
                     "japanese": "パナマ",
@@ -11898,7 +12323,8 @@
                 }
             },
             {
-                "id": 671285248,
+                "id": 3,
+                "full_id": 671285248,
                 "name": "Bocas del Toro",
                 "translations": {
                     "japanese": "ボカズ・デル・トーロ",
@@ -11924,7 +12350,8 @@
                 }
             },
             {
-                "id": 671350784,
+                "id": 4,
+                "full_id": 671350784,
                 "name": "Chiriquí",
                 "translations": {
                     "japanese": "チリキ",
@@ -11950,7 +12377,8 @@
                 }
             },
             {
-                "id": 671416320,
+                "id": 5,
+                "full_id": 671416320,
                 "name": "Coclé",
                 "translations": {
                     "japanese": "コクレ",
@@ -11976,7 +12404,8 @@
                 }
             },
             {
-                "id": 671481856,
+                "id": 6,
+                "full_id": 671481856,
                 "name": "Colón",
                 "translations": {
                     "japanese": "コロン",
@@ -12002,7 +12431,8 @@
                 }
             },
             {
-                "id": 671547392,
+                "id": 7,
+                "full_id": 671547392,
                 "name": "Darién",
                 "translations": {
                     "japanese": "ダリエン",
@@ -12028,7 +12458,8 @@
                 }
             },
             {
-                "id": 671612928,
+                "id": 8,
+                "full_id": 671612928,
                 "name": "Herrera",
                 "translations": {
                     "japanese": "エレーラ",
@@ -12054,7 +12485,8 @@
                 }
             },
             {
-                "id": 671678464,
+                "id": 9,
+                "full_id": 671678464,
                 "name": "Los Santos",
                 "translations": {
                     "japanese": "ロス・サントス",
@@ -12080,7 +12512,8 @@
                 }
             },
             {
-                "id": 671744000,
+                "id": 10,
+                "full_id": 671744000,
                 "name": "Kuna Yala",
                 "translations": {
                     "japanese": "サンブラス諸島",
@@ -12106,7 +12539,8 @@
                 }
             },
             {
-                "id": 671809536,
+                "id": 11,
+                "full_id": 671809536,
                 "name": "Veraguas",
                 "translations": {
                     "japanese": "ベラグアス",
@@ -12157,7 +12591,8 @@
         },
         "regions": [
             {
-                "id": 687865856,
+                "id": 0,
+                "full_id": 687865856,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -12183,7 +12618,8 @@
                 }
             },
             {
-                "id": 687996928,
+                "id": 2,
+                "full_id": 687996928,
                 "name": "Central",
                 "translations": {
                     "japanese": "セントラル県",
@@ -12209,7 +12645,8 @@
                 }
             },
             {
-                "id": 688062464,
+                "id": 3,
+                "full_id": 688062464,
                 "name": "Alto Paraná",
                 "translations": {
                     "japanese": "アルト・パラナ県",
@@ -12235,7 +12672,8 @@
                 }
             },
             {
-                "id": 688128000,
+                "id": 4,
+                "full_id": 688128000,
                 "name": "Amambay",
                 "translations": {
                     "japanese": "アマンバイ県",
@@ -12261,7 +12699,8 @@
                 }
             },
             {
-                "id": 688193536,
+                "id": 5,
+                "full_id": 688193536,
                 "name": "Caaguazú",
                 "translations": {
                     "japanese": "カアグアスー県",
@@ -12287,7 +12726,8 @@
                 }
             },
             {
-                "id": 688259072,
+                "id": 6,
+                "full_id": 688259072,
                 "name": "Caazapá",
                 "translations": {
                     "japanese": "カアサパ県",
@@ -12313,7 +12753,8 @@
                 }
             },
             {
-                "id": 688324608,
+                "id": 7,
+                "full_id": 688324608,
                 "name": "Concepción",
                 "translations": {
                     "japanese": "コンセプシオン県",
@@ -12339,7 +12780,8 @@
                 }
             },
             {
-                "id": 688390144,
+                "id": 8,
+                "full_id": 688390144,
                 "name": "Cordillera",
                 "translations": {
                     "japanese": "コルディリェラ県",
@@ -12365,7 +12807,8 @@
                 }
             },
             {
-                "id": 688455680,
+                "id": 9,
+                "full_id": 688455680,
                 "name": "Guairá",
                 "translations": {
                     "japanese": "グアイラー県",
@@ -12391,7 +12834,8 @@
                 }
             },
             {
-                "id": 688521216,
+                "id": 10,
+                "full_id": 688521216,
                 "name": "Itapúa",
                 "translations": {
                     "japanese": "イタプア県",
@@ -12417,7 +12861,8 @@
                 }
             },
             {
-                "id": 688586752,
+                "id": 11,
+                "full_id": 688586752,
                 "name": "Misiones",
                 "translations": {
                     "japanese": "ミシオネス県",
@@ -12443,7 +12888,8 @@
                 }
             },
             {
-                "id": 688652288,
+                "id": 12,
+                "full_id": 688652288,
                 "name": "Ñeembucú",
                 "translations": {
                     "japanese": "ニェエンブク県",
@@ -12469,7 +12915,8 @@
                 }
             },
             {
-                "id": 688717824,
+                "id": 13,
+                "full_id": 688717824,
                 "name": "Paraguarí",
                 "translations": {
                     "japanese": "パラグアリ県",
@@ -12495,7 +12942,8 @@
                 }
             },
             {
-                "id": 688783360,
+                "id": 14,
+                "full_id": 688783360,
                 "name": "Presidente Hayes",
                 "translations": {
                     "japanese": "プレジデンテ・アエス県",
@@ -12521,7 +12969,8 @@
                 }
             },
             {
-                "id": 688848896,
+                "id": 15,
+                "full_id": 688848896,
                 "name": "San Pedro",
                 "translations": {
                     "japanese": "サン・ペドロ県",
@@ -12547,7 +12996,8 @@
                 }
             },
             {
-                "id": 688914432,
+                "id": 1,
+                "full_id": 688914432,
                 "name": "Canindeyú",
                 "translations": {
                     "japanese": "カニンデジュ県",
@@ -12573,7 +13023,8 @@
                 }
             },
             {
-                "id": 688979968,
+                "id": 17,
+                "full_id": 688979968,
                 "name": "Asunción",
                 "translations": {
                     "japanese": "アスンシオン市",
@@ -12599,7 +13050,8 @@
                 }
             },
             {
-                "id": 689045504,
+                "id": 18,
+                "full_id": 689045504,
                 "name": "Alto Paraguay",
                 "translations": {
                     "japanese": "アルト・パラグアイ県",
@@ -12625,7 +13077,8 @@
                 }
             },
             {
-                "id": 689111040,
+                "id": 19,
+                "full_id": 689111040,
                 "name": "Boquerón",
                 "translations": {
                     "japanese": "ボケロン県",
@@ -12676,7 +13129,8 @@
         },
         "regions": [
             {
-                "id": 704643072,
+                "id": 0,
+                "full_id": 704643072,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -12702,7 +13156,8 @@
                 }
             },
             {
-                "id": 704774144,
+                "id": 2,
+                "full_id": 704774144,
                 "name": "Lima",
                 "translations": {
                     "japanese": "リマ",
@@ -12728,7 +13183,8 @@
                 }
             },
             {
-                "id": 704839680,
+                "id": 3,
+                "full_id": 704839680,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス",
@@ -12754,7 +13210,8 @@
                 }
             },
             {
-                "id": 704905216,
+                "id": 4,
+                "full_id": 704905216,
                 "name": "Ancash",
                 "translations": {
                     "japanese": "アンカッシュ",
@@ -12780,7 +13237,8 @@
                 }
             },
             {
-                "id": 704970752,
+                "id": 5,
+                "full_id": 704970752,
                 "name": "Apurímac",
                 "translations": {
                     "japanese": "アプリマック",
@@ -12806,7 +13264,8 @@
                 }
             },
             {
-                "id": 705036288,
+                "id": 6,
+                "full_id": 705036288,
                 "name": "Arequipa",
                 "translations": {
                     "japanese": "アレキパ",
@@ -12832,7 +13291,8 @@
                 }
             },
             {
-                "id": 705101824,
+                "id": 7,
+                "full_id": 705101824,
                 "name": "Ayacucho",
                 "translations": {
                     "japanese": "アヤクーチョ",
@@ -12858,7 +13318,8 @@
                 }
             },
             {
-                "id": 705167360,
+                "id": 8,
+                "full_id": 705167360,
                 "name": "Cajamarca",
                 "translations": {
                     "japanese": "カハマルカ",
@@ -12884,7 +13345,8 @@
                 }
             },
             {
-                "id": 705232896,
+                "id": 9,
+                "full_id": 705232896,
                 "name": "Callao",
                 "translations": {
                     "japanese": "カヤオ",
@@ -12910,7 +13372,8 @@
                 }
             },
             {
-                "id": 705298432,
+                "id": 10,
+                "full_id": 705298432,
                 "name": "Cuzco",
                 "translations": {
                     "japanese": "クスコ",
@@ -12936,7 +13399,8 @@
                 }
             },
             {
-                "id": 705363968,
+                "id": 11,
+                "full_id": 705363968,
                 "name": "Huancavelica",
                 "translations": {
                     "japanese": "ワンカベリカ",
@@ -12962,7 +13426,8 @@
                 }
             },
             {
-                "id": 705429504,
+                "id": 12,
+                "full_id": 705429504,
                 "name": "Huánuco",
                 "translations": {
                     "japanese": "ワヌコ",
@@ -12988,7 +13453,8 @@
                 }
             },
             {
-                "id": 705495040,
+                "id": 13,
+                "full_id": 705495040,
                 "name": "Ica",
                 "translations": {
                     "japanese": "イカ",
@@ -13014,7 +13480,8 @@
                 }
             },
             {
-                "id": 705560576,
+                "id": 14,
+                "full_id": 705560576,
                 "name": "Junín",
                 "translations": {
                     "japanese": "フニン",
@@ -13040,7 +13507,8 @@
                 }
             },
             {
-                "id": 705626112,
+                "id": 15,
+                "full_id": 705626112,
                 "name": "La Libertad",
                 "translations": {
                     "japanese": "ラ・リベルター",
@@ -13066,7 +13534,8 @@
                 }
             },
             {
-                "id": 705691648,
+                "id": 1,
+                "full_id": 705691648,
                 "name": "Lambayeque",
                 "translations": {
                     "japanese": "ランバイェケ",
@@ -13092,7 +13561,8 @@
                 }
             },
             {
-                "id": 705757184,
+                "id": 17,
+                "full_id": 705757184,
                 "name": "Loreto",
                 "translations": {
                     "japanese": "ロレト",
@@ -13118,7 +13588,8 @@
                 }
             },
             {
-                "id": 705822720,
+                "id": 18,
+                "full_id": 705822720,
                 "name": "Madre de Dios",
                 "translations": {
                     "japanese": "マドレ・デ・ディオス",
@@ -13144,7 +13615,8 @@
                 }
             },
             {
-                "id": 705888256,
+                "id": 19,
+                "full_id": 705888256,
                 "name": "Moquegua",
                 "translations": {
                     "japanese": "モケグア",
@@ -13170,7 +13642,8 @@
                 }
             },
             {
-                "id": 705953792,
+                "id": 20,
+                "full_id": 705953792,
                 "name": "Pasco",
                 "translations": {
                     "japanese": "パスコ",
@@ -13196,7 +13669,8 @@
                 }
             },
             {
-                "id": 706019328,
+                "id": 21,
+                "full_id": 706019328,
                 "name": "Piura",
                 "translations": {
                     "japanese": "ピウラ",
@@ -13222,7 +13696,8 @@
                 }
             },
             {
-                "id": 706084864,
+                "id": 22,
+                "full_id": 706084864,
                 "name": "Puno",
                 "translations": {
                     "japanese": "プーノ",
@@ -13248,7 +13723,8 @@
                 }
             },
             {
-                "id": 706150400,
+                "id": 23,
+                "full_id": 706150400,
                 "name": "San Martín",
                 "translations": {
                     "japanese": "サン・マルティン",
@@ -13274,7 +13750,8 @@
                 }
             },
             {
-                "id": 706215936,
+                "id": 24,
+                "full_id": 706215936,
                 "name": "Tacna",
                 "translations": {
                     "japanese": "タクナ",
@@ -13300,7 +13777,8 @@
                 }
             },
             {
-                "id": 706281472,
+                "id": 25,
+                "full_id": 706281472,
                 "name": "Tumbes",
                 "translations": {
                     "japanese": "トゥンベス",
@@ -13326,7 +13804,8 @@
                 }
             },
             {
-                "id": 706347008,
+                "id": 26,
+                "full_id": 706347008,
                 "name": "Ucayali",
                 "translations": {
                     "japanese": "ウカヤリ",
@@ -13377,7 +13856,8 @@
         },
         "regions": [
             {
-                "id": 721420288,
+                "id": 0,
+                "full_id": 721420288,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13403,7 +13883,8 @@
                 }
             },
             {
-                "id": 721551360,
+                "id": 2,
+                "full_id": 721551360,
                 "name": "Saint George Basseterre",
                 "translations": {
                     "japanese": "セント・ジョージ・バセテール",
@@ -13429,7 +13910,8 @@
                 }
             },
             {
-                "id": 721616896,
+                "id": 3,
+                "full_id": 721616896,
                 "name": "Christ Church Nichola Town",
                 "translations": {
                     "japanese": "クライスト・チャーチ・ニコラタウン",
@@ -13455,7 +13937,8 @@
                 }
             },
             {
-                "id": 721682432,
+                "id": 4,
+                "full_id": 721682432,
                 "name": "Saint Anne Sandy Point",
                 "translations": {
                     "japanese": "セント・アン・サンディ・ポイント",
@@ -13481,7 +13964,8 @@
                 }
             },
             {
-                "id": 721747968,
+                "id": 5,
+                "full_id": 721747968,
                 "name": "Saint George Gingerland",
                 "translations": {
                     "japanese": "セント・ジョージ・ジンジャーランド",
@@ -13507,7 +13991,8 @@
                 }
             },
             {
-                "id": 721813504,
+                "id": 6,
+                "full_id": 721813504,
                 "name": "Saint James Windward",
                 "translations": {
                     "japanese": "セント・ジェームズ・ウィンドワード",
@@ -13533,7 +14018,8 @@
                 }
             },
             {
-                "id": 721879040,
+                "id": 7,
+                "full_id": 721879040,
                 "name": "Saint John Capesterre",
                 "translations": {
                     "japanese": "セント・ジョン・カピステール",
@@ -13559,7 +14045,8 @@
                 }
             },
             {
-                "id": 721944576,
+                "id": 8,
+                "full_id": 721944576,
                 "name": "Saint John Figtree",
                 "translations": {
                     "japanese": "セント・ジョン・フィッグトリー",
@@ -13585,7 +14072,8 @@
                 }
             },
             {
-                "id": 722010112,
+                "id": 9,
+                "full_id": 722010112,
                 "name": "Saint Mary Cayon",
                 "translations": {
                     "japanese": "セント・メリー・ケーヨン",
@@ -13611,7 +14099,8 @@
                 }
             },
             {
-                "id": 722075648,
+                "id": 10,
+                "full_id": 722075648,
                 "name": "Saint Paul Capesterre",
                 "translations": {
                     "japanese": "セント・ポール・カピステール",
@@ -13637,7 +14126,8 @@
                 }
             },
             {
-                "id": 722141184,
+                "id": 11,
+                "full_id": 722141184,
                 "name": "Saint Paul Charlestown",
                 "translations": {
                     "japanese": "セント・ポール・チャールズタウン",
@@ -13663,7 +14153,8 @@
                 }
             },
             {
-                "id": 722206720,
+                "id": 12,
+                "full_id": 722206720,
                 "name": "Saint Peter Basseterre",
                 "translations": {
                     "japanese": "セント・ピーター・バセテール",
@@ -13689,7 +14180,8 @@
                 }
             },
             {
-                "id": 722272256,
+                "id": 13,
+                "full_id": 722272256,
                 "name": "Saint Thomas Lowland",
                 "translations": {
                     "japanese": "セント・トーマス・ロウランド",
@@ -13715,7 +14207,8 @@
                 }
             },
             {
-                "id": 722337792,
+                "id": 14,
+                "full_id": 722337792,
                 "name": "Saint Thomas Middle Island",
                 "translations": {
                     "japanese": "セント・トーマス・ミドルアイランド",
@@ -13741,7 +14234,8 @@
                 }
             },
             {
-                "id": 722403328,
+                "id": 15,
+                "full_id": 722403328,
                 "name": "Trinity Palmetto Point",
                 "translations": {
                     "japanese": "トリニティ・パルメット・ポイント",
@@ -13792,7 +14286,8 @@
         },
         "regions": [
             {
-                "id": 738197504,
+                "id": 0,
+                "full_id": 738197504,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13818,7 +14313,8 @@
                 }
             },
             {
-                "id": 738263040,
+                "id": 1,
+                "full_id": 738263040,
                 "name": "St. Lucia",
                 "translations": {
                     "japanese": "セントルシア",
@@ -13869,7 +14365,8 @@
         },
         "regions": [
             {
-                "id": 754974720,
+                "id": 0,
+                "full_id": 754974720,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13895,7 +14392,8 @@
                 }
             },
             {
-                "id": 755040256,
+                "id": 1,
+                "full_id": 755040256,
                 "name": "St. Vincent and the Grenadines",
                 "translations": {
                     "japanese": "セントビンセント・グレナディーン",
@@ -13946,7 +14444,8 @@
         },
         "regions": [
             {
-                "id": 771751936,
+                "id": 0,
+                "full_id": 771751936,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -13972,7 +14471,8 @@
                 }
             },
             {
-                "id": 771883008,
+                "id": 2,
+                "full_id": 771883008,
                 "name": "Paramaribo",
                 "translations": {
                     "japanese": "パラマリボ",
@@ -13998,7 +14498,8 @@
                 }
             },
             {
-                "id": 771948544,
+                "id": 3,
+                "full_id": 771948544,
                 "name": "Brokopondo",
                 "translations": {
                     "japanese": "ブロコポンド",
@@ -14024,7 +14525,8 @@
                 }
             },
             {
-                "id": 772014080,
+                "id": 4,
+                "full_id": 772014080,
                 "name": "Commewijne",
                 "translations": {
                     "japanese": "コメウィネ",
@@ -14050,7 +14552,8 @@
                 }
             },
             {
-                "id": 772079616,
+                "id": 5,
+                "full_id": 772079616,
                 "name": "Coronie",
                 "translations": {
                     "japanese": "コロニー",
@@ -14076,7 +14579,8 @@
                 }
             },
             {
-                "id": 772145152,
+                "id": 6,
+                "full_id": 772145152,
                 "name": "Marowijne",
                 "translations": {
                     "japanese": "マロウィネ",
@@ -14102,7 +14606,8 @@
                 }
             },
             {
-                "id": 772210688,
+                "id": 7,
+                "full_id": 772210688,
                 "name": "Nickerie",
                 "translations": {
                     "japanese": "ニッケリー",
@@ -14128,7 +14633,8 @@
                 }
             },
             {
-                "id": 772276224,
+                "id": 8,
+                "full_id": 772276224,
                 "name": "Para",
                 "translations": {
                     "japanese": "パラ",
@@ -14154,7 +14660,8 @@
                 }
             },
             {
-                "id": 772341760,
+                "id": 9,
+                "full_id": 772341760,
                 "name": "Saramacca",
                 "translations": {
                     "japanese": "サラマッカ",
@@ -14180,7 +14687,8 @@
                 }
             },
             {
-                "id": 772407296,
+                "id": 10,
+                "full_id": 772407296,
                 "name": "Sipaliwini",
                 "translations": {
                     "japanese": "シパリウィニ",
@@ -14206,7 +14714,8 @@
                 }
             },
             {
-                "id": 772472832,
+                "id": 11,
+                "full_id": 772472832,
                 "name": "Wanica",
                 "translations": {
                     "japanese": "ワニカ",
@@ -14257,7 +14766,8 @@
         },
         "regions": [
             {
-                "id": 788529152,
+                "id": 0,
+                "full_id": 788529152,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14283,7 +14793,8 @@
                 }
             },
             {
-                "id": 788660224,
+                "id": 2,
+                "full_id": 788660224,
                 "name": "Port-of-Spain",
                 "translations": {
                     "japanese": "ポート・オブ・スペイン",
@@ -14309,7 +14820,8 @@
                 }
             },
             {
-                "id": 788725760,
+                "id": 3,
+                "full_id": 788725760,
                 "name": "Arima",
                 "translations": {
                     "japanese": "アリマ",
@@ -14335,7 +14847,8 @@
                 }
             },
             {
-                "id": 788791296,
+                "id": 4,
+                "full_id": 788791296,
                 "name": "Caroni",
                 "translations": {
                     "japanese": "カロニ州",
@@ -14361,7 +14874,8 @@
                 }
             },
             {
-                "id": 788856832,
+                "id": 5,
+                "full_id": 788856832,
                 "name": "Mayaro",
                 "translations": {
                     "japanese": "マジャロ州",
@@ -14387,7 +14901,8 @@
                 }
             },
             {
-                "id": 788922368,
+                "id": 6,
+                "full_id": 788922368,
                 "name": "Nariva",
                 "translations": {
                     "japanese": "ナリバ州",
@@ -14413,7 +14928,8 @@
                 }
             },
             {
-                "id": 788987904,
+                "id": 7,
+                "full_id": 788987904,
                 "name": "Saint Andrew",
                 "translations": {
                     "japanese": "セント・アンドリュー州",
@@ -14439,7 +14955,8 @@
                 }
             },
             {
-                "id": 789053440,
+                "id": 8,
+                "full_id": 789053440,
                 "name": "Saint David",
                 "translations": {
                     "japanese": "セント・デビッド州",
@@ -14465,7 +14982,8 @@
                 }
             },
             {
-                "id": 789118976,
+                "id": 9,
+                "full_id": 789118976,
                 "name": "Saint George",
                 "translations": {
                     "japanese": "セント・ジョージ州",
@@ -14491,7 +15009,8 @@
                 }
             },
             {
-                "id": 789184512,
+                "id": 10,
+                "full_id": 789184512,
                 "name": "Saint Patrick",
                 "translations": {
                     "japanese": "セント・パトリック州",
@@ -14517,7 +15036,8 @@
                 }
             },
             {
-                "id": 789250048,
+                "id": 11,
+                "full_id": 789250048,
                 "name": "San Fernando",
                 "translations": {
                     "japanese": "サン・フェルナンド",
@@ -14543,7 +15063,8 @@
                 }
             },
             {
-                "id": 789315584,
+                "id": 12,
+                "full_id": 789315584,
                 "name": "Tobago",
                 "translations": {
                     "japanese": "トバゴ島",
@@ -14569,7 +15090,8 @@
                 }
             },
             {
-                "id": 789381120,
+                "id": 13,
+                "full_id": 789381120,
                 "name": "Victoria",
                 "translations": {
                     "japanese": "ビクトリア州",
@@ -14595,7 +15117,8 @@
                 }
             },
             {
-                "id": 789446656,
+                "id": 14,
+                "full_id": 789446656,
                 "name": "Point Fortin",
                 "translations": {
                     "japanese": "ポイントフォーティン",
@@ -14646,7 +15169,8 @@
         },
         "regions": [
             {
-                "id": 805306368,
+                "id": 0,
+                "full_id": 805306368,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14672,7 +15196,8 @@
                 }
             },
             {
-                "id": 805371904,
+                "id": 1,
+                "full_id": 805371904,
                 "name": "Turks and Caicos Islands",
                 "translations": {
                     "japanese": "タークス・カイコス諸島",
@@ -14723,7 +15248,8 @@
         },
         "regions": [
             {
-                "id": 822083584,
+                "id": 0,
+                "full_id": 822083584,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -14749,7 +15275,8 @@
                 }
             },
             {
-                "id": 822214656,
+                "id": 2,
+                "full_id": 822214656,
                 "name": "District of Columbia",
                 "translations": {
                     "japanese": "コロンビア特別区",
@@ -14775,7 +15302,8 @@
                 }
             },
             {
-                "id": 822280192,
+                "id": 3,
+                "full_id": 822280192,
                 "name": "Alaska",
                 "translations": {
                     "japanese": "アラスカ州",
@@ -14801,7 +15329,8 @@
                 }
             },
             {
-                "id": 822345728,
+                "id": 4,
+                "full_id": 822345728,
                 "name": "Alabama",
                 "translations": {
                     "japanese": "アラバマ州",
@@ -14827,7 +15356,8 @@
                 }
             },
             {
-                "id": 822411264,
+                "id": 5,
+                "full_id": 822411264,
                 "name": "Arkansas",
                 "translations": {
                     "japanese": "アーカンソー州",
@@ -14853,7 +15383,8 @@
                 }
             },
             {
-                "id": 822476800,
+                "id": 6,
+                "full_id": 822476800,
                 "name": "Arizona",
                 "translations": {
                     "japanese": "アリゾナ州",
@@ -14879,7 +15410,8 @@
                 }
             },
             {
-                "id": 822542336,
+                "id": 7,
+                "full_id": 822542336,
                 "name": "California",
                 "translations": {
                     "japanese": "カリフォルニア州",
@@ -14905,7 +15437,8 @@
                 }
             },
             {
-                "id": 822607872,
+                "id": 8,
+                "full_id": 822607872,
                 "name": "Colorado",
                 "translations": {
                     "japanese": "コロラド州",
@@ -14931,7 +15464,8 @@
                 }
             },
             {
-                "id": 822673408,
+                "id": 9,
+                "full_id": 822673408,
                 "name": "Connecticut",
                 "translations": {
                     "japanese": "コネティカット州",
@@ -14957,7 +15491,8 @@
                 }
             },
             {
-                "id": 822738944,
+                "id": 10,
+                "full_id": 822738944,
                 "name": "Delaware",
                 "translations": {
                     "japanese": "デラウェア州",
@@ -14983,7 +15518,8 @@
                 }
             },
             {
-                "id": 822804480,
+                "id": 11,
+                "full_id": 822804480,
                 "name": "Florida",
                 "translations": {
                     "japanese": "フロリダ州",
@@ -15009,7 +15545,8 @@
                 }
             },
             {
-                "id": 822870016,
+                "id": 12,
+                "full_id": 822870016,
                 "name": "Georgia",
                 "translations": {
                     "japanese": "ジョージア州",
@@ -15035,7 +15572,8 @@
                 }
             },
             {
-                "id": 822935552,
+                "id": 13,
+                "full_id": 822935552,
                 "name": "Hawaii",
                 "translations": {
                     "japanese": "ハワイ州",
@@ -15061,7 +15599,8 @@
                 }
             },
             {
-                "id": 823001088,
+                "id": 14,
+                "full_id": 823001088,
                 "name": "Iowa",
                 "translations": {
                     "japanese": "アイオワ州",
@@ -15087,7 +15626,8 @@
                 }
             },
             {
-                "id": 823066624,
+                "id": 15,
+                "full_id": 823066624,
                 "name": "Idaho",
                 "translations": {
                     "japanese": "アイダホ州",
@@ -15113,7 +15653,8 @@
                 }
             },
             {
-                "id": 823132160,
+                "id": 1,
+                "full_id": 823132160,
                 "name": "Illinois",
                 "translations": {
                     "japanese": "イリノイ州",
@@ -15139,7 +15680,8 @@
                 }
             },
             {
-                "id": 823197696,
+                "id": 17,
+                "full_id": 823197696,
                 "name": "Indiana",
                 "translations": {
                     "japanese": "インディアナ州",
@@ -15165,7 +15707,8 @@
                 }
             },
             {
-                "id": 823263232,
+                "id": 18,
+                "full_id": 823263232,
                 "name": "Kansas",
                 "translations": {
                     "japanese": "カンザス州",
@@ -15191,7 +15734,8 @@
                 }
             },
             {
-                "id": 823328768,
+                "id": 19,
+                "full_id": 823328768,
                 "name": "Kentucky",
                 "translations": {
                     "japanese": "ケンタッキー州",
@@ -15217,7 +15761,8 @@
                 }
             },
             {
-                "id": 823394304,
+                "id": 20,
+                "full_id": 823394304,
                 "name": "Louisiana",
                 "translations": {
                     "japanese": "ルイジアナ州",
@@ -15243,7 +15788,8 @@
                 }
             },
             {
-                "id": 823459840,
+                "id": 21,
+                "full_id": 823459840,
                 "name": "Massachusetts",
                 "translations": {
                     "japanese": "マサチューセッツ州",
@@ -15269,7 +15815,8 @@
                 }
             },
             {
-                "id": 823525376,
+                "id": 22,
+                "full_id": 823525376,
                 "name": "Maryland",
                 "translations": {
                     "japanese": "メリーランド州",
@@ -15295,7 +15842,8 @@
                 }
             },
             {
-                "id": 823590912,
+                "id": 23,
+                "full_id": 823590912,
                 "name": "Maine",
                 "translations": {
                     "japanese": "メーン州",
@@ -15321,7 +15869,8 @@
                 }
             },
             {
-                "id": 823656448,
+                "id": 24,
+                "full_id": 823656448,
                 "name": "Michigan",
                 "translations": {
                     "japanese": "ミシガン州",
@@ -15347,7 +15896,8 @@
                 }
             },
             {
-                "id": 823721984,
+                "id": 25,
+                "full_id": 823721984,
                 "name": "Minnesota",
                 "translations": {
                     "japanese": "ミネソタ州",
@@ -15373,7 +15923,8 @@
                 }
             },
             {
-                "id": 823787520,
+                "id": 26,
+                "full_id": 823787520,
                 "name": "Missouri",
                 "translations": {
                     "japanese": "ミズーリ州",
@@ -15399,7 +15950,8 @@
                 }
             },
             {
-                "id": 823853056,
+                "id": 27,
+                "full_id": 823853056,
                 "name": "Mississippi",
                 "translations": {
                     "japanese": "ミシシッピ州",
@@ -15425,7 +15977,8 @@
                 }
             },
             {
-                "id": 823918592,
+                "id": 28,
+                "full_id": 823918592,
                 "name": "Montana",
                 "translations": {
                     "japanese": "モンタナ州",
@@ -15451,7 +16004,8 @@
                 }
             },
             {
-                "id": 823984128,
+                "id": 29,
+                "full_id": 823984128,
                 "name": "North Carolina",
                 "translations": {
                     "japanese": "ノースカロライナ州",
@@ -15477,7 +16031,8 @@
                 }
             },
             {
-                "id": 824049664,
+                "id": 30,
+                "full_id": 824049664,
                 "name": "North Dakota",
                 "translations": {
                     "japanese": "ノースダコタ州",
@@ -15503,7 +16058,8 @@
                 }
             },
             {
-                "id": 824115200,
+                "id": 31,
+                "full_id": 824115200,
                 "name": "Nebraska",
                 "translations": {
                     "japanese": "ネブラスカ州",
@@ -15529,7 +16085,8 @@
                 }
             },
             {
-                "id": 824180736,
+                "id": 2,
+                "full_id": 824180736,
                 "name": "New Hampshire",
                 "translations": {
                     "japanese": "ニューハンプシャー州",
@@ -15555,7 +16112,8 @@
                 }
             },
             {
-                "id": 824246272,
+                "id": 33,
+                "full_id": 824246272,
                 "name": "New Jersey",
                 "translations": {
                     "japanese": "ニュージャージー州",
@@ -15581,7 +16139,8 @@
                 }
             },
             {
-                "id": 824311808,
+                "id": 34,
+                "full_id": 824311808,
                 "name": "New Mexico",
                 "translations": {
                     "japanese": "ニューメキシコ州",
@@ -15607,7 +16166,8 @@
                 }
             },
             {
-                "id": 824377344,
+                "id": 35,
+                "full_id": 824377344,
                 "name": "Nevada",
                 "translations": {
                     "japanese": "ネバダ州",
@@ -15633,7 +16193,8 @@
                 }
             },
             {
-                "id": 824442880,
+                "id": 36,
+                "full_id": 824442880,
                 "name": "New York",
                 "translations": {
                     "japanese": "ニューヨーク州",
@@ -15659,7 +16220,8 @@
                 }
             },
             {
-                "id": 824508416,
+                "id": 37,
+                "full_id": 824508416,
                 "name": "Ohio",
                 "translations": {
                     "japanese": "オハイオ州",
@@ -15685,7 +16247,8 @@
                 }
             },
             {
-                "id": 824573952,
+                "id": 38,
+                "full_id": 824573952,
                 "name": "Oklahoma",
                 "translations": {
                     "japanese": "オクラホマ州",
@@ -15711,7 +16274,8 @@
                 }
             },
             {
-                "id": 824639488,
+                "id": 39,
+                "full_id": 824639488,
                 "name": "Oregon",
                 "translations": {
                     "japanese": "オレゴン州",
@@ -15737,7 +16301,8 @@
                 }
             },
             {
-                "id": 824705024,
+                "id": 40,
+                "full_id": 824705024,
                 "name": "Pennsylvania",
                 "translations": {
                     "japanese": "ペンシルベニア州",
@@ -15763,7 +16328,8 @@
                 }
             },
             {
-                "id": 824770560,
+                "id": 41,
+                "full_id": 824770560,
                 "name": "Rhode Island",
                 "translations": {
                     "japanese": "ロードアイランド州",
@@ -15789,7 +16355,8 @@
                 }
             },
             {
-                "id": 824836096,
+                "id": 42,
+                "full_id": 824836096,
                 "name": "South Carolina",
                 "translations": {
                     "japanese": "サウスカロライナ州",
@@ -15815,7 +16382,8 @@
                 }
             },
             {
-                "id": 824901632,
+                "id": 43,
+                "full_id": 824901632,
                 "name": "South Dakota",
                 "translations": {
                     "japanese": "サウスダコタ州",
@@ -15841,7 +16409,8 @@
                 }
             },
             {
-                "id": 824967168,
+                "id": 44,
+                "full_id": 824967168,
                 "name": "Tennessee",
                 "translations": {
                     "japanese": "テネシー州",
@@ -15867,7 +16436,8 @@
                 }
             },
             {
-                "id": 825032704,
+                "id": 45,
+                "full_id": 825032704,
                 "name": "Texas",
                 "translations": {
                     "japanese": "テキサス州",
@@ -15893,7 +16463,8 @@
                 }
             },
             {
-                "id": 825098240,
+                "id": 46,
+                "full_id": 825098240,
                 "name": "Utah",
                 "translations": {
                     "japanese": "ユタ州",
@@ -15919,7 +16490,8 @@
                 }
             },
             {
-                "id": 825163776,
+                "id": 47,
+                "full_id": 825163776,
                 "name": "Virginia",
                 "translations": {
                     "japanese": "バージニア州",
@@ -15945,7 +16517,8 @@
                 }
             },
             {
-                "id": 825229312,
+                "id": 3,
+                "full_id": 825229312,
                 "name": "Vermont",
                 "translations": {
                     "japanese": "バーモント州",
@@ -15971,7 +16544,8 @@
                 }
             },
             {
-                "id": 825294848,
+                "id": 49,
+                "full_id": 825294848,
                 "name": "Washington",
                 "translations": {
                     "japanese": "ワシントン州",
@@ -15997,7 +16571,8 @@
                 }
             },
             {
-                "id": 825360384,
+                "id": 50,
+                "full_id": 825360384,
                 "name": "Wisconsin",
                 "translations": {
                     "japanese": "ウィスコンシン州",
@@ -16023,7 +16598,8 @@
                 }
             },
             {
-                "id": 825425920,
+                "id": 51,
+                "full_id": 825425920,
                 "name": "West Virginia",
                 "translations": {
                     "japanese": "ウェストバージニア州",
@@ -16049,7 +16625,8 @@
                 }
             },
             {
-                "id": 825491456,
+                "id": 52,
+                "full_id": 825491456,
                 "name": "Wyoming",
                 "translations": {
                     "japanese": "ワイオミング州",
@@ -16075,7 +16652,8 @@
                 }
             },
             {
-                "id": 825556992,
+                "id": 53,
+                "full_id": 825556992,
                 "name": "Puerto Rico",
                 "translations": {
                     "japanese": "プエルトリコ",
@@ -16126,7 +16704,8 @@
         },
         "regions": [
             {
-                "id": 838860800,
+                "id": 0,
+                "full_id": 838860800,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -16152,7 +16731,8 @@
                 }
             },
             {
-                "id": 838991872,
+                "id": 2,
+                "full_id": 838991872,
                 "name": "Montevideo",
                 "translations": {
                     "japanese": "モンテビデオ",
@@ -16178,7 +16758,8 @@
                 }
             },
             {
-                "id": 839057408,
+                "id": 3,
+                "full_id": 839057408,
                 "name": "Artigas",
                 "translations": {
                     "japanese": "アルティガス",
@@ -16204,7 +16785,8 @@
                 }
             },
             {
-                "id": 839122944,
+                "id": 4,
+                "full_id": 839122944,
                 "name": "Canelones",
                 "translations": {
                     "japanese": "カネロネス",
@@ -16230,7 +16812,8 @@
                 }
             },
             {
-                "id": 839188480,
+                "id": 5,
+                "full_id": 839188480,
                 "name": "Cerro Largo",
                 "translations": {
                     "japanese": "セロ・ラルゴ",
@@ -16256,7 +16839,8 @@
                 }
             },
             {
-                "id": 839254016,
+                "id": 6,
+                "full_id": 839254016,
                 "name": "Colonia",
                 "translations": {
                     "japanese": "コロニア",
@@ -16282,7 +16866,8 @@
                 }
             },
             {
-                "id": 839319552,
+                "id": 7,
+                "full_id": 839319552,
                 "name": "Durazno",
                 "translations": {
                     "japanese": "ドゥラスノ",
@@ -16308,7 +16893,8 @@
                 }
             },
             {
-                "id": 839385088,
+                "id": 8,
+                "full_id": 839385088,
                 "name": "Flores",
                 "translations": {
                     "japanese": "フロレス",
@@ -16334,7 +16920,8 @@
                 }
             },
             {
-                "id": 839450624,
+                "id": 9,
+                "full_id": 839450624,
                 "name": "Florida",
                 "translations": {
                     "japanese": "フロリダ",
@@ -16360,7 +16947,8 @@
                 }
             },
             {
-                "id": 839516160,
+                "id": 10,
+                "full_id": 839516160,
                 "name": "Lavalleja",
                 "translations": {
                     "japanese": "ラバジェハ",
@@ -16386,7 +16974,8 @@
                 }
             },
             {
-                "id": 839581696,
+                "id": 11,
+                "full_id": 839581696,
                 "name": "Maldonado",
                 "translations": {
                     "japanese": "マルドナド",
@@ -16412,7 +17001,8 @@
                 }
             },
             {
-                "id": 839647232,
+                "id": 12,
+                "full_id": 839647232,
                 "name": "Paysandú",
                 "translations": {
                     "japanese": "パイサンドゥ",
@@ -16438,7 +17028,8 @@
                 }
             },
             {
-                "id": 839712768,
+                "id": 13,
+                "full_id": 839712768,
                 "name": "Río Negro",
                 "translations": {
                     "japanese": "リオ・ネグロ",
@@ -16464,7 +17055,8 @@
                 }
             },
             {
-                "id": 839778304,
+                "id": 14,
+                "full_id": 839778304,
                 "name": "Rivera",
                 "translations": {
                     "japanese": "リベラ",
@@ -16490,7 +17082,8 @@
                 }
             },
             {
-                "id": 839843840,
+                "id": 15,
+                "full_id": 839843840,
                 "name": "Rocha",
                 "translations": {
                     "japanese": "ロチャ",
@@ -16516,7 +17109,8 @@
                 }
             },
             {
-                "id": 839909376,
+                "id": 1,
+                "full_id": 839909376,
                 "name": "Salto",
                 "translations": {
                     "japanese": "サルト",
@@ -16542,7 +17136,8 @@
                 }
             },
             {
-                "id": 839974912,
+                "id": 17,
+                "full_id": 839974912,
                 "name": "San José",
                 "translations": {
                     "japanese": "サン・ホセ",
@@ -16568,7 +17163,8 @@
                 }
             },
             {
-                "id": 840040448,
+                "id": 18,
+                "full_id": 840040448,
                 "name": "Soriano",
                 "translations": {
                     "japanese": "ソリアノ",
@@ -16594,7 +17190,8 @@
                 }
             },
             {
-                "id": 840105984,
+                "id": 19,
+                "full_id": 840105984,
                 "name": "Tacuarembó",
                 "translations": {
                     "japanese": "タクアレンボ",
@@ -16620,7 +17217,8 @@
                 }
             },
             {
-                "id": 840171520,
+                "id": 20,
+                "full_id": 840171520,
                 "name": "Treinta y Tres",
                 "translations": {
                     "japanese": "トレインタ・イ・トレス",
@@ -16671,7 +17269,8 @@
         },
         "regions": [
             {
-                "id": 855638016,
+                "id": 0,
+                "full_id": 855638016,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -16697,7 +17296,8 @@
                 }
             },
             {
-                "id": 855703552,
+                "id": 1,
+                "full_id": 855703552,
                 "name": "US Virgin Islands",
                 "translations": {
                     "japanese": "米領バージン諸島",
@@ -16748,7 +17348,8 @@
         },
         "regions": [
             {
-                "id": 872415232,
+                "id": 0,
+                "full_id": 872415232,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -16774,7 +17375,8 @@
                 }
             },
             {
-                "id": 872546304,
+                "id": 2,
+                "full_id": 872546304,
                 "name": "Distrito Federal",
                 "translations": {
                     "japanese": "ディストリト首都地区",
@@ -16800,7 +17402,8 @@
                 }
             },
             {
-                "id": 872611840,
+                "id": 3,
+                "full_id": 872611840,
                 "name": "Amazonas",
                 "translations": {
                     "japanese": "アマソナス",
@@ -16826,7 +17429,8 @@
                 }
             },
             {
-                "id": 872677376,
+                "id": 4,
+                "full_id": 872677376,
                 "name": "Anzoátegui",
                 "translations": {
                     "japanese": "アンソアテギ",
@@ -16852,7 +17456,8 @@
                 }
             },
             {
-                "id": 872742912,
+                "id": 5,
+                "full_id": 872742912,
                 "name": "Apure",
                 "translations": {
                     "japanese": "アプレ",
@@ -16878,7 +17483,8 @@
                 }
             },
             {
-                "id": 872808448,
+                "id": 6,
+                "full_id": 872808448,
                 "name": "Aragua",
                 "translations": {
                     "japanese": "アラグア",
@@ -16904,7 +17510,8 @@
                 }
             },
             {
-                "id": 872873984,
+                "id": 7,
+                "full_id": 872873984,
                 "name": "Barinas",
                 "translations": {
                     "japanese": "バリナス",
@@ -16930,7 +17537,8 @@
                 }
             },
             {
-                "id": 872939520,
+                "id": 8,
+                "full_id": 872939520,
                 "name": "Bolívar",
                 "translations": {
                     "japanese": "ボリーバル",
@@ -16956,7 +17564,8 @@
                 }
             },
             {
-                "id": 873005056,
+                "id": 9,
+                "full_id": 873005056,
                 "name": "Carabobo",
                 "translations": {
                     "japanese": "カラボボ",
@@ -16982,7 +17591,8 @@
                 }
             },
             {
-                "id": 873070592,
+                "id": 10,
+                "full_id": 873070592,
                 "name": "Cojedes",
                 "translations": {
                     "japanese": "コヘデス",
@@ -17008,7 +17618,8 @@
                 }
             },
             {
-                "id": 873136128,
+                "id": 11,
+                "full_id": 873136128,
                 "name": "Delta Amacuro",
                 "translations": {
                     "japanese": "デルタ・アマクロ",
@@ -17034,7 +17645,8 @@
                 }
             },
             {
-                "id": 873201664,
+                "id": 12,
+                "full_id": 873201664,
                 "name": "Falcón",
                 "translations": {
                     "japanese": "ファルコン",
@@ -17060,7 +17672,8 @@
                 }
             },
             {
-                "id": 873267200,
+                "id": 13,
+                "full_id": 873267200,
                 "name": "Guárico",
                 "translations": {
                     "japanese": "グアリコ",
@@ -17086,7 +17699,8 @@
                 }
             },
             {
-                "id": 873332736,
+                "id": 14,
+                "full_id": 873332736,
                 "name": "Lara",
                 "translations": {
                     "japanese": "ララ",
@@ -17112,7 +17726,8 @@
                 }
             },
             {
-                "id": 873398272,
+                "id": 15,
+                "full_id": 873398272,
                 "name": "Mérida",
                 "translations": {
                     "japanese": "メリダ",
@@ -17138,7 +17753,8 @@
                 }
             },
             {
-                "id": 873463808,
+                "id": 1,
+                "full_id": 873463808,
                 "name": "Miranda",
                 "translations": {
                     "japanese": "ミランダ",
@@ -17164,7 +17780,8 @@
                 }
             },
             {
-                "id": 873529344,
+                "id": 17,
+                "full_id": 873529344,
                 "name": "Monagas",
                 "translations": {
                     "japanese": "モナガス",
@@ -17190,7 +17807,8 @@
                 }
             },
             {
-                "id": 873594880,
+                "id": 18,
+                "full_id": 873594880,
                 "name": "Nueva Esparta",
                 "translations": {
                     "japanese": "ヌエバエスパルタ",
@@ -17216,7 +17834,8 @@
                 }
             },
             {
-                "id": 873660416,
+                "id": 19,
+                "full_id": 873660416,
                 "name": "Portuguesa",
                 "translations": {
                     "japanese": "ポルトゥゲサ",
@@ -17242,7 +17861,8 @@
                 }
             },
             {
-                "id": 873725952,
+                "id": 20,
+                "full_id": 873725952,
                 "name": "Sucre",
                 "translations": {
                     "japanese": "スクレ",
@@ -17268,7 +17888,8 @@
                 }
             },
             {
-                "id": 873791488,
+                "id": 21,
+                "full_id": 873791488,
                 "name": "Táchira",
                 "translations": {
                     "japanese": "タチラ",
@@ -17294,7 +17915,8 @@
                 }
             },
             {
-                "id": 873857024,
+                "id": 22,
+                "full_id": 873857024,
                 "name": "Trujillo",
                 "translations": {
                     "japanese": "トルヒーヨ",
@@ -17320,7 +17942,8 @@
                 }
             },
             {
-                "id": 873922560,
+                "id": 23,
+                "full_id": 873922560,
                 "name": "Yaracuy",
                 "translations": {
                     "japanese": "ヤラクイ",
@@ -17346,7 +17969,8 @@
                 }
             },
             {
-                "id": 873988096,
+                "id": 24,
+                "full_id": 873988096,
                 "name": "Zulia",
                 "translations": {
                     "japanese": "スリア",
@@ -17372,7 +17996,8 @@
                 }
             },
             {
-                "id": 874053632,
+                "id": 25,
+                "full_id": 874053632,
                 "name": "Dependencias Federales",
                 "translations": {
                     "japanese": "連邦保護領",
@@ -17398,7 +18023,8 @@
                 }
             },
             {
-                "id": 874119168,
+                "id": 26,
+                "full_id": 874119168,
                 "name": "Vargas",
                 "translations": {
                     "japanese": "バルガス",
@@ -17449,7 +18075,8 @@
         },
         "regions": [
             {
-                "id": 1073741824,
+                "id": 0,
+                "full_id": 1073741824,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -17475,7 +18102,8 @@
                 }
             },
             {
-                "id": 1073872896,
+                "id": 2,
+                "full_id": 1073872896,
                 "name": "Tirana",
                 "translations": {
                     "japanese": "ティラナ州",
@@ -17501,7 +18129,8 @@
                 }
             },
             {
-                "id": 1073938432,
+                "id": 3,
+                "full_id": 1073938432,
                 "name": "Berat",
                 "translations": {
                     "japanese": "ベラト州",
@@ -17527,7 +18156,8 @@
                 }
             },
             {
-                "id": 1074003968,
+                "id": 4,
+                "full_id": 1074003968,
                 "name": "Dibër",
                 "translations": {
                     "japanese": "ディブラ州",
@@ -17553,7 +18183,8 @@
                 }
             },
             {
-                "id": 1074069504,
+                "id": 5,
+                "full_id": 1074069504,
                 "name": "Durrës",
                 "translations": {
                     "japanese": "デュラス州",
@@ -17579,7 +18210,8 @@
                 }
             },
             {
-                "id": 1074135040,
+                "id": 6,
+                "full_id": 1074135040,
                 "name": "Elbasan",
                 "translations": {
                     "japanese": "エルバサン州",
@@ -17605,7 +18237,8 @@
                 }
             },
             {
-                "id": 1074200576,
+                "id": 7,
+                "full_id": 1074200576,
                 "name": "Fier",
                 "translations": {
                     "japanese": "フィエル州",
@@ -17631,7 +18264,8 @@
                 }
             },
             {
-                "id": 1074266112,
+                "id": 8,
+                "full_id": 1074266112,
                 "name": "Gjirokastër",
                 "translations": {
                     "japanese": "ギロカストラ州",
@@ -17657,7 +18291,8 @@
                 }
             },
             {
-                "id": 1074331648,
+                "id": 9,
+                "full_id": 1074331648,
                 "name": "Korçë",
                 "translations": {
                     "japanese": "コルチャ州",
@@ -17683,7 +18318,8 @@
                 }
             },
             {
-                "id": 1074397184,
+                "id": 10,
+                "full_id": 1074397184,
                 "name": "Kukës",
                 "translations": {
                     "japanese": "クケス州",
@@ -17709,7 +18345,8 @@
                 }
             },
             {
-                "id": 1074462720,
+                "id": 11,
+                "full_id": 1074462720,
                 "name": "Lezhë",
                 "translations": {
                     "japanese": "レジャ州",
@@ -17735,7 +18372,8 @@
                 }
             },
             {
-                "id": 1074528256,
+                "id": 12,
+                "full_id": 1074528256,
                 "name": "Shkodër",
                 "translations": {
                     "japanese": "シュコドラ州",
@@ -17761,7 +18399,8 @@
                 }
             },
             {
-                "id": 1074593792,
+                "id": 13,
+                "full_id": 1074593792,
                 "name": "Vlorë",
                 "translations": {
                     "japanese": "ヴロラ州",
@@ -17812,7 +18451,8 @@
         },
         "regions": [
             {
-                "id": 1090519040,
+                "id": 0,
+                "full_id": 1090519040,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -17838,7 +18478,8 @@
                 }
             },
             {
-                "id": 1090650112,
+                "id": 2,
+                "full_id": 1090650112,
                 "name": "Australian Capital Territory",
                 "translations": {
                     "japanese": "オーストラリア首都特別地域",
@@ -17864,7 +18505,8 @@
                 }
             },
             {
-                "id": 1090715648,
+                "id": 3,
+                "full_id": 1090715648,
                 "name": "New South Wales",
                 "translations": {
                     "japanese": "ニューサウスウェールズ州",
@@ -17890,7 +18532,8 @@
                 }
             },
             {
-                "id": 1090781184,
+                "id": 4,
+                "full_id": 1090781184,
                 "name": "Northern Territory",
                 "translations": {
                     "japanese": "ノーザンテリトリー",
@@ -17916,7 +18559,8 @@
                 }
             },
             {
-                "id": 1090846720,
+                "id": 5,
+                "full_id": 1090846720,
                 "name": "Queensland",
                 "translations": {
                     "japanese": "クィーンズランド州",
@@ -17942,7 +18586,8 @@
                 }
             },
             {
-                "id": 1090912256,
+                "id": 6,
+                "full_id": 1090912256,
                 "name": "South Australia",
                 "translations": {
                     "japanese": "南オーストラリア州",
@@ -17968,7 +18613,8 @@
                 }
             },
             {
-                "id": 1090977792,
+                "id": 7,
+                "full_id": 1090977792,
                 "name": "Tasmania",
                 "translations": {
                     "japanese": "タスマニア州",
@@ -17994,7 +18640,8 @@
                 }
             },
             {
-                "id": 1091043328,
+                "id": 8,
+                "full_id": 1091043328,
                 "name": "Victoria",
                 "translations": {
                     "japanese": "ヴィクトリア州",
@@ -18020,7 +18667,8 @@
                 }
             },
             {
-                "id": 1091108864,
+                "id": 9,
+                "full_id": 1091108864,
                 "name": "Western Australia",
                 "translations": {
                     "japanese": "西オーストラリア州",
@@ -18071,7 +18719,8 @@
         },
         "regions": [
             {
-                "id": 1107296256,
+                "id": 0,
+                "full_id": 1107296256,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18097,7 +18746,8 @@
                 }
             },
             {
-                "id": 1107427328,
+                "id": 2,
+                "full_id": 1107427328,
                 "name": "Vienna",
                 "translations": {
                     "japanese": "ウィーン",
@@ -18123,7 +18773,8 @@
                 }
             },
             {
-                "id": 1107492864,
+                "id": 3,
+                "full_id": 1107492864,
                 "name": "Burgenland",
                 "translations": {
                     "japanese": "ブルゲンラント州",
@@ -18149,7 +18800,8 @@
                 }
             },
             {
-                "id": 1107558400,
+                "id": 4,
+                "full_id": 1107558400,
                 "name": "Carinthia",
                 "translations": {
                     "japanese": "ケルンテン州",
@@ -18175,7 +18827,8 @@
                 }
             },
             {
-                "id": 1107623936,
+                "id": 5,
+                "full_id": 1107623936,
                 "name": "Lower Austria",
                 "translations": {
                     "japanese": "ニーダー・エスターライヒ州",
@@ -18201,7 +18854,8 @@
                 }
             },
             {
-                "id": 1107689472,
+                "id": 6,
+                "full_id": 1107689472,
                 "name": "Upper Austria",
                 "translations": {
                     "japanese": "オーバー・エスターライヒ州",
@@ -18227,7 +18881,8 @@
                 }
             },
             {
-                "id": 1107755008,
+                "id": 7,
+                "full_id": 1107755008,
                 "name": "Salzburg",
                 "translations": {
                     "japanese": "ザルツブルク州",
@@ -18253,7 +18908,8 @@
                 }
             },
             {
-                "id": 1107820544,
+                "id": 8,
+                "full_id": 1107820544,
                 "name": "Styria",
                 "translations": {
                     "japanese": "シュタイアーマルク州",
@@ -18279,7 +18935,8 @@
                 }
             },
             {
-                "id": 1107886080,
+                "id": 9,
+                "full_id": 1107886080,
                 "name": "Tyrol",
                 "translations": {
                     "japanese": "ティロル州",
@@ -18305,7 +18962,8 @@
                 }
             },
             {
-                "id": 1107951616,
+                "id": 10,
+                "full_id": 1107951616,
                 "name": "Vorarlberg",
                 "translations": {
                     "japanese": "フォアアールベルク州",
@@ -18356,7 +19014,8 @@
         },
         "regions": [
             {
-                "id": 1124073472,
+                "id": 0,
+                "full_id": 1124073472,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18382,7 +19041,8 @@
                 }
             },
             {
-                "id": 1124204544,
+                "id": 2,
+                "full_id": 1124204544,
                 "name": "Brussels Region",
                 "translations": {
                     "japanese": "ブリュッセル首都地域圏",
@@ -18408,7 +19068,8 @@
                 }
             },
             {
-                "id": 1124270080,
+                "id": 3,
+                "full_id": 1124270080,
                 "name": "Flanders",
                 "translations": {
                     "japanese": "フランデレン地域圏",
@@ -18434,7 +19095,8 @@
                 }
             },
             {
-                "id": 1124335616,
+                "id": 4,
+                "full_id": 1124335616,
                 "name": "Wallonia",
                 "translations": {
                     "japanese": "ワロン地域圏",
@@ -18485,7 +19147,8 @@
         },
         "regions": [
             {
-                "id": 1140850688,
+                "id": 0,
+                "full_id": 1140850688,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18511,7 +19174,8 @@
                 }
             },
             {
-                "id": 1140981760,
+                "id": 2,
+                "full_id": 1140981760,
                 "name": "Federation of Bosnia and Herzegovina",
                 "translations": {
                     "japanese": "ボスニア・ヘルツェゴビナ連邦",
@@ -18537,7 +19201,8 @@
                 }
             },
             {
-                "id": 1141047296,
+                "id": 3,
+                "full_id": 1141047296,
                 "name": "Republika Srpska",
                 "translations": {
                     "japanese": "セルビア人共和国",
@@ -18563,7 +19228,8 @@
                 }
             },
             {
-                "id": 1141112832,
+                "id": 4,
+                "full_id": 1141112832,
                 "name": "Brčko District",
                 "translations": {
                     "japanese": "ブルチュコ",
@@ -18614,7 +19280,8 @@
         },
         "regions": [
             {
-                "id": 1157627904,
+                "id": 0,
+                "full_id": 1157627904,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18640,7 +19307,8 @@
                 }
             },
             {
-                "id": 1157693440,
+                "id": 1,
+                "full_id": 1157693440,
                 "name": "Botswana",
                 "translations": {
                     "japanese": "ボツワナ",
@@ -18691,7 +19359,8 @@
         },
         "regions": [
             {
-                "id": 1174405120,
+                "id": 0,
+                "full_id": 1174405120,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -18717,7 +19386,8 @@
                 }
             },
             {
-                "id": 1174536192,
+                "id": 2,
+                "full_id": 1174536192,
                 "name": "Sofia City",
                 "translations": {
                     "japanese": "ソフィア市",
@@ -18743,7 +19413,8 @@
                 }
             },
             {
-                "id": 1174601728,
+                "id": 3,
+                "full_id": 1174601728,
                 "name": "Sofia Province",
                 "translations": {
                     "japanese": "ソフィア州",
@@ -18769,7 +19440,8 @@
                 }
             },
             {
-                "id": 1174667264,
+                "id": 4,
+                "full_id": 1174667264,
                 "name": "Blagoevgrad",
                 "translations": {
                     "japanese": "ブラゴエブグラト州",
@@ -18795,7 +19467,8 @@
                 }
             },
             {
-                "id": 1174732800,
+                "id": 5,
+                "full_id": 1174732800,
                 "name": "Pleven",
                 "translations": {
                     "japanese": "プレベン州",
@@ -18821,7 +19494,8 @@
                 }
             },
             {
-                "id": 1174798336,
+                "id": 6,
+                "full_id": 1174798336,
                 "name": "Vidin",
                 "translations": {
                     "japanese": "ビディン州",
@@ -18847,7 +19521,8 @@
                 }
             },
             {
-                "id": 1174863872,
+                "id": 7,
+                "full_id": 1174863872,
                 "name": "Varna",
                 "translations": {
                     "japanese": "バルナ州",
@@ -18873,7 +19548,8 @@
                 }
             },
             {
-                "id": 1174929408,
+                "id": 8,
+                "full_id": 1174929408,
                 "name": "Burgas",
                 "translations": {
                     "japanese": "ブルガス州",
@@ -18899,7 +19575,8 @@
                 }
             },
             {
-                "id": 1174994944,
+                "id": 9,
+                "full_id": 1174994944,
                 "name": "Dobrich",
                 "translations": {
                     "japanese": "ドブリチ州",
@@ -18925,7 +19602,8 @@
                 }
             },
             {
-                "id": 1175060480,
+                "id": 10,
+                "full_id": 1175060480,
                 "name": "Gabrovo",
                 "translations": {
                     "japanese": "ガブロボ州",
@@ -18951,7 +19629,8 @@
                 }
             },
             {
-                "id": 1175126016,
+                "id": 11,
+                "full_id": 1175126016,
                 "name": "Haskovo",
                 "translations": {
                     "japanese": "ハスコボ州",
@@ -18977,7 +19656,8 @@
                 }
             },
             {
-                "id": 1175191552,
+                "id": 12,
+                "full_id": 1175191552,
                 "name": "Yambol",
                 "translations": {
                     "japanese": "ヤンボル州",
@@ -19003,7 +19683,8 @@
                 }
             },
             {
-                "id": 1175257088,
+                "id": 13,
+                "full_id": 1175257088,
                 "name": "Kardzhali",
                 "translations": {
                     "japanese": "クルジャリ州",
@@ -19029,7 +19710,8 @@
                 }
             },
             {
-                "id": 1175322624,
+                "id": 14,
+                "full_id": 1175322624,
                 "name": "Kyustendil",
                 "translations": {
                     "japanese": "キュステンディル州",
@@ -19055,7 +19737,8 @@
                 }
             },
             {
-                "id": 1175388160,
+                "id": 15,
+                "full_id": 1175388160,
                 "name": "Lovech",
                 "translations": {
                     "japanese": "ロベチ州",
@@ -19081,7 +19764,8 @@
                 }
             },
             {
-                "id": 1175453696,
+                "id": 1,
+                "full_id": 1175453696,
                 "name": "Montana",
                 "translations": {
                     "japanese": "モンタナ州",
@@ -19107,7 +19791,8 @@
                 }
             },
             {
-                "id": 1175519232,
+                "id": 17,
+                "full_id": 1175519232,
                 "name": "Pazardzhik",
                 "translations": {
                     "japanese": "パザルジク州",
@@ -19133,7 +19818,8 @@
                 }
             },
             {
-                "id": 1175584768,
+                "id": 18,
+                "full_id": 1175584768,
                 "name": "Pernik",
                 "translations": {
                     "japanese": "ペルニク州",
@@ -19159,7 +19845,8 @@
                 }
             },
             {
-                "id": 1175650304,
+                "id": 19,
+                "full_id": 1175650304,
                 "name": "Plovdiv",
                 "translations": {
                     "japanese": "プロブディフ州",
@@ -19185,7 +19872,8 @@
                 }
             },
             {
-                "id": 1175715840,
+                "id": 20,
+                "full_id": 1175715840,
                 "name": "Razgrad",
                 "translations": {
                     "japanese": "ラズグラド州",
@@ -19211,7 +19899,8 @@
                 }
             },
             {
-                "id": 1175781376,
+                "id": 21,
+                "full_id": 1175781376,
                 "name": "Ruse",
                 "translations": {
                     "japanese": "ルセ州",
@@ -19237,7 +19926,8 @@
                 }
             },
             {
-                "id": 1175846912,
+                "id": 22,
+                "full_id": 1175846912,
                 "name": "Silistra",
                 "translations": {
                     "japanese": "シリストラ州",
@@ -19263,7 +19953,8 @@
                 }
             },
             {
-                "id": 1175912448,
+                "id": 23,
+                "full_id": 1175912448,
                 "name": "Sliven",
                 "translations": {
                     "japanese": "スリベン州",
@@ -19289,7 +19980,8 @@
                 }
             },
             {
-                "id": 1175977984,
+                "id": 24,
+                "full_id": 1175977984,
                 "name": "Smolyan",
                 "translations": {
                     "japanese": "スモリャン州",
@@ -19315,7 +20007,8 @@
                 }
             },
             {
-                "id": 1176043520,
+                "id": 25,
+                "full_id": 1176043520,
                 "name": "Stara Zagora",
                 "translations": {
                     "japanese": "スタラ・ザゴラ州",
@@ -19341,7 +20034,8 @@
                 }
             },
             {
-                "id": 1176109056,
+                "id": 26,
+                "full_id": 1176109056,
                 "name": "Shumen",
                 "translations": {
                     "japanese": "シュメン州",
@@ -19367,7 +20061,8 @@
                 }
             },
             {
-                "id": 1176174592,
+                "id": 27,
+                "full_id": 1176174592,
                 "name": "Targovishte",
                 "translations": {
                     "japanese": "トゥルゴビシュテ州",
@@ -19393,7 +20088,8 @@
                 }
             },
             {
-                "id": 1176240128,
+                "id": 28,
+                "full_id": 1176240128,
                 "name": "Veliko Tarnovo",
                 "translations": {
                     "japanese": "ベリコ・トゥルノボ州",
@@ -19419,7 +20115,8 @@
                 }
             },
             {
-                "id": 1176305664,
+                "id": 29,
+                "full_id": 1176305664,
                 "name": "Vratsa",
                 "translations": {
                     "japanese": "ブラツァ州",
@@ -19470,7 +20167,8 @@
         },
         "regions": [
             {
-                "id": 1191182336,
+                "id": 0,
+                "full_id": 1191182336,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -19496,7 +20194,8 @@
                 }
             },
             {
-                "id": 1191575552,
+                "id": 6,
+                "full_id": 1191575552,
                 "name": "Zagreb",
                 "translations": {
                     "japanese": "ザグレブ直轄市",
@@ -19522,7 +20221,8 @@
                 }
             },
             {
-                "id": 1191641088,
+                "id": 7,
+                "full_id": 1191641088,
                 "name": "Bjelovar-Bilogora County",
                 "translations": {
                     "japanese": "ビェロヴァル＝ビロゴラ郡",
@@ -19548,7 +20248,8 @@
                 }
             },
             {
-                "id": 1191706624,
+                "id": 8,
+                "full_id": 1191706624,
                 "name": "Brod-Posavina County",
                 "translations": {
                     "japanese": "ブロド＝ポサヴィナ郡",
@@ -19574,7 +20275,8 @@
                 }
             },
             {
-                "id": 1191772160,
+                "id": 9,
+                "full_id": 1191772160,
                 "name": "Dubrovnik-Neretva County",
                 "translations": {
                     "japanese": "ドゥブロヴニク＝ネレトヴァ郡",
@@ -19600,7 +20302,8 @@
                 }
             },
             {
-                "id": 1191837696,
+                "id": 10,
+                "full_id": 1191837696,
                 "name": "Istria County",
                 "translations": {
                     "japanese": "イストラ郡",
@@ -19626,7 +20329,8 @@
                 }
             },
             {
-                "id": 1191903232,
+                "id": 11,
+                "full_id": 1191903232,
                 "name": "Karlovac County",
                 "translations": {
                     "japanese": "カルロヴァツ郡",
@@ -19652,7 +20356,8 @@
                 }
             },
             {
-                "id": 1191968768,
+                "id": 12,
+                "full_id": 1191968768,
                 "name": "Koprivnica-Križevci County",
                 "translations": {
                     "japanese": "コプリヴニツァ＝クリジェヴツィ郡",
@@ -19678,7 +20383,8 @@
                 }
             },
             {
-                "id": 1192034304,
+                "id": 13,
+                "full_id": 1192034304,
                 "name": "Krapina-Zagorje County",
                 "translations": {
                     "japanese": "クラピナ＝ザゴリエ郡",
@@ -19704,7 +20410,8 @@
                 }
             },
             {
-                "id": 1192099840,
+                "id": 14,
+                "full_id": 1192099840,
                 "name": "Lika-Senj County",
                 "translations": {
                     "japanese": "リカ＝セニ郡",
@@ -19730,7 +20437,8 @@
                 }
             },
             {
-                "id": 1192165376,
+                "id": 15,
+                "full_id": 1192165376,
                 "name": "Međimurje County",
                 "translations": {
                     "japanese": "メジムリェ郡",
@@ -19756,7 +20464,8 @@
                 }
             },
             {
-                "id": 1192230912,
+                "id": 1,
+                "full_id": 1192230912,
                 "name": "Osijek-Baranja County",
                 "translations": {
                     "japanese": "オシエク＝バラニャ郡",
@@ -19782,7 +20491,8 @@
                 }
             },
             {
-                "id": 1192296448,
+                "id": 17,
+                "full_id": 1192296448,
                 "name": "Požega-Slavonia County",
                 "translations": {
                     "japanese": "ポジェガ＝スラヴォニア郡",
@@ -19808,7 +20518,8 @@
                 }
             },
             {
-                "id": 1192361984,
+                "id": 18,
+                "full_id": 1192361984,
                 "name": "Primorje-Gorski Kotar County",
                 "translations": {
                     "japanese": "プリモリェ＝ゴルスキ・コタル郡",
@@ -19834,7 +20545,8 @@
                 }
             },
             {
-                "id": 1192427520,
+                "id": 19,
+                "full_id": 1192427520,
                 "name": "Sisak-Moslavina County",
                 "translations": {
                     "japanese": "シサク＝モスラヴィナ郡",
@@ -19850,7 +20562,7 @@
                     "russian": "Сисацко-Мославинская жупания",
                     "chinese_traditional": "Sisak-Moslavina County",
                     "unknown1": "Sisak-Moslavina County",
-                    "unknown2": "ᑻ۱埣ἴk-Moslavina County",
+                    "unknown2": "Sisak-Moslavina County",
                     "unknown3": "Sisak-Moslavina County",
                     "unknown4": "Sisak-Moslavina County"
                 },
@@ -19860,7 +20572,8 @@
                 }
             },
             {
-                "id": 1192493056,
+                "id": 20,
+                "full_id": 1192493056,
                 "name": "Split-Dalmatia County",
                 "translations": {
                     "japanese": "スプリト＝ダルマチア郡",
@@ -19886,7 +20599,8 @@
                 }
             },
             {
-                "id": 1192558592,
+                "id": 21,
+                "full_id": 1192558592,
                 "name": "Šibenik-Knin County",
                 "translations": {
                     "japanese": "シベニク＝クニン郡",
@@ -19912,7 +20626,8 @@
                 }
             },
             {
-                "id": 1192624128,
+                "id": 22,
+                "full_id": 1192624128,
                 "name": "Varaždin County",
                 "translations": {
                     "japanese": "ヴァラジュディン郡",
@@ -19938,7 +20653,8 @@
                 }
             },
             {
-                "id": 1192689664,
+                "id": 23,
+                "full_id": 1192689664,
                 "name": "Virovitica-Podravina County",
                 "translations": {
                     "japanese": "ヴィロヴィティツァ＝ポドラヴィナ郡",
@@ -19964,7 +20680,8 @@
                 }
             },
             {
-                "id": 1192755200,
+                "id": 24,
+                "full_id": 1192755200,
                 "name": "Vukovar-Syrmia County",
                 "translations": {
                     "japanese": "ヴコヴァル＝スリイェム郡",
@@ -19990,7 +20707,8 @@
                 }
             },
             {
-                "id": 1192820736,
+                "id": 25,
+                "full_id": 1192820736,
                 "name": "Zadar County",
                 "translations": {
                     "japanese": "ザダル郡",
@@ -20016,7 +20734,8 @@
                 }
             },
             {
-                "id": 1192886272,
+                "id": 26,
+                "full_id": 1192886272,
                 "name": "Zagreb County",
                 "translations": {
                     "japanese": "ザグレブ郡",
@@ -20067,7 +20786,8 @@
         },
         "regions": [
             {
-                "id": 1207959552,
+                "id": 0,
+                "full_id": 1207959552,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20093,7 +20813,8 @@
                 }
             },
             {
-                "id": 1208025088,
+                "id": 1,
+                "full_id": 1208025088,
                 "name": "Cyprus",
                 "translations": {
                     "japanese": "キプロス",
@@ -20144,7 +20865,8 @@
         },
         "regions": [
             {
-                "id": 1224736768,
+                "id": 0,
+                "full_id": 1224736768,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20170,7 +20892,8 @@
                 }
             },
             {
-                "id": 1224867840,
+                "id": 2,
+                "full_id": 1224867840,
                 "name": "Prague",
                 "translations": {
                     "japanese": "プラハ",
@@ -20196,7 +20919,8 @@
                 }
             },
             {
-                "id": 1224933376,
+                "id": 3,
+                "full_id": 1224933376,
                 "name": "Central Bohemian Region",
                 "translations": {
                     "japanese": "中部ボヘミア地方",
@@ -20222,7 +20946,8 @@
                 }
             },
             {
-                "id": 1224998912,
+                "id": 4,
+                "full_id": 1224998912,
                 "name": "South Bohemian Region",
                 "translations": {
                     "japanese": "南ボヘミア地方",
@@ -20248,7 +20973,8 @@
                 }
             },
             {
-                "id": 1225064448,
+                "id": 5,
+                "full_id": 1225064448,
                 "name": "Plzeň Region",
                 "translations": {
                     "japanese": "プルゼニ地方",
@@ -20274,7 +21000,8 @@
                 }
             },
             {
-                "id": 1225129984,
+                "id": 6,
+                "full_id": 1225129984,
                 "name": "Karlovy Vary Region",
                 "translations": {
                     "japanese": "カールスバート地方",
@@ -20300,7 +21027,8 @@
                 }
             },
             {
-                "id": 1225195520,
+                "id": 7,
+                "full_id": 1225195520,
                 "name": "Ústí nad Labem Region",
                 "translations": {
                     "japanese": "ウースチー・ナド・ラベム地方",
@@ -20326,7 +21054,8 @@
                 }
             },
             {
-                "id": 1225261056,
+                "id": 8,
+                "full_id": 1225261056,
                 "name": "Liberec Region",
                 "translations": {
                     "japanese": "リベレツ地方",
@@ -20352,7 +21081,8 @@
                 }
             },
             {
-                "id": 1225326592,
+                "id": 9,
+                "full_id": 1225326592,
                 "name": "Hradec Králové Region",
                 "translations": {
                     "japanese": "フラデツ・クラロベ地方",
@@ -20378,7 +21108,8 @@
                 }
             },
             {
-                "id": 1225392128,
+                "id": 10,
+                "full_id": 1225392128,
                 "name": "Pardubice Region",
                 "translations": {
                     "japanese": "パルドゥビツェ地方",
@@ -20404,7 +21135,8 @@
                 }
             },
             {
-                "id": 1225457664,
+                "id": 11,
+                "full_id": 1225457664,
                 "name": "Olomouc Region",
                 "translations": {
                     "japanese": "オロモウツ地方",
@@ -20430,7 +21162,8 @@
                 }
             },
             {
-                "id": 1225523200,
+                "id": 12,
+                "full_id": 1225523200,
                 "name": "Moravian-Silesian Region",
                 "translations": {
                     "japanese": "モラビア・シレジア地方",
@@ -20456,7 +21189,8 @@
                 }
             },
             {
-                "id": 1225588736,
+                "id": 13,
+                "full_id": 1225588736,
                 "name": "South Moravian Region",
                 "translations": {
                     "japanese": "南モラビア地方",
@@ -20482,7 +21216,8 @@
                 }
             },
             {
-                "id": 1225654272,
+                "id": 14,
+                "full_id": 1225654272,
                 "name": "Zlín Region",
                 "translations": {
                     "japanese": "ズリン地方",
@@ -20508,7 +21243,8 @@
                 }
             },
             {
-                "id": 1225719808,
+                "id": 15,
+                "full_id": 1225719808,
                 "name": "Vysočina Region",
                 "translations": {
                     "japanese": "ヴィソチナ地方",
@@ -20559,7 +21295,8 @@
         },
         "regions": [
             {
-                "id": 1241513984,
+                "id": 0,
+                "full_id": 1241513984,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20585,7 +21322,8 @@
                 }
             },
             {
-                "id": 1242693632,
+                "id": 18,
+                "full_id": 1242693632,
                 "name": "Greenland",
                 "translations": {
                     "japanese": "グリーンランド",
@@ -20611,7 +21349,8 @@
                 }
             },
             {
-                "id": 1242759168,
+                "id": 19,
+                "full_id": 1242759168,
                 "name": "Capital Region of Denmark",
                 "translations": {
                     "japanese": "デンマーク首都地域",
@@ -20637,7 +21376,8 @@
                 }
             },
             {
-                "id": 1242824704,
+                "id": 20,
+                "full_id": 1242824704,
                 "name": "Central Denmark Region",
                 "translations": {
                     "japanese": "中央ユラン地域",
@@ -20663,7 +21403,8 @@
                 }
             },
             {
-                "id": 1242890240,
+                "id": 21,
+                "full_id": 1242890240,
                 "name": "North Denmark Region",
                 "translations": {
                     "japanese": "北ユラン地域",
@@ -20689,7 +21430,8 @@
                 }
             },
             {
-                "id": 1242955776,
+                "id": 22,
+                "full_id": 1242955776,
                 "name": "Region Zealand",
                 "translations": {
                     "japanese": "シェラン地域",
@@ -20715,7 +21457,8 @@
                 }
             },
             {
-                "id": 1243021312,
+                "id": 23,
+                "full_id": 1243021312,
                 "name": "Region of Southern Denmark",
                 "translations": {
                     "japanese": "南デンマーク地域",
@@ -20733,7 +21476,7 @@
                     "unknown1": "Region of Southern Denmark",
                     "unknown2": "Region of Southern Denmark",
                     "unknown3": "Region of Southern Denmark",
-                    "unknown4": "씒⭤ꥠ軷on of Southern Denmark"
+                    "unknown4": "Region of Southern Denmark"
                 },
                 "coordinates": {
                     "latitude": 55.711669288,
@@ -20741,7 +21484,8 @@
                 }
             },
             {
-                "id": 1243086848,
+                "id": 24,
+                "full_id": 1243086848,
                 "name": "Faroe Islands",
                 "translations": {
                     "japanese": "フェロー諸島",
@@ -20792,7 +21536,8 @@
         },
         "regions": [
             {
-                "id": 1258291200,
+                "id": 0,
+                "full_id": 1258291200,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20818,7 +21563,8 @@
                 }
             },
             {
-                "id": 1258356736,
+                "id": 1,
+                "full_id": 1258356736,
                 "name": "Estonia",
                 "translations": {
                     "japanese": "エストニア",
@@ -20869,7 +21615,8 @@
         },
         "regions": [
             {
-                "id": 1275068416,
+                "id": 0,
+                "full_id": 1275068416,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -20895,7 +21642,8 @@
                 }
             },
             {
-                "id": 1275592704,
+                "id": 8,
+                "full_id": 1275592704,
                 "name": "Uusimaa / Nyland",
                 "translations": {
                     "japanese": "ウーシマー県",
@@ -20921,7 +21669,8 @@
                 }
             },
             {
-                "id": 1275658240,
+                "id": 9,
+                "full_id": 1275658240,
                 "name": "Lappi / Lapland",
                 "translations": {
                     "japanese": "ラッピ州",
@@ -20947,7 +21696,8 @@
                 }
             },
             {
-                "id": 1275723776,
+                "id": 10,
+                "full_id": 1275723776,
                 "name": "Pohjois-Pohjanmaa / Norra Österbotten",
                 "translations": {
                     "japanese": "北ポフヤンマー県",
@@ -20973,7 +21723,8 @@
                 }
             },
             {
-                "id": 1275789312,
+                "id": 11,
+                "full_id": 1275789312,
                 "name": "Kainuu / Kajanaland",
                 "translations": {
                     "japanese": "カイヌー県",
@@ -20999,7 +21750,8 @@
                 }
             },
             {
-                "id": 1275854848,
+                "id": 12,
+                "full_id": 1275854848,
                 "name": "Pohjois-Karjala / Norra Karelen",
                 "translations": {
                     "japanese": "北カレリア県",
@@ -21025,7 +21777,8 @@
                 }
             },
             {
-                "id": 1275920384,
+                "id": 13,
+                "full_id": 1275920384,
                 "name": "Pohjois-Savo / Norra Savolax",
                 "translations": {
                     "japanese": "北サヴォ県",
@@ -21051,7 +21804,8 @@
                 }
             },
             {
-                "id": 1275985920,
+                "id": 14,
+                "full_id": 1275985920,
                 "name": "Etelä-Savo / Södra Savolax",
                 "translations": {
                     "japanese": "南サヴォ県",
@@ -21077,7 +21831,8 @@
                 }
             },
             {
-                "id": 1276051456,
+                "id": 15,
+                "full_id": 1276051456,
                 "name": "Etelä-Pohjanmaa / Södra Österbotten",
                 "translations": {
                     "japanese": "南ポフヤンマー県",
@@ -21103,7 +21858,8 @@
                 }
             },
             {
-                "id": 1276116992,
+                "id": 1,
+                "full_id": 1276116992,
                 "name": "Pohjanmaa / Österbotten",
                 "translations": {
                     "japanese": "ポフヤンマー県",
@@ -21129,7 +21885,8 @@
                 }
             },
             {
-                "id": 1276182528,
+                "id": 17,
+                "full_id": 1276182528,
                 "name": "Pirkanmaa / Birkaland",
                 "translations": {
                     "japanese": "ピルカンマー県",
@@ -21155,7 +21912,8 @@
                 }
             },
             {
-                "id": 1276248064,
+                "id": 18,
+                "full_id": 1276248064,
                 "name": "Satakunta / Satakunda",
                 "translations": {
                     "japanese": "サタクンタ県",
@@ -21181,7 +21939,8 @@
                 }
             },
             {
-                "id": 1276313600,
+                "id": 19,
+                "full_id": 1276313600,
                 "name": "Keski-Pohjanmaa / Mellersta Österbotten",
                 "translations": {
                     "japanese": "中部ポフヤンマー県",
@@ -21207,7 +21966,8 @@
                 }
             },
             {
-                "id": 1276379136,
+                "id": 20,
+                "full_id": 1276379136,
                 "name": "Keski-Suomi / Mellersta Finland",
                 "translations": {
                     "japanese": "中央スオミ県",
@@ -21233,7 +21993,8 @@
                 }
             },
             {
-                "id": 1276444672,
+                "id": 21,
+                "full_id": 1276444672,
                 "name": "Varsinais-Suomi / Egentliga Finland",
                 "translations": {
                     "japanese": "ヴァルシナイス=スオミ県",
@@ -21259,7 +22020,8 @@
                 }
             },
             {
-                "id": 1276510208,
+                "id": 22,
+                "full_id": 1276510208,
                 "name": "Etelä-Karjala / Södra Karelen",
                 "translations": {
                     "japanese": "南カレリア県",
@@ -21285,7 +22047,8 @@
                 }
             },
             {
-                "id": 1276575744,
+                "id": 23,
+                "full_id": 1276575744,
                 "name": "Päijät-Häme / Päijänne Tavastland",
                 "translations": {
                     "japanese": "パイヤト=ハメ県",
@@ -21311,7 +22074,8 @@
                 }
             },
             {
-                "id": 1276641280,
+                "id": 24,
+                "full_id": 1276641280,
                 "name": "Kanta-Häme / Egentliga Tavastland",
                 "translations": {
                     "japanese": "カンタ=ハメ県",
@@ -21337,7 +22101,8 @@
                 }
             },
             {
-                "id": 1276772352,
+                "id": 26,
+                "full_id": 1276772352,
                 "name": "Kymenlaakso / Kymmenedalen",
                 "translations": {
                     "japanese": "キュメンラークソ県",
@@ -21363,7 +22128,8 @@
                 }
             },
             {
-                "id": 1276837888,
+                "id": 27,
+                "full_id": 1276837888,
                 "name": "Ahvenanmaa / Åland",
                 "translations": {
                     "japanese": "アハベナンマー州",
@@ -21414,7 +22180,8 @@
         },
         "regions": [
             {
-                "id": 1291845632,
+                "id": 0,
+                "full_id": 1291845632,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -21440,7 +22207,8 @@
                 }
             },
             {
-                "id": 1291976704,
+                "id": 2,
+                "full_id": 1291976704,
                 "name": "Île-de-France",
                 "translations": {
                     "japanese": "イール・ド・フランス",
@@ -21466,7 +22234,8 @@
                 }
             },
             {
-                "id": 1292042240,
+                "id": 3,
+                "full_id": 1292042240,
                 "name": "Alsace",
                 "translations": {
                     "japanese": "アルザス",
@@ -21492,7 +22261,8 @@
                 }
             },
             {
-                "id": 1292107776,
+                "id": 4,
+                "full_id": 1292107776,
                 "name": "Aquitaine",
                 "translations": {
                     "japanese": "アキテーヌ",
@@ -21518,7 +22288,8 @@
                 }
             },
             {
-                "id": 1292173312,
+                "id": 5,
+                "full_id": 1292173312,
                 "name": "Auvergne",
                 "translations": {
                     "japanese": "オーベルニュ",
@@ -21544,7 +22315,8 @@
                 }
             },
             {
-                "id": 1292238848,
+                "id": 6,
+                "full_id": 1292238848,
                 "name": "Lower Normandy",
                 "translations": {
                     "japanese": "バス・ノルマンディ",
@@ -21570,7 +22342,8 @@
                 }
             },
             {
-                "id": 1292304384,
+                "id": 7,
+                "full_id": 1292304384,
                 "name": "Burgundy",
                 "translations": {
                     "japanese": "ブルゴーニュ",
@@ -21596,7 +22369,8 @@
                 }
             },
             {
-                "id": 1292369920,
+                "id": 8,
+                "full_id": 1292369920,
                 "name": "Brittany",
                 "translations": {
                     "japanese": "ブルターニュ",
@@ -21622,7 +22396,8 @@
                 }
             },
             {
-                "id": 1292435456,
+                "id": 9,
+                "full_id": 1292435456,
                 "name": "Centre",
                 "translations": {
                     "japanese": "サントル",
@@ -21648,7 +22423,8 @@
                 }
             },
             {
-                "id": 1292500992,
+                "id": 10,
+                "full_id": 1292500992,
                 "name": "Champagne-Ardenne",
                 "translations": {
                     "japanese": "シャンパーニュ・アルデンヌ",
@@ -21674,7 +22450,8 @@
                 }
             },
             {
-                "id": 1292566528,
+                "id": 11,
+                "full_id": 1292566528,
                 "name": "Corsica",
                 "translations": {
                     "japanese": "コルシカ",
@@ -21700,7 +22477,8 @@
                 }
             },
             {
-                "id": 1292632064,
+                "id": 12,
+                "full_id": 1292632064,
                 "name": "Franche-Comté",
                 "translations": {
                     "japanese": "フランシュ・コンテ",
@@ -21726,7 +22504,8 @@
                 }
             },
             {
-                "id": 1292697600,
+                "id": 13,
+                "full_id": 1292697600,
                 "name": "Upper Normandy",
                 "translations": {
                     "japanese": "オート・ノルマンディ",
@@ -21752,7 +22531,8 @@
                 }
             },
             {
-                "id": 1292763136,
+                "id": 14,
+                "full_id": 1292763136,
                 "name": "Languedoc-Roussillon",
                 "translations": {
                     "japanese": "ラングドック・ルシヨン",
@@ -21778,7 +22558,8 @@
                 }
             },
             {
-                "id": 1292828672,
+                "id": 15,
+                "full_id": 1292828672,
                 "name": "Limousin",
                 "translations": {
                     "japanese": "リムーザン",
@@ -21804,7 +22585,8 @@
                 }
             },
             {
-                "id": 1292894208,
+                "id": 1,
+                "full_id": 1292894208,
                 "name": "Lorraine",
                 "translations": {
                     "japanese": "ロレーヌ",
@@ -21830,7 +22612,8 @@
                 }
             },
             {
-                "id": 1292959744,
+                "id": 17,
+                "full_id": 1292959744,
                 "name": "Midi-Pyrénées",
                 "translations": {
                     "japanese": "ミディ・ピレネー",
@@ -21856,7 +22639,8 @@
                 }
             },
             {
-                "id": 1293025280,
+                "id": 18,
+                "full_id": 1293025280,
                 "name": "Nord-Pas-de-Calais",
                 "translations": {
                     "japanese": "ノール・パ・ド・カレー",
@@ -21882,7 +22666,8 @@
                 }
             },
             {
-                "id": 1293090816,
+                "id": 19,
+                "full_id": 1293090816,
                 "name": "Pays de la Loire",
                 "translations": {
                     "japanese": "ペイ・ド・ラ・ロワール",
@@ -21908,7 +22693,8 @@
                 }
             },
             {
-                "id": 1293156352,
+                "id": 20,
+                "full_id": 1293156352,
                 "name": "Picardy",
                 "translations": {
                     "japanese": "ピカルディー",
@@ -21934,7 +22720,8 @@
                 }
             },
             {
-                "id": 1293221888,
+                "id": 21,
+                "full_id": 1293221888,
                 "name": "Poitou-Charentes",
                 "translations": {
                     "japanese": "ポワトゥー・シャラント",
@@ -21960,7 +22747,8 @@
                 }
             },
             {
-                "id": 1293287424,
+                "id": 22,
+                "full_id": 1293287424,
                 "name": "Provence-Alpes-Côte d'Azur",
                 "translations": {
                     "japanese": "プロヴァンス・アルプ・コート・ダジュール",
@@ -21986,7 +22774,8 @@
                 }
             },
             {
-                "id": 1293352960,
+                "id": 23,
+                "full_id": 1293352960,
                 "name": "Rhône-Alpes",
                 "translations": {
                     "japanese": "ローヌ・アルプ",
@@ -22012,7 +22801,8 @@
                 }
             },
             {
-                "id": 1293418496,
+                "id": 24,
+                "full_id": 1293418496,
                 "name": "Guadeloupe",
                 "translations": {
                     "japanese": "グアドループ",
@@ -22038,7 +22828,8 @@
                 }
             },
             {
-                "id": 1293484032,
+                "id": 25,
+                "full_id": 1293484032,
                 "name": "Martinique",
                 "translations": {
                     "japanese": "マルチニーク",
@@ -22064,7 +22855,8 @@
                 }
             },
             {
-                "id": 1293549568,
+                "id": 26,
+                "full_id": 1293549568,
                 "name": "French Guiana",
                 "translations": {
                     "japanese": "フランス領ギアナ",
@@ -22090,7 +22882,8 @@
                 }
             },
             {
-                "id": 1293615104,
+                "id": 27,
+                "full_id": 1293615104,
                 "name": "Réunion",
                 "translations": {
                     "japanese": "レユニオン",
@@ -22116,7 +22909,8 @@
                 }
             },
             {
-                "id": 1293680640,
+                "id": 28,
+                "full_id": 1293680640,
                 "name": "Mayotte",
                 "translations": {
                     "japanese": "マヨット島",
@@ -22167,7 +22961,8 @@
         },
         "regions": [
             {
-                "id": 1308622848,
+                "id": 0,
+                "full_id": 1308622848,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -22193,7 +22988,8 @@
                 }
             },
             {
-                "id": 1308753920,
+                "id": 2,
+                "full_id": 1308753920,
                 "name": "Berlin",
                 "translations": {
                     "japanese": "ベルリン",
@@ -22219,7 +23015,8 @@
                 }
             },
             {
-                "id": 1308819456,
+                "id": 3,
+                "full_id": 1308819456,
                 "name": "Hesse",
                 "translations": {
                     "japanese": "ヘッセン州",
@@ -22245,7 +23042,8 @@
                 }
             },
             {
-                "id": 1308884992,
+                "id": 4,
+                "full_id": 1308884992,
                 "name": "Baden-Württemberg",
                 "translations": {
                     "japanese": "バーデン・ビュルテンベルク州",
@@ -22271,7 +23069,8 @@
                 }
             },
             {
-                "id": 1308950528,
+                "id": 5,
+                "full_id": 1308950528,
                 "name": "Bavaria",
                 "translations": {
                     "japanese": "バイエルン州",
@@ -22297,7 +23096,8 @@
                 }
             },
             {
-                "id": 1309016064,
+                "id": 6,
+                "full_id": 1309016064,
                 "name": "Brandenburg",
                 "translations": {
                     "japanese": "ブランデンブルク州",
@@ -22323,7 +23123,8 @@
                 }
             },
             {
-                "id": 1309081600,
+                "id": 7,
+                "full_id": 1309081600,
                 "name": "Bremen",
                 "translations": {
                     "japanese": "ブレーメン",
@@ -22349,7 +23150,8 @@
                 }
             },
             {
-                "id": 1309147136,
+                "id": 8,
+                "full_id": 1309147136,
                 "name": "Hamburg",
                 "translations": {
                     "japanese": "ハンブルク",
@@ -22375,7 +23177,8 @@
                 }
             },
             {
-                "id": 1309212672,
+                "id": 9,
+                "full_id": 1309212672,
                 "name": "Mecklenburg-Vorpommern",
                 "translations": {
                     "japanese": "メクレンブルク・フォアポンメルン州",
@@ -22401,7 +23204,8 @@
                 }
             },
             {
-                "id": 1309278208,
+                "id": 10,
+                "full_id": 1309278208,
                 "name": "Lower Saxony",
                 "translations": {
                     "japanese": "ニーダーザクセン州",
@@ -22427,7 +23231,8 @@
                 }
             },
             {
-                "id": 1309343744,
+                "id": 11,
+                "full_id": 1309343744,
                 "name": "North Rhine-Westphalia",
                 "translations": {
                     "japanese": "ノルトライン・ウェストファーレン州",
@@ -22453,13 +23258,14 @@
                 }
             },
             {
-                "id": 1309409280,
+                "id": 12,
+                "full_id": 1309409280,
                 "name": "Rhineland-Palatinate",
                 "translations": {
                     "japanese": "ラインラント・ファルツ州",
                     "english": "Rhineland-Palatinate",
                     "french": "Rhénanie-Palatinat",
-                    "german": "Rh쳐歮覀㞂ʮ∎d-Pfalz",
+                    "german": "Rheinland-Pfalz",
                     "italian": "Renania-Palatinato",
                     "spanish": "Renania-Palatinado",
                     "chinese_simple": "莱茵兰-普法尔茨州",
@@ -22479,7 +23285,8 @@
                 }
             },
             {
-                "id": 1309474816,
+                "id": 13,
+                "full_id": 1309474816,
                 "name": "Saarland",
                 "translations": {
                     "japanese": "ザールラント州",
@@ -22505,7 +23312,8 @@
                 }
             },
             {
-                "id": 1309540352,
+                "id": 14,
+                "full_id": 1309540352,
                 "name": "Saxony",
                 "translations": {
                     "japanese": "ザクセン州",
@@ -22531,7 +23339,8 @@
                 }
             },
             {
-                "id": 1309605888,
+                "id": 15,
+                "full_id": 1309605888,
                 "name": "Saxony-Anhalt",
                 "translations": {
                     "japanese": "ザクセン・アンハルト州",
@@ -22557,7 +23366,8 @@
                 }
             },
             {
-                "id": 1309671424,
+                "id": 1,
+                "full_id": 1309671424,
                 "name": "Schleswig-Holstein",
                 "translations": {
                     "japanese": "シュレスビヒ・ホルシュタイン州",
@@ -22583,7 +23393,8 @@
                 }
             },
             {
-                "id": 1309736960,
+                "id": 17,
+                "full_id": 1309736960,
                 "name": "Thuringia",
                 "translations": {
                     "japanese": "テューリンゲン州",
@@ -22634,7 +23445,8 @@
         },
         "regions": [
             {
-                "id": 1325400064,
+                "id": 0,
+                "full_id": 1325400064,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -22660,7 +23472,8 @@
                 }
             },
             {
-                "id": 1325531136,
+                "id": 2,
+                "full_id": 1325531136,
                 "name": "Attica",
                 "translations": {
                     "japanese": "アッティカ",
@@ -22686,7 +23499,8 @@
                 }
             },
             {
-                "id": 1325596672,
+                "id": 3,
+                "full_id": 1325596672,
                 "name": "Central Greece",
                 "translations": {
                     "japanese": "中央ギリシャ",
@@ -22712,7 +23526,8 @@
                 }
             },
             {
-                "id": 1325662208,
+                "id": 4,
+                "full_id": 1325662208,
                 "name": "Central Macedonia",
                 "translations": {
                     "japanese": "中央マケドニア",
@@ -22738,7 +23553,8 @@
                 }
             },
             {
-                "id": 1325727744,
+                "id": 5,
+                "full_id": 1325727744,
                 "name": "Crete",
                 "translations": {
                     "japanese": "クレタ",
@@ -22764,7 +23580,8 @@
                 }
             },
             {
-                "id": 1325793280,
+                "id": 6,
+                "full_id": 1325793280,
                 "name": "East Macedonia and Thrace",
                 "translations": {
                     "japanese": "東マケドニア・トラキア",
@@ -22790,7 +23607,8 @@
                 }
             },
             {
-                "id": 1325858816,
+                "id": 7,
+                "full_id": 1325858816,
                 "name": "Epirus",
                 "translations": {
                     "japanese": "イピロス",
@@ -22816,7 +23634,8 @@
                 }
             },
             {
-                "id": 1325924352,
+                "id": 8,
+                "full_id": 1325924352,
                 "name": "Ionian Islands",
                 "translations": {
                     "japanese": "イオニア",
@@ -22842,7 +23661,8 @@
                 }
             },
             {
-                "id": 1325989888,
+                "id": 9,
+                "full_id": 1325989888,
                 "name": "North Aegean",
                 "translations": {
                     "japanese": "北エーゲ",
@@ -22868,7 +23688,8 @@
                 }
             },
             {
-                "id": 1326055424,
+                "id": 10,
+                "full_id": 1326055424,
                 "name": "Peloponnese",
                 "translations": {
                     "japanese": "ペロポネソス",
@@ -22894,7 +23715,8 @@
                 }
             },
             {
-                "id": 1326120960,
+                "id": 11,
+                "full_id": 1326120960,
                 "name": "South Aegean",
                 "translations": {
                     "japanese": "南エーゲ",
@@ -22920,7 +23742,8 @@
                 }
             },
             {
-                "id": 1326186496,
+                "id": 12,
+                "full_id": 1326186496,
                 "name": "Thessaly",
                 "translations": {
                     "japanese": "テッサリーア",
@@ -22946,7 +23769,8 @@
                 }
             },
             {
-                "id": 1326252032,
+                "id": 13,
+                "full_id": 1326252032,
                 "name": "West Greece",
                 "translations": {
                     "japanese": "西ギリシャ",
@@ -22972,7 +23796,8 @@
                 }
             },
             {
-                "id": 1326317568,
+                "id": 14,
+                "full_id": 1326317568,
                 "name": "West Macedonia",
                 "translations": {
                     "japanese": "西マケドニア",
@@ -23023,7 +23848,8 @@
         },
         "regions": [
             {
-                "id": 1342177280,
+                "id": 0,
+                "full_id": 1342177280,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -23049,7 +23875,8 @@
                 }
             },
             {
-                "id": 1342308352,
+                "id": 2,
+                "full_id": 1342308352,
                 "name": "Budapest",
                 "translations": {
                     "japanese": "ブダペスト",
@@ -23075,7 +23902,8 @@
                 }
             },
             {
-                "id": 1342373888,
+                "id": 3,
+                "full_id": 1342373888,
                 "name": "Bács-Kiskun County",
                 "translations": {
                     "japanese": "バーチ・キシュクン州",
@@ -23101,7 +23929,8 @@
                 }
             },
             {
-                "id": 1342439424,
+                "id": 4,
+                "full_id": 1342439424,
                 "name": "Baranya County",
                 "translations": {
                     "japanese": "バラニャ州",
@@ -23127,7 +23956,8 @@
                 }
             },
             {
-                "id": 1342504960,
+                "id": 5,
+                "full_id": 1342504960,
                 "name": "Békés County",
                 "translations": {
                     "japanese": "ベーケーシュ州",
@@ -23153,7 +23983,8 @@
                 }
             },
             {
-                "id": 1342570496,
+                "id": 6,
+                "full_id": 1342570496,
                 "name": "Borsod-Abaúj-Zemplén County",
                 "translations": {
                     "japanese": "ボルショド・アバウーイ・ゼンプレーン州",
@@ -23179,7 +24010,8 @@
                 }
             },
             {
-                "id": 1342636032,
+                "id": 7,
+                "full_id": 1342636032,
                 "name": "Csongrád County",
                 "translations": {
                     "japanese": "チョングラード州",
@@ -23205,7 +24037,8 @@
                 }
             },
             {
-                "id": 1342701568,
+                "id": 8,
+                "full_id": 1342701568,
                 "name": "Fejér County",
                 "translations": {
                     "japanese": "フェイェール州",
@@ -23231,7 +24064,8 @@
                 }
             },
             {
-                "id": 1342767104,
+                "id": 9,
+                "full_id": 1342767104,
                 "name": "Győr-Moson-Sopron County",
                 "translations": {
                     "japanese": "ジェール・モション・ショプロン州",
@@ -23257,7 +24091,8 @@
                 }
             },
             {
-                "id": 1342832640,
+                "id": 10,
+                "full_id": 1342832640,
                 "name": "Hajdú-Bihar County",
                 "translations": {
                     "japanese": "ハイドゥー・ヒバル州",
@@ -23283,7 +24118,8 @@
                 }
             },
             {
-                "id": 1342898176,
+                "id": 11,
+                "full_id": 1342898176,
                 "name": "Heves County",
                 "translations": {
                     "japanese": "ヘヴェシュ州",
@@ -23309,7 +24145,8 @@
                 }
             },
             {
-                "id": 1342963712,
+                "id": 12,
+                "full_id": 1342963712,
                 "name": "Jász-Nagykun-Szolnok County",
                 "translations": {
                     "japanese": "ヤース・ナチクン・ソルノク州",
@@ -23317,7 +24154,7 @@
                     "french": "Jász-Nagykun-Szolnok",
                     "german": "Jász-Nagykun-Szolnok",
                     "italian": "Jász-Nagykun-Szolnok",
-                    "spanish": "Jász-Nagyk쳐歮覀㞂ʮ∎辝硂旱✑櫙᰺͖ﻩ",
+                    "spanish": "Jász-Nagykun-Szolnok",
                     "chinese_simple": "加兹-纳杰孔-索尔诺克州",
                     "korean": "야스너지쿤솔노크 주",
                     "dutch": "Jász-Nagykun-Szolnok",
@@ -23335,7 +24172,8 @@
                 }
             },
             {
-                "id": 1343029248,
+                "id": 13,
+                "full_id": 1343029248,
                 "name": "Komárom-Esztergom County",
                 "translations": {
                     "japanese": "コマーロム・エステルゴム州",
@@ -23361,7 +24199,8 @@
                 }
             },
             {
-                "id": 1343094784,
+                "id": 14,
+                "full_id": 1343094784,
                 "name": "Nógrád County",
                 "translations": {
                     "japanese": "ノーグラード州",
@@ -23387,7 +24226,8 @@
                 }
             },
             {
-                "id": 1343160320,
+                "id": 15,
+                "full_id": 1343160320,
                 "name": "Pest County",
                 "translations": {
                     "japanese": "ペシュト州",
@@ -23413,7 +24253,8 @@
                 }
             },
             {
-                "id": 1343225856,
+                "id": 1,
+                "full_id": 1343225856,
                 "name": "Somogy County",
                 "translations": {
                     "japanese": "ショモジ州",
@@ -23439,7 +24280,8 @@
                 }
             },
             {
-                "id": 1343291392,
+                "id": 17,
+                "full_id": 1343291392,
                 "name": "Szabolcs-Szatmár-Bereg County",
                 "translations": {
                     "japanese": "サボルチ・サトマール・ベレグ州",
@@ -23465,7 +24307,8 @@
                 }
             },
             {
-                "id": 1343356928,
+                "id": 18,
+                "full_id": 1343356928,
                 "name": "Tolna County",
                 "translations": {
                     "japanese": "トルナ州",
@@ -23491,7 +24334,8 @@
                 }
             },
             {
-                "id": 1343422464,
+                "id": 19,
+                "full_id": 1343422464,
                 "name": "Vas County",
                 "translations": {
                     "japanese": "ヴァシュ州",
@@ -23517,7 +24361,8 @@
                 }
             },
             {
-                "id": 1343488000,
+                "id": 20,
+                "full_id": 1343488000,
                 "name": "Veszprém County",
                 "translations": {
                     "japanese": "ベスプレーム州",
@@ -23543,7 +24388,8 @@
                 }
             },
             {
-                "id": 1343553536,
+                "id": 21,
+                "full_id": 1343553536,
                 "name": "Zala County",
                 "translations": {
                     "japanese": "ザラ州",
@@ -23594,7 +24440,8 @@
         },
         "regions": [
             {
-                "id": 1358954496,
+                "id": 0,
+                "full_id": 1358954496,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -23620,7 +24467,8 @@
                 }
             },
             {
-                "id": 1359020032,
+                "id": 1,
+                "full_id": 1359020032,
                 "name": "Iceland",
                 "translations": {
                     "japanese": "アイスランド",
@@ -23671,7 +24519,8 @@
         },
         "regions": [
             {
-                "id": 1375731712,
+                "id": 0,
+                "full_id": 1375731712,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -23697,7 +24546,8 @@
                 }
             },
             {
-                "id": 1375862784,
+                "id": 2,
+                "full_id": 1375862784,
                 "name": "Dublin",
                 "translations": {
                     "japanese": "ダブリン州",
@@ -23723,7 +24573,8 @@
                 }
             },
             {
-                "id": 1376387072,
+                "id": 10,
+                "full_id": 1376387072,
                 "name": "County Carlow",
                 "translations": {
                     "japanese": "カーロウ州",
@@ -23749,7 +24600,8 @@
                 }
             },
             {
-                "id": 1376452608,
+                "id": 11,
+                "full_id": 1376452608,
                 "name": "County Cavan",
                 "translations": {
                     "japanese": "キャバン州",
@@ -23775,7 +24627,8 @@
                 }
             },
             {
-                "id": 1376518144,
+                "id": 12,
+                "full_id": 1376518144,
                 "name": "County Clare",
                 "translations": {
                     "japanese": "クレア州",
@@ -23801,7 +24654,8 @@
                 }
             },
             {
-                "id": 1376583680,
+                "id": 13,
+                "full_id": 1376583680,
                 "name": "County Cork",
                 "translations": {
                     "japanese": "コーク州",
@@ -23827,7 +24681,8 @@
                 }
             },
             {
-                "id": 1376649216,
+                "id": 14,
+                "full_id": 1376649216,
                 "name": "County Donegal",
                 "translations": {
                     "japanese": "ドニゴール州",
@@ -23853,7 +24708,8 @@
                 }
             },
             {
-                "id": 1376714752,
+                "id": 15,
+                "full_id": 1376714752,
                 "name": "County Galway",
                 "translations": {
                     "japanese": "ゴールウェイ州",
@@ -23879,7 +24735,8 @@
                 }
             },
             {
-                "id": 1376780288,
+                "id": 1,
+                "full_id": 1376780288,
                 "name": "County Kerry",
                 "translations": {
                     "japanese": "ケリー州",
@@ -23905,7 +24762,8 @@
                 }
             },
             {
-                "id": 1376845824,
+                "id": 17,
+                "full_id": 1376845824,
                 "name": "County Kildare",
                 "translations": {
                     "japanese": "キルデア州",
@@ -23931,7 +24789,8 @@
                 }
             },
             {
-                "id": 1376911360,
+                "id": 18,
+                "full_id": 1376911360,
                 "name": "County Kilkenny",
                 "translations": {
                     "japanese": "キルケニー州",
@@ -23957,7 +24816,8 @@
                 }
             },
             {
-                "id": 1376976896,
+                "id": 19,
+                "full_id": 1376976896,
                 "name": "County Laois",
                 "translations": {
                     "japanese": "リーシュ州",
@@ -23983,7 +24843,8 @@
                 }
             },
             {
-                "id": 1377042432,
+                "id": 20,
+                "full_id": 1377042432,
                 "name": "County Leitrim",
                 "translations": {
                     "japanese": "リートリム州",
@@ -24009,7 +24870,8 @@
                 }
             },
             {
-                "id": 1377107968,
+                "id": 21,
+                "full_id": 1377107968,
                 "name": "County Limerick",
                 "translations": {
                     "japanese": "リムリック州",
@@ -24035,7 +24897,8 @@
                 }
             },
             {
-                "id": 1377173504,
+                "id": 22,
+                "full_id": 1377173504,
                 "name": "County Longford",
                 "translations": {
                     "japanese": "ロングフォード州",
@@ -24061,7 +24924,8 @@
                 }
             },
             {
-                "id": 1377239040,
+                "id": 23,
+                "full_id": 1377239040,
                 "name": "County Louth",
                 "translations": {
                     "japanese": "ラウス州",
@@ -24087,7 +24951,8 @@
                 }
             },
             {
-                "id": 1377304576,
+                "id": 24,
+                "full_id": 1377304576,
                 "name": "County Mayo",
                 "translations": {
                     "japanese": "メイヨー州",
@@ -24113,7 +24978,8 @@
                 }
             },
             {
-                "id": 1377370112,
+                "id": 25,
+                "full_id": 1377370112,
                 "name": "County Meath",
                 "translations": {
                     "japanese": "ミース州",
@@ -24139,7 +25005,8 @@
                 }
             },
             {
-                "id": 1377435648,
+                "id": 26,
+                "full_id": 1377435648,
                 "name": "County Monaghan",
                 "translations": {
                     "japanese": "モナハン州",
@@ -24165,7 +25032,8 @@
                 }
             },
             {
-                "id": 1377501184,
+                "id": 27,
+                "full_id": 1377501184,
                 "name": "County Offaly",
                 "translations": {
                     "japanese": "オファリー州",
@@ -24191,7 +25059,8 @@
                 }
             },
             {
-                "id": 1377566720,
+                "id": 28,
+                "full_id": 1377566720,
                 "name": "County Roscommon",
                 "translations": {
                     "japanese": "ロスコモン州",
@@ -24217,7 +25086,8 @@
                 }
             },
             {
-                "id": 1377632256,
+                "id": 29,
+                "full_id": 1377632256,
                 "name": "County Sligo",
                 "translations": {
                     "japanese": "スライゴ州",
@@ -24243,7 +25113,8 @@
                 }
             },
             {
-                "id": 1377697792,
+                "id": 30,
+                "full_id": 1377697792,
                 "name": "County Tipperary",
                 "translations": {
                     "japanese": "ティペラリー州",
@@ -24269,7 +25140,8 @@
                 }
             },
             {
-                "id": 1377763328,
+                "id": 31,
+                "full_id": 1377763328,
                 "name": "County Waterford",
                 "translations": {
                     "japanese": "ウォーターフォード州",
@@ -24295,7 +25167,8 @@
                 }
             },
             {
-                "id": 1377828864,
+                "id": 2,
+                "full_id": 1377828864,
                 "name": "County Westmeath",
                 "translations": {
                     "japanese": "ウェストミース州",
@@ -24321,7 +25194,8 @@
                 }
             },
             {
-                "id": 1377894400,
+                "id": 33,
+                "full_id": 1377894400,
                 "name": "County Wexford",
                 "translations": {
                     "japanese": "ウェックスフォード州",
@@ -24347,7 +25221,8 @@
                 }
             },
             {
-                "id": 1377959936,
+                "id": 34,
+                "full_id": 1377959936,
                 "name": "County Wicklow",
                 "translations": {
                     "japanese": "ウィックロー州",
@@ -24398,7 +25273,8 @@
         },
         "regions": [
             {
-                "id": 1392508928,
+                "id": 0,
+                "full_id": 1392508928,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -24424,7 +25300,8 @@
                 }
             },
             {
-                "id": 1392640000,
+                "id": 2,
+                "full_id": 1392640000,
                 "name": "Lazio",
                 "translations": {
                     "japanese": "ラツィオ州",
@@ -24450,7 +25327,8 @@
                 }
             },
             {
-                "id": 1392705536,
+                "id": 3,
+                "full_id": 1392705536,
                 "name": "Aosta Valley",
                 "translations": {
                     "japanese": "バッレ・ダオスタ州",
@@ -24476,7 +25354,8 @@
                 }
             },
             {
-                "id": 1392771072,
+                "id": 4,
+                "full_id": 1392771072,
                 "name": "Piedmont",
                 "translations": {
                     "japanese": "ピエモンテ州",
@@ -24502,7 +25381,8 @@
                 }
             },
             {
-                "id": 1392836608,
+                "id": 5,
+                "full_id": 1392836608,
                 "name": "Liguria",
                 "translations": {
                     "japanese": "リグリア州",
@@ -24528,7 +25408,8 @@
                 }
             },
             {
-                "id": 1392902144,
+                "id": 6,
+                "full_id": 1392902144,
                 "name": "Lombardy",
                 "translations": {
                     "japanese": "ロンバルディア州",
@@ -24554,7 +25435,8 @@
                 }
             },
             {
-                "id": 1392967680,
+                "id": 7,
+                "full_id": 1392967680,
                 "name": "Trentino-Alto Adige",
                 "translations": {
                     "japanese": "トレンティノ・アルト・アディジェ州",
@@ -24580,7 +25462,8 @@
                 }
             },
             {
-                "id": 1393033216,
+                "id": 8,
+                "full_id": 1393033216,
                 "name": "Veneto",
                 "translations": {
                     "japanese": "ベネト州",
@@ -24606,7 +25489,8 @@
                 }
             },
             {
-                "id": 1393098752,
+                "id": 9,
+                "full_id": 1393098752,
                 "name": "Friuli Venezia Giulia",
                 "translations": {
                     "japanese": "フリウリ・ベネチア・ジュリア州",
@@ -24632,7 +25516,8 @@
                 }
             },
             {
-                "id": 1393164288,
+                "id": 10,
+                "full_id": 1393164288,
                 "name": "Emilia-Romagna",
                 "translations": {
                     "japanese": "エミリア・ロマーニャ州",
@@ -24658,7 +25543,8 @@
                 }
             },
             {
-                "id": 1393229824,
+                "id": 11,
+                "full_id": 1393229824,
                 "name": "Tuscany",
                 "translations": {
                     "japanese": "トスカナ州",
@@ -24684,7 +25570,8 @@
                 }
             },
             {
-                "id": 1393295360,
+                "id": 12,
+                "full_id": 1393295360,
                 "name": "Umbria",
                 "translations": {
                     "japanese": "ウンブリア州",
@@ -24710,7 +25597,8 @@
                 }
             },
             {
-                "id": 1393360896,
+                "id": 13,
+                "full_id": 1393360896,
                 "name": "Marche",
                 "translations": {
                     "japanese": "マルケ州",
@@ -24736,7 +25624,8 @@
                 }
             },
             {
-                "id": 1393426432,
+                "id": 14,
+                "full_id": 1393426432,
                 "name": "Abruzzo",
                 "translations": {
                     "japanese": "アブルッツィ州",
@@ -24762,7 +25651,8 @@
                 }
             },
             {
-                "id": 1393491968,
+                "id": 15,
+                "full_id": 1393491968,
                 "name": "Molise",
                 "translations": {
                     "japanese": "モリーゼ州",
@@ -24788,7 +25678,8 @@
                 }
             },
             {
-                "id": 1393557504,
+                "id": 1,
+                "full_id": 1393557504,
                 "name": "Campania",
                 "translations": {
                     "japanese": "カンパニア州",
@@ -24814,7 +25705,8 @@
                 }
             },
             {
-                "id": 1393623040,
+                "id": 17,
+                "full_id": 1393623040,
                 "name": "Apulia",
                 "translations": {
                     "japanese": "プーリア州",
@@ -24840,7 +25732,8 @@
                 }
             },
             {
-                "id": 1393688576,
+                "id": 18,
+                "full_id": 1393688576,
                 "name": "Basilicata",
                 "translations": {
                     "japanese": "バジリカータ州",
@@ -24866,7 +25759,8 @@
                 }
             },
             {
-                "id": 1393754112,
+                "id": 19,
+                "full_id": 1393754112,
                 "name": "Calabria",
                 "translations": {
                     "japanese": "カラブリア州",
@@ -24892,7 +25786,8 @@
                 }
             },
             {
-                "id": 1393819648,
+                "id": 20,
+                "full_id": 1393819648,
                 "name": "Sicily",
                 "translations": {
                     "japanese": "シチリア州",
@@ -24918,7 +25813,8 @@
                 }
             },
             {
-                "id": 1393885184,
+                "id": 21,
+                "full_id": 1393885184,
                 "name": "Sardinia",
                 "translations": {
                     "japanese": "サルデーニャ州",
@@ -24969,7 +25865,8 @@
         },
         "regions": [
             {
-                "id": 1409286144,
+                "id": 0,
+                "full_id": 1409286144,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -24995,7 +25892,8 @@
                 }
             },
             {
-                "id": 1409351680,
+                "id": 1,
+                "full_id": 1409351680,
                 "name": "Latvia",
                 "translations": {
                     "japanese": "ラトビア",
@@ -25046,7 +25944,8 @@
         },
         "regions": [
             {
-                "id": 1426063360,
+                "id": 0,
+                "full_id": 1426063360,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25072,7 +25971,8 @@
                 }
             },
             {
-                "id": 1426194432,
+                "id": 2,
+                "full_id": 1426194432,
                 "name": "Maseru",
                 "translations": {
                     "japanese": "マセル県",
@@ -25098,7 +25998,8 @@
                 }
             },
             {
-                "id": 1426259968,
+                "id": 3,
+                "full_id": 1426259968,
                 "name": "Berea",
                 "translations": {
                     "japanese": "べレア県",
@@ -25124,7 +26025,8 @@
                 }
             },
             {
-                "id": 1426325504,
+                "id": 4,
+                "full_id": 1426325504,
                 "name": "Butha-Buthe",
                 "translations": {
                     "japanese": "ブータ・ブーテ県",
@@ -25150,7 +26052,8 @@
                 }
             },
             {
-                "id": 1426391040,
+                "id": 5,
+                "full_id": 1426391040,
                 "name": "Leribe",
                 "translations": {
                     "japanese": "レリベ県",
@@ -25176,7 +26079,8 @@
                 }
             },
             {
-                "id": 1426456576,
+                "id": 6,
+                "full_id": 1426456576,
                 "name": "Mafeteng",
                 "translations": {
                     "japanese": "マフェテング県",
@@ -25202,7 +26106,8 @@
                 }
             },
             {
-                "id": 1426522112,
+                "id": 7,
+                "full_id": 1426522112,
                 "name": "Mohale's Hoek",
                 "translations": {
                     "japanese": "モハーレスフーク県",
@@ -25228,7 +26133,8 @@
                 }
             },
             {
-                "id": 1426587648,
+                "id": 8,
+                "full_id": 1426587648,
                 "name": "Mokhotlong",
                 "translations": {
                     "japanese": "モコトロング県",
@@ -25254,7 +26160,8 @@
                 }
             },
             {
-                "id": 1426653184,
+                "id": 9,
+                "full_id": 1426653184,
                 "name": "Qacha's Nek",
                 "translations": {
                     "japanese": "クァクハスネック県",
@@ -25280,7 +26187,8 @@
                 }
             },
             {
-                "id": 1426718720,
+                "id": 10,
+                "full_id": 1426718720,
                 "name": "Quthing",
                 "translations": {
                     "japanese": "クティング県",
@@ -25306,7 +26214,8 @@
                 }
             },
             {
-                "id": 1426784256,
+                "id": 11,
+                "full_id": 1426784256,
                 "name": "Thaba-Tseka",
                 "translations": {
                     "japanese": "ターバ・ツェーカ県",
@@ -25357,7 +26266,8 @@
         },
         "regions": [
             {
-                "id": 1442840576,
+                "id": 0,
+                "full_id": 1442840576,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25383,7 +26293,8 @@
                 }
             },
             {
-                "id": 1442906112,
+                "id": 1,
+                "full_id": 1442906112,
                 "name": "Liechtenstein",
                 "translations": {
                     "japanese": "リヒテンシュタイン",
@@ -25434,7 +26345,8 @@
         },
         "regions": [
             {
-                "id": 1459617792,
+                "id": 0,
+                "full_id": 1459617792,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25460,7 +26372,8 @@
                 }
             },
             {
-                "id": 1459748864,
+                "id": 2,
+                "full_id": 1459748864,
                 "name": "Vilnius",
                 "translations": {
                     "japanese": "ヴィリニュス州",
@@ -25486,7 +26399,8 @@
                 }
             },
             {
-                "id": 1459814400,
+                "id": 3,
+                "full_id": 1459814400,
                 "name": "Alytus",
                 "translations": {
                     "japanese": "アリートゥス州",
@@ -25512,7 +26426,8 @@
                 }
             },
             {
-                "id": 1459879936,
+                "id": 4,
+                "full_id": 1459879936,
                 "name": "Kaunas",
                 "translations": {
                     "japanese": "カウナス州",
@@ -25538,7 +26453,8 @@
                 }
             },
             {
-                "id": 1459945472,
+                "id": 5,
+                "full_id": 1459945472,
                 "name": "Klaipėda",
                 "translations": {
                     "japanese": "クライペダ州",
@@ -25564,7 +26480,8 @@
                 }
             },
             {
-                "id": 1460011008,
+                "id": 6,
+                "full_id": 1460011008,
                 "name": "Marijampolė",
                 "translations": {
                     "japanese": "マリヤンポレ州",
@@ -25590,7 +26507,8 @@
                 }
             },
             {
-                "id": 1460076544,
+                "id": 7,
+                "full_id": 1460076544,
                 "name": "Panevėžys",
                 "translations": {
                     "japanese": "パネベジス州",
@@ -25616,7 +26534,8 @@
                 }
             },
             {
-                "id": 1460142080,
+                "id": 8,
+                "full_id": 1460142080,
                 "name": "Šiauliai",
                 "translations": {
                     "japanese": "シャウレイ州",
@@ -25642,7 +26561,8 @@
                 }
             },
             {
-                "id": 1460207616,
+                "id": 9,
+                "full_id": 1460207616,
                 "name": "Taurage",
                 "translations": {
                     "japanese": "タウラゲ州",
@@ -25668,7 +26588,8 @@
                 }
             },
             {
-                "id": 1460273152,
+                "id": 10,
+                "full_id": 1460273152,
                 "name": "Telšiai",
                 "translations": {
                     "japanese": "テルシェイ州",
@@ -25694,7 +26615,8 @@
                 }
             },
             {
-                "id": 1460338688,
+                "id": 11,
+                "full_id": 1460338688,
                 "name": "Utena",
                 "translations": {
                     "japanese": "ウテナ州",
@@ -25745,7 +26667,8 @@
         },
         "regions": [
             {
-                "id": 1476395008,
+                "id": 0,
+                "full_id": 1476395008,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25771,7 +26694,8 @@
                 }
             },
             {
-                "id": 1476460544,
+                "id": 1,
+                "full_id": 1476460544,
                 "name": "Luxembourg",
                 "translations": {
                     "japanese": "ルクセンブルク",
@@ -25822,7 +26746,8 @@
         },
         "regions": [
             {
-                "id": 1493172224,
+                "id": 0,
+                "full_id": 1493172224,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25848,7 +26773,8 @@
                 }
             },
             {
-                "id": 1493237760,
+                "id": 1,
+                "full_id": 1493237760,
                 "name": "Macedonia (Republic of)",
                 "translations": {
                     "japanese": "マケドニア",
@@ -25899,7 +26825,8 @@
         },
         "regions": [
             {
-                "id": 1509949440,
+                "id": 0,
+                "full_id": 1509949440,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -25925,7 +26852,8 @@
                 }
             },
             {
-                "id": 1510014976,
+                "id": 1,
+                "full_id": 1510014976,
                 "name": "Malta",
                 "translations": {
                     "japanese": "マルタ",
@@ -25976,7 +26904,8 @@
         },
         "regions": [
             {
-                "id": 1526726656,
+                "id": 0,
+                "full_id": 1526726656,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26002,7 +26931,8 @@
                 }
             },
             {
-                "id": 1526792192,
+                "id": 1,
+                "full_id": 1526792192,
                 "name": "Montenegro",
                 "translations": {
                     "japanese": "モンテネグロ",
@@ -26053,7 +26983,8 @@
         },
         "regions": [
             {
-                "id": 1543503872,
+                "id": 0,
+                "full_id": 1543503872,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26079,7 +27010,8 @@
                 }
             },
             {
-                "id": 1543569408,
+                "id": 1,
+                "full_id": 1543569408,
                 "name": "Mozambique",
                 "translations": {
                     "japanese": "モザンビーク",
@@ -26130,7 +27062,8 @@
         },
         "regions": [
             {
-                "id": 1560281088,
+                "id": 0,
+                "full_id": 1560281088,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26156,7 +27089,8 @@
                 }
             },
             {
-                "id": 1560346624,
+                "id": 1,
+                "full_id": 1560346624,
                 "name": "Namibia",
                 "translations": {
                     "japanese": "ナミビア",
@@ -26207,7 +27141,8 @@
         },
         "regions": [
             {
-                "id": 1577058304,
+                "id": 0,
+                "full_id": 1577058304,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26233,7 +27168,8 @@
                 }
             },
             {
-                "id": 1577189376,
+                "id": 2,
+                "full_id": 1577189376,
                 "name": "North Holland",
                 "translations": {
                     "japanese": "ノールト・ホラント州",
@@ -26259,7 +27195,8 @@
                 }
             },
             {
-                "id": 1577254912,
+                "id": 3,
+                "full_id": 1577254912,
                 "name": "Drenthe",
                 "translations": {
                     "japanese": "ドレンテ州",
@@ -26285,7 +27222,8 @@
                 }
             },
             {
-                "id": 1577320448,
+                "id": 4,
+                "full_id": 1577320448,
                 "name": "Flevoland",
                 "translations": {
                     "japanese": "フレボラント州",
@@ -26311,7 +27249,8 @@
                 }
             },
             {
-                "id": 1577385984,
+                "id": 5,
+                "full_id": 1577385984,
                 "name": "Friesland",
                 "translations": {
                     "japanese": "フリースラント州",
@@ -26337,7 +27276,8 @@
                 }
             },
             {
-                "id": 1577451520,
+                "id": 6,
+                "full_id": 1577451520,
                 "name": "Gelderland",
                 "translations": {
                     "japanese": "ヘルデンラント州",
@@ -26363,7 +27303,8 @@
                 }
             },
             {
-                "id": 1577517056,
+                "id": 7,
+                "full_id": 1577517056,
                 "name": "Groningen",
                 "translations": {
                     "japanese": "フローニンゲン州",
@@ -26389,7 +27330,8 @@
                 }
             },
             {
-                "id": 1577582592,
+                "id": 8,
+                "full_id": 1577582592,
                 "name": "Limburg",
                 "translations": {
                     "japanese": "リンビュルフ州",
@@ -26415,7 +27357,8 @@
                 }
             },
             {
-                "id": 1577648128,
+                "id": 9,
+                "full_id": 1577648128,
                 "name": "North Brabant",
                 "translations": {
                     "japanese": "ノールト・ブラバント州",
@@ -26441,7 +27384,8 @@
                 }
             },
             {
-                "id": 1577713664,
+                "id": 10,
+                "full_id": 1577713664,
                 "name": "Overijssel",
                 "translations": {
                     "japanese": "オーベルアイセル州",
@@ -26467,7 +27411,8 @@
                 }
             },
             {
-                "id": 1577779200,
+                "id": 11,
+                "full_id": 1577779200,
                 "name": "South Holland",
                 "translations": {
                     "japanese": "ゾイト・ホラント州",
@@ -26493,7 +27438,8 @@
                 }
             },
             {
-                "id": 1577844736,
+                "id": 12,
+                "full_id": 1577844736,
                 "name": "Utrecht",
                 "translations": {
                     "japanese": "ユトレヒト州",
@@ -26519,7 +27465,8 @@
                 }
             },
             {
-                "id": 1577910272,
+                "id": 13,
+                "full_id": 1577910272,
                 "name": "Zeeland",
                 "translations": {
                     "japanese": "ゼーラント州",
@@ -26570,7 +27517,8 @@
         },
         "regions": [
             {
-                "id": 1593835520,
+                "id": 0,
+                "full_id": 1593835520,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -26596,7 +27544,8 @@
                 }
             },
             {
-                "id": 1593966592,
+                "id": 2,
+                "full_id": 1593966592,
                 "name": "Wellington",
                 "translations": {
                     "japanese": "ウェリントン",
@@ -26622,7 +27571,8 @@
                 }
             },
             {
-                "id": 1594032128,
+                "id": 3,
+                "full_id": 1594032128,
                 "name": "Auckland",
                 "translations": {
                     "japanese": "オークランド",
@@ -26648,7 +27598,8 @@
                 }
             },
             {
-                "id": 1594097664,
+                "id": 4,
+                "full_id": 1594097664,
                 "name": "Bay of Plenty",
                 "translations": {
                     "japanese": "ベイ・オブ・プレンティ",
@@ -26674,7 +27625,8 @@
                 }
             },
             {
-                "id": 1594163200,
+                "id": 5,
+                "full_id": 1594163200,
                 "name": "Canterbury",
                 "translations": {
                     "japanese": "カンタベリー",
@@ -26700,7 +27652,8 @@
                 }
             },
             {
-                "id": 1594228736,
+                "id": 6,
+                "full_id": 1594228736,
                 "name": "Otago",
                 "translations": {
                     "japanese": "ダニーデン",
@@ -26726,7 +27679,8 @@
                 }
             },
             {
-                "id": 1594294272,
+                "id": 7,
+                "full_id": 1594294272,
                 "name": "Hawke's Bay",
                 "translations": {
                     "japanese": "ホークスベイ",
@@ -26752,7 +27706,8 @@
                 }
             },
             {
-                "id": 1594359808,
+                "id": 8,
+                "full_id": 1594359808,
                 "name": "Manawatu-Wanganui",
                 "translations": {
                     "japanese": "マナワツ・ワンガヌイ",
@@ -26778,7 +27733,8 @@
                 }
             },
             {
-                "id": 1594425344,
+                "id": 9,
+                "full_id": 1594425344,
                 "name": "Nelson",
                 "translations": {
                     "japanese": "ネルソン・マールボロ",
@@ -26804,7 +27760,8 @@
                 }
             },
             {
-                "id": 1594490880,
+                "id": 10,
+                "full_id": 1594490880,
                 "name": "Northland",
                 "translations": {
                     "japanese": "ノースランド",
@@ -26830,7 +27787,8 @@
                 }
             },
             {
-                "id": 1594621952,
+                "id": 12,
+                "full_id": 1594621952,
                 "name": "Southland",
                 "translations": {
                     "japanese": "サウスランド",
@@ -26856,7 +27814,8 @@
                 }
             },
             {
-                "id": 1594687488,
+                "id": 13,
+                "full_id": 1594687488,
                 "name": "Taranaki",
                 "translations": {
                     "japanese": "タラナキ",
@@ -26882,7 +27841,8 @@
                 }
             },
             {
-                "id": 1594753024,
+                "id": 14,
+                "full_id": 1594753024,
                 "name": "Waikato",
                 "translations": {
                     "japanese": "ワイカト",
@@ -26908,7 +27868,8 @@
                 }
             },
             {
-                "id": 1594818560,
+                "id": 15,
+                "full_id": 1594818560,
                 "name": "Gisborne",
                 "translations": {
                     "japanese": "ギズボーン",
@@ -26934,7 +27895,8 @@
                 }
             },
             {
-                "id": 1594884096,
+                "id": 1,
+                "full_id": 1594884096,
                 "name": "West Coast",
                 "translations": {
                     "japanese": "ウェストコースト",
@@ -26960,7 +27922,8 @@
                 }
             },
             {
-                "id": 1594949632,
+                "id": 17,
+                "full_id": 1594949632,
                 "name": "Marlborough",
                 "translations": {
                     "japanese": "マールボロ",
@@ -26986,7 +27949,8 @@
                 }
             },
             {
-                "id": 1595015168,
+                "id": 18,
+                "full_id": 1595015168,
                 "name": "Tasman",
                 "translations": {
                     "japanese": "タスマン",
@@ -27037,7 +28001,8 @@
         },
         "regions": [
             {
-                "id": 1610612736,
+                "id": 0,
+                "full_id": 1610612736,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27063,7 +28028,8 @@
                 }
             },
             {
-                "id": 1611071488,
+                "id": 7,
+                "full_id": 1611071488,
                 "name": "Oslo",
                 "translations": {
                     "japanese": "オスロ",
@@ -27089,7 +28055,8 @@
                 }
             },
             {
-                "id": 1611137024,
+                "id": 8,
+                "full_id": 1611137024,
                 "name": "Akershus",
                 "translations": {
                     "japanese": "アーケシュフース県",
@@ -27115,7 +28082,8 @@
                 }
             },
             {
-                "id": 1611202560,
+                "id": 9,
+                "full_id": 1611202560,
                 "name": "Aust-Agder",
                 "translations": {
                     "japanese": "アウスト・アグデル県",
@@ -27141,7 +28109,8 @@
                 }
             },
             {
-                "id": 1611268096,
+                "id": 10,
+                "full_id": 1611268096,
                 "name": "Buskerud",
                 "translations": {
                     "japanese": "ブスケルー県",
@@ -27167,7 +28136,8 @@
                 }
             },
             {
-                "id": 1611333632,
+                "id": 11,
+                "full_id": 1611333632,
                 "name": "Finnmark",
                 "translations": {
                     "japanese": "フィンマルク県",
@@ -27193,7 +28163,8 @@
                 }
             },
             {
-                "id": 1611399168,
+                "id": 12,
+                "full_id": 1611399168,
                 "name": "Hedmark",
                 "translations": {
                     "japanese": "ヘードマルク県",
@@ -27219,7 +28190,8 @@
                 }
             },
             {
-                "id": 1611464704,
+                "id": 13,
+                "full_id": 1611464704,
                 "name": "Hordaland",
                 "translations": {
                     "japanese": "ホルダラン県",
@@ -27245,7 +28217,8 @@
                 }
             },
             {
-                "id": 1611530240,
+                "id": 14,
+                "full_id": 1611530240,
                 "name": "Møre og Romsdal",
                 "translations": {
                     "japanese": "ムーレ・オ・ロムスダール県",
@@ -27271,7 +28244,8 @@
                 }
             },
             {
-                "id": 1611595776,
+                "id": 15,
+                "full_id": 1611595776,
                 "name": "Nordland",
                 "translations": {
                     "japanese": "ヌールラン県",
@@ -27297,7 +28271,8 @@
                 }
             },
             {
-                "id": 1611661312,
+                "id": 1,
+                "full_id": 1611661312,
                 "name": "Nord-Trøndelag",
                 "translations": {
                     "japanese": "ヌール・トロンデラーグ県",
@@ -27323,7 +28298,8 @@
                 }
             },
             {
-                "id": 1611726848,
+                "id": 17,
+                "full_id": 1611726848,
                 "name": "Oppland",
                 "translations": {
                     "japanese": "オップラン県",
@@ -27349,7 +28325,8 @@
                 }
             },
             {
-                "id": 1611792384,
+                "id": 18,
+                "full_id": 1611792384,
                 "name": "Rogaland",
                 "translations": {
                     "japanese": "ローガラン県",
@@ -27375,7 +28352,8 @@
                 }
             },
             {
-                "id": 1611857920,
+                "id": 19,
+                "full_id": 1611857920,
                 "name": "Sogn og Fjordane",
                 "translations": {
                     "japanese": "ソグン・オ・フィヨーラネ県",
@@ -27401,7 +28379,8 @@
                 }
             },
             {
-                "id": 1611923456,
+                "id": 20,
+                "full_id": 1611923456,
                 "name": "Sør-Trøndelag",
                 "translations": {
                     "japanese": "ソール・トロンデラーグ県",
@@ -27427,7 +28406,8 @@
                 }
             },
             {
-                "id": 1611988992,
+                "id": 21,
+                "full_id": 1611988992,
                 "name": "Telemark",
                 "translations": {
                     "japanese": "テレマルク県",
@@ -27453,7 +28433,8 @@
                 }
             },
             {
-                "id": 1612054528,
+                "id": 22,
+                "full_id": 1612054528,
                 "name": "Troms",
                 "translations": {
                     "japanese": "トロムス県",
@@ -27479,7 +28460,8 @@
                 }
             },
             {
-                "id": 1612120064,
+                "id": 23,
+                "full_id": 1612120064,
                 "name": "Vest-Agder",
                 "translations": {
                     "japanese": "ヴェスト・アグデル県",
@@ -27505,7 +28487,8 @@
                 }
             },
             {
-                "id": 1612185600,
+                "id": 24,
+                "full_id": 1612185600,
                 "name": "Vestfold",
                 "translations": {
                     "japanese": "ヴェストフォル県",
@@ -27531,7 +28514,8 @@
                 }
             },
             {
-                "id": 1612251136,
+                "id": 25,
+                "full_id": 1612251136,
                 "name": "Østfold",
                 "translations": {
                     "japanese": "エストフォル県",
@@ -27557,7 +28541,8 @@
                 }
             },
             {
-                "id": 1612316672,
+                "id": 26,
+                "full_id": 1612316672,
                 "name": "Svalbard",
                 "translations": {
                     "japanese": "スヴァールバル諸島",
@@ -27608,7 +28593,8 @@
         },
         "regions": [
             {
-                "id": 1627389952,
+                "id": 0,
+                "full_id": 1627389952,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -27634,7 +28620,8 @@
                 }
             },
             {
-                "id": 1627521024,
+                "id": 2,
+                "full_id": 1627521024,
                 "name": "Masovia",
                 "translations": {
                     "japanese": "マゾフシェ",
@@ -27660,7 +28647,8 @@
                 }
             },
             {
-                "id": 1627586560,
+                "id": 3,
+                "full_id": 1627586560,
                 "name": "Lower Silesia",
                 "translations": {
                     "japanese": "ドルヌィ・シロンスク",
@@ -27686,7 +28674,8 @@
                 }
             },
             {
-                "id": 1627652096,
+                "id": 4,
+                "full_id": 1627652096,
                 "name": "Kuyavian-Pomeranian Voivodeship",
                 "translations": {
                     "japanese": "クヤヴィ・ポモージェ",
@@ -27712,7 +28701,8 @@
                 }
             },
             {
-                "id": 1627717632,
+                "id": 5,
+                "full_id": 1627717632,
                 "name": "Lodz",
                 "translations": {
                     "japanese": "ウッジ",
@@ -27738,7 +28728,8 @@
                 }
             },
             {
-                "id": 1627783168,
+                "id": 6,
+                "full_id": 1627783168,
                 "name": "Lublin",
                 "translations": {
                     "japanese": "ルブリン",
@@ -27764,7 +28755,8 @@
                 }
             },
             {
-                "id": 1627848704,
+                "id": 7,
+                "full_id": 1627848704,
                 "name": "Lubusz",
                 "translations": {
                     "japanese": "ルブシュ",
@@ -27790,7 +28782,8 @@
                 }
             },
             {
-                "id": 1627914240,
+                "id": 8,
+                "full_id": 1627914240,
                 "name": "Lesser Poland",
                 "translations": {
                     "japanese": "マウォポルスカ",
@@ -27816,7 +28809,8 @@
                 }
             },
             {
-                "id": 1627979776,
+                "id": 9,
+                "full_id": 1627979776,
                 "name": "Opole",
                 "translations": {
                     "japanese": "オポーレ",
@@ -27842,7 +28836,8 @@
                 }
             },
             {
-                "id": 1628045312,
+                "id": 10,
+                "full_id": 1628045312,
                 "name": "Subcarpathia",
                 "translations": {
                     "japanese": "ポトカルパチェ",
@@ -27868,7 +28863,8 @@
                 }
             },
             {
-                "id": 1628110848,
+                "id": 11,
+                "full_id": 1628110848,
                 "name": "Podlachia",
                 "translations": {
                     "japanese": "ポドラシェ",
@@ -27894,7 +28890,8 @@
                 }
             },
             {
-                "id": 1628176384,
+                "id": 12,
+                "full_id": 1628176384,
                 "name": "Pomerania",
                 "translations": {
                     "japanese": "ポモージェ",
@@ -27920,7 +28917,8 @@
                 }
             },
             {
-                "id": 1628241920,
+                "id": 13,
+                "full_id": 1628241920,
                 "name": "Silesia",
                 "translations": {
                     "japanese": "シュレジエン",
@@ -27946,7 +28944,8 @@
                 }
             },
             {
-                "id": 1628307456,
+                "id": 14,
+                "full_id": 1628307456,
                 "name": "Świętokrzyskie",
                 "translations": {
                     "japanese": "シフィェンティクシシュ",
@@ -27972,7 +28971,8 @@
                 }
             },
             {
-                "id": 1628372992,
+                "id": 15,
+                "full_id": 1628372992,
                 "name": "Warmian-Masurian Voivodeship",
                 "translations": {
                     "japanese": "ヴァルミア・マスールィ",
@@ -27998,7 +28998,8 @@
                 }
             },
             {
-                "id": 1628438528,
+                "id": 1,
+                "full_id": 1628438528,
                 "name": "Greater Poland",
                 "translations": {
                     "japanese": "ヴィェルコポルスカ",
@@ -28024,7 +29025,8 @@
                 }
             },
             {
-                "id": 1628504064,
+                "id": 17,
+                "full_id": 1628504064,
                 "name": "Western Pomerania",
                 "translations": {
                     "japanese": "西ポモージェ",
@@ -28075,7 +29077,8 @@
         },
         "regions": [
             {
-                "id": 1644167168,
+                "id": 0,
+                "full_id": 1644167168,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -28101,7 +29104,8 @@
                 }
             },
             {
-                "id": 1644298240,
+                "id": 2,
+                "full_id": 1644298240,
                 "name": "Lisbon",
                 "translations": {
                     "japanese": "リスボン県",
@@ -28127,7 +29131,8 @@
                 }
             },
             {
-                "id": 1644625920,
+                "id": 7,
+                "full_id": 1644625920,
                 "name": "Madeira",
                 "translations": {
                     "japanese": "マディラ自治州",
@@ -28153,7 +29158,8 @@
                 }
             },
             {
-                "id": 1644691456,
+                "id": 8,
+                "full_id": 1644691456,
                 "name": "Azores",
                 "translations": {
                     "japanese": "アソレス自治州",
@@ -28179,7 +29185,8 @@
                 }
             },
             {
-                "id": 1644756992,
+                "id": 9,
+                "full_id": 1644756992,
                 "name": "Aveiro",
                 "translations": {
                     "japanese": "アヴェイロ県",
@@ -28205,7 +29212,8 @@
                 }
             },
             {
-                "id": 1644822528,
+                "id": 10,
+                "full_id": 1644822528,
                 "name": "Beja",
                 "translations": {
                     "japanese": "ベージャ県",
@@ -28231,7 +29239,8 @@
                 }
             },
             {
-                "id": 1644888064,
+                "id": 11,
+                "full_id": 1644888064,
                 "name": "Braga",
                 "translations": {
                     "japanese": "ブラガ県",
@@ -28257,7 +29266,8 @@
                 }
             },
             {
-                "id": 1644953600,
+                "id": 12,
+                "full_id": 1644953600,
                 "name": "Bragança",
                 "translations": {
                     "japanese": "ブラガンサ県",
@@ -28283,7 +29293,8 @@
                 }
             },
             {
-                "id": 1645019136,
+                "id": 13,
+                "full_id": 1645019136,
                 "name": "Castelo Branco",
                 "translations": {
                     "japanese": "カステロ・ブランコ県",
@@ -28309,7 +29320,8 @@
                 }
             },
             {
-                "id": 1645084672,
+                "id": 14,
+                "full_id": 1645084672,
                 "name": "Coimbra",
                 "translations": {
                     "japanese": "コインブラ県",
@@ -28335,7 +29347,8 @@
                 }
             },
             {
-                "id": 1645150208,
+                "id": 15,
+                "full_id": 1645150208,
                 "name": "Évora",
                 "translations": {
                     "japanese": "エヴォラ県",
@@ -28361,7 +29374,8 @@
                 }
             },
             {
-                "id": 1645215744,
+                "id": 1,
+                "full_id": 1645215744,
                 "name": "Faro",
                 "translations": {
                     "japanese": "ファーロ県",
@@ -28387,7 +29401,8 @@
                 }
             },
             {
-                "id": 1645281280,
+                "id": 17,
+                "full_id": 1645281280,
                 "name": "Guarda",
                 "translations": {
                     "japanese": "グアルダ県",
@@ -28413,7 +29428,8 @@
                 }
             },
             {
-                "id": 1645346816,
+                "id": 18,
+                "full_id": 1645346816,
                 "name": "Leiria",
                 "translations": {
                     "japanese": "レイリア県",
@@ -28439,7 +29455,8 @@
                 }
             },
             {
-                "id": 1645412352,
+                "id": 19,
+                "full_id": 1645412352,
                 "name": "Portalegre",
                 "translations": {
                     "japanese": "ポルタレグレ県",
@@ -28465,7 +29482,8 @@
                 }
             },
             {
-                "id": 1645477888,
+                "id": 20,
+                "full_id": 1645477888,
                 "name": "Porto",
                 "translations": {
                     "japanese": "ポルト県",
@@ -28491,7 +29509,8 @@
                 }
             },
             {
-                "id": 1645543424,
+                "id": 21,
+                "full_id": 1645543424,
                 "name": "Santarém",
                 "translations": {
                     "japanese": "サンタレン県",
@@ -28517,7 +29536,8 @@
                 }
             },
             {
-                "id": 1645608960,
+                "id": 22,
+                "full_id": 1645608960,
                 "name": "Setúbal",
                 "translations": {
                     "japanese": "セトゥーバル県",
@@ -28543,7 +29563,8 @@
                 }
             },
             {
-                "id": 1645674496,
+                "id": 23,
+                "full_id": 1645674496,
                 "name": "Viana do Castelo",
                 "translations": {
                     "japanese": "ヴィアナ・ド・カステロ県",
@@ -28569,7 +29590,8 @@
                 }
             },
             {
-                "id": 1645740032,
+                "id": 24,
+                "full_id": 1645740032,
                 "name": "Vila Real",
                 "translations": {
                     "japanese": "ヴィラ・レアル県",
@@ -28595,7 +29617,8 @@
                 }
             },
             {
-                "id": 1645805568,
+                "id": 25,
+                "full_id": 1645805568,
                 "name": "Viseu",
                 "translations": {
                     "japanese": "ヴィゼウ県",
@@ -28646,7 +29669,8 @@
         },
         "regions": [
             {
-                "id": 1660944384,
+                "id": 0,
+                "full_id": 1660944384,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -28672,7 +29696,8 @@
                 }
             },
             {
-                "id": 1661075456,
+                "id": 2,
+                "full_id": 1661075456,
                 "name": "Bucharest",
                 "translations": {
                     "japanese": "ブカレスト州",
@@ -28698,7 +29723,8 @@
                 }
             },
             {
-                "id": 1661140992,
+                "id": 3,
+                "full_id": 1661140992,
                 "name": "Alba",
                 "translations": {
                     "japanese": "アルバ州",
@@ -28724,7 +29750,8 @@
                 }
             },
             {
-                "id": 1661206528,
+                "id": 4,
+                "full_id": 1661206528,
                 "name": "Arad",
                 "translations": {
                     "japanese": "アラド州",
@@ -28750,7 +29777,8 @@
                 }
             },
             {
-                "id": 1661272064,
+                "id": 5,
+                "full_id": 1661272064,
                 "name": "Arges",
                 "translations": {
                     "japanese": "アルジェシュ州",
@@ -28776,7 +29804,8 @@
                 }
             },
             {
-                "id": 1661337600,
+                "id": 6,
+                "full_id": 1661337600,
                 "name": "Bacau",
                 "translations": {
                     "japanese": "バカウ州",
@@ -28802,7 +29831,8 @@
                 }
             },
             {
-                "id": 1661403136,
+                "id": 7,
+                "full_id": 1661403136,
                 "name": "Bihor",
                 "translations": {
                     "japanese": "ビホル州",
@@ -28828,7 +29858,8 @@
                 }
             },
             {
-                "id": 1661468672,
+                "id": 8,
+                "full_id": 1661468672,
                 "name": "Bistrita-Nasaud",
                 "translations": {
                     "japanese": "ビストリツァ・ナサウド州",
@@ -28854,7 +29885,8 @@
                 }
             },
             {
-                "id": 1661534208,
+                "id": 9,
+                "full_id": 1661534208,
                 "name": "Botosani",
                 "translations": {
                     "japanese": "ボトシャニ州",
@@ -28880,7 +29912,8 @@
                 }
             },
             {
-                "id": 1661599744,
+                "id": 10,
+                "full_id": 1661599744,
                 "name": "Braila",
                 "translations": {
                     "japanese": "ブライラ州",
@@ -28906,7 +29939,8 @@
                 }
             },
             {
-                "id": 1661665280,
+                "id": 11,
+                "full_id": 1661665280,
                 "name": "Brasov",
                 "translations": {
                     "japanese": "ブラショヴ州",
@@ -28932,7 +29966,8 @@
                 }
             },
             {
-                "id": 1661730816,
+                "id": 12,
+                "full_id": 1661730816,
                 "name": "Buzau",
                 "translations": {
                     "japanese": "ブザウ州",
@@ -28958,7 +29993,8 @@
                 }
             },
             {
-                "id": 1661796352,
+                "id": 13,
+                "full_id": 1661796352,
                 "name": "Calarasi",
                 "translations": {
                     "japanese": "カララシ州",
@@ -28984,7 +30020,8 @@
                 }
             },
             {
-                "id": 1661861888,
+                "id": 14,
+                "full_id": 1661861888,
                 "name": "Caras-Severin",
                 "translations": {
                     "japanese": "カラシュ・セヴェリン州",
@@ -29010,7 +30047,8 @@
                 }
             },
             {
-                "id": 1661927424,
+                "id": 15,
+                "full_id": 1661927424,
                 "name": "Cluj",
                 "translations": {
                     "japanese": "クルージュ州",
@@ -29036,7 +30074,8 @@
                 }
             },
             {
-                "id": 1661992960,
+                "id": 1,
+                "full_id": 1661992960,
                 "name": "Constanta",
                 "translations": {
                     "japanese": "コンスタンツァ州",
@@ -29062,7 +30101,8 @@
                 }
             },
             {
-                "id": 1662058496,
+                "id": 17,
+                "full_id": 1662058496,
                 "name": "Covasna",
                 "translations": {
                     "japanese": "コヴァスナ州",
@@ -29088,7 +30128,8 @@
                 }
             },
             {
-                "id": 1662124032,
+                "id": 18,
+                "full_id": 1662124032,
                 "name": "Dâmbovita",
                 "translations": {
                     "japanese": "ドゥンボビツァ州",
@@ -29114,7 +30155,8 @@
                 }
             },
             {
-                "id": 1662189568,
+                "id": 19,
+                "full_id": 1662189568,
                 "name": "Dolj",
                 "translations": {
                     "japanese": "ドルジュ州",
@@ -29140,7 +30182,8 @@
                 }
             },
             {
-                "id": 1662255104,
+                "id": 20,
+                "full_id": 1662255104,
                 "name": "Galati",
                 "translations": {
                     "japanese": "ガラツィ州",
@@ -29166,7 +30209,8 @@
                 }
             },
             {
-                "id": 1662320640,
+                "id": 21,
+                "full_id": 1662320640,
                 "name": "Giurgiu",
                 "translations": {
                     "japanese": "ジュルジュ州",
@@ -29192,7 +30236,8 @@
                 }
             },
             {
-                "id": 1662386176,
+                "id": 22,
+                "full_id": 1662386176,
                 "name": "Gorj",
                 "translations": {
                     "japanese": "ゴルジュ州",
@@ -29218,7 +30263,8 @@
                 }
             },
             {
-                "id": 1662451712,
+                "id": 23,
+                "full_id": 1662451712,
                 "name": "Harghita",
                 "translations": {
                     "japanese": "ハルギタ州",
@@ -29244,7 +30290,8 @@
                 }
             },
             {
-                "id": 1662517248,
+                "id": 24,
+                "full_id": 1662517248,
                 "name": "Hunedoara",
                 "translations": {
                     "japanese": "フネドアラ州",
@@ -29270,7 +30317,8 @@
                 }
             },
             {
-                "id": 1662582784,
+                "id": 25,
+                "full_id": 1662582784,
                 "name": "Ialomita",
                 "translations": {
                     "japanese": "ヤロミツァ州",
@@ -29296,7 +30344,8 @@
                 }
             },
             {
-                "id": 1662648320,
+                "id": 26,
+                "full_id": 1662648320,
                 "name": "Iasi",
                 "translations": {
                     "japanese": "ヤシ州",
@@ -29322,7 +30371,8 @@
                 }
             },
             {
-                "id": 1662713856,
+                "id": 27,
+                "full_id": 1662713856,
                 "name": "Ilfov",
                 "translations": {
                     "japanese": "イルホヴ州",
@@ -29348,7 +30398,8 @@
                 }
             },
             {
-                "id": 1662779392,
+                "id": 28,
+                "full_id": 1662779392,
                 "name": "Maramures",
                 "translations": {
                     "japanese": "マラムレシュ州",
@@ -29374,7 +30425,8 @@
                 }
             },
             {
-                "id": 1662844928,
+                "id": 29,
+                "full_id": 1662844928,
                 "name": "Mehedinti",
                 "translations": {
                     "japanese": "メヘディンツィ州",
@@ -29400,7 +30452,8 @@
                 }
             },
             {
-                "id": 1662910464,
+                "id": 30,
+                "full_id": 1662910464,
                 "name": "Mures",
                 "translations": {
                     "japanese": "ムレシュ州",
@@ -29426,7 +30479,8 @@
                 }
             },
             {
-                "id": 1662976000,
+                "id": 31,
+                "full_id": 1662976000,
                 "name": "Neamt",
                 "translations": {
                     "japanese": "ネアムツ州",
@@ -29452,7 +30506,8 @@
                 }
             },
             {
-                "id": 1663041536,
+                "id": 2,
+                "full_id": 1663041536,
                 "name": "Olt",
                 "translations": {
                     "japanese": "オルト州",
@@ -29478,7 +30533,8 @@
                 }
             },
             {
-                "id": 1663107072,
+                "id": 33,
+                "full_id": 1663107072,
                 "name": "Prahova",
                 "translations": {
                     "japanese": "プラホヴァ州",
@@ -29504,7 +30560,8 @@
                 }
             },
             {
-                "id": 1663172608,
+                "id": 34,
+                "full_id": 1663172608,
                 "name": "Salaj",
                 "translations": {
                     "japanese": "サラージュ州",
@@ -29530,7 +30587,8 @@
                 }
             },
             {
-                "id": 1663238144,
+                "id": 35,
+                "full_id": 1663238144,
                 "name": "Satu Mare",
                 "translations": {
                     "japanese": "サトゥ・マーレ州",
@@ -29556,7 +30614,8 @@
                 }
             },
             {
-                "id": 1663303680,
+                "id": 36,
+                "full_id": 1663303680,
                 "name": "Sibiu",
                 "translations": {
                     "japanese": "シビウ州",
@@ -29582,7 +30641,8 @@
                 }
             },
             {
-                "id": 1663369216,
+                "id": 37,
+                "full_id": 1663369216,
                 "name": "Suceava",
                 "translations": {
                     "japanese": "スチャヴァ州",
@@ -29608,7 +30668,8 @@
                 }
             },
             {
-                "id": 1663434752,
+                "id": 38,
+                "full_id": 1663434752,
                 "name": "Teleorman",
                 "translations": {
                     "japanese": "テレオルマン州",
@@ -29634,7 +30695,8 @@
                 }
             },
             {
-                "id": 1663500288,
+                "id": 39,
+                "full_id": 1663500288,
                 "name": "Timis",
                 "translations": {
                     "japanese": "ティミシュ州",
@@ -29660,7 +30722,8 @@
                 }
             },
             {
-                "id": 1663565824,
+                "id": 40,
+                "full_id": 1663565824,
                 "name": "Tulcea",
                 "translations": {
                     "japanese": "トゥルチャ州",
@@ -29686,7 +30749,8 @@
                 }
             },
             {
-                "id": 1663631360,
+                "id": 41,
+                "full_id": 1663631360,
                 "name": "Vâlcea",
                 "translations": {
                     "japanese": "ヴルチャ州",
@@ -29712,7 +30776,8 @@
                 }
             },
             {
-                "id": 1663696896,
+                "id": 42,
+                "full_id": 1663696896,
                 "name": "Vaslui",
                 "translations": {
                     "japanese": "ヴァスルイ州",
@@ -29738,7 +30803,8 @@
                 }
             },
             {
-                "id": 1663762432,
+                "id": 43,
+                "full_id": 1663762432,
                 "name": "Vrancea",
                 "translations": {
                     "japanese": "フランチェア州",
@@ -29789,7 +30855,8 @@
         },
         "regions": [
             {
-                "id": 1677721600,
+                "id": 0,
+                "full_id": 1677721600,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -29815,7 +30882,8 @@
                 }
             },
             {
-                "id": 1678311424,
+                "id": 9,
+                "full_id": 1678311424,
                 "name": "Moscow City",
                 "translations": {
                     "japanese": "モスクワ市",
@@ -29841,7 +30909,8 @@
                 }
             },
             {
-                "id": 1678376960,
+                "id": 10,
+                "full_id": 1678376960,
                 "name": "Adygey",
                 "translations": {
                     "japanese": "アディゲ共和国",
@@ -29867,7 +30936,8 @@
                 }
             },
             {
-                "id": 1678442496,
+                "id": 11,
+                "full_id": 1678442496,
                 "name": "Gorno-Altay",
                 "translations": {
                     "japanese": "アルタイ共和国",
@@ -29893,7 +30963,8 @@
                 }
             },
             {
-                "id": 1678508032,
+                "id": 12,
+                "full_id": 1678508032,
                 "name": "Altay",
                 "translations": {
                     "japanese": "アルタイ地方",
@@ -29919,7 +30990,8 @@
                 }
             },
             {
-                "id": 1678573568,
+                "id": 13,
+                "full_id": 1678573568,
                 "name": "Amur",
                 "translations": {
                     "japanese": "アムール州",
@@ -29945,7 +31017,8 @@
                 }
             },
             {
-                "id": 1678639104,
+                "id": 14,
+                "full_id": 1678639104,
                 "name": "Arkhangel'sk",
                 "translations": {
                     "japanese": "アルハンゲリスク州",
@@ -29971,7 +31044,8 @@
                 }
             },
             {
-                "id": 1678704640,
+                "id": 15,
+                "full_id": 1678704640,
                 "name": "Astrakhan'",
                 "translations": {
                     "japanese": "アストラハン州",
@@ -29997,7 +31071,8 @@
                 }
             },
             {
-                "id": 1678770176,
+                "id": 1,
+                "full_id": 1678770176,
                 "name": "Bashkortostan",
                 "translations": {
                     "japanese": "バシコルトスタン共和国",
@@ -30023,7 +31098,8 @@
                 }
             },
             {
-                "id": 1678835712,
+                "id": 17,
+                "full_id": 1678835712,
                 "name": "Belgorod",
                 "translations": {
                     "japanese": "ベルゴロド州",
@@ -30049,7 +31125,8 @@
                 }
             },
             {
-                "id": 1678901248,
+                "id": 18,
+                "full_id": 1678901248,
                 "name": "Bryansk",
                 "translations": {
                     "japanese": "ブリャンスク州",
@@ -30075,7 +31152,8 @@
                 }
             },
             {
-                "id": 1678966784,
+                "id": 19,
+                "full_id": 1678966784,
                 "name": "Buryat",
                 "translations": {
                     "japanese": "ブリヤート共和国",
@@ -30101,7 +31179,8 @@
                 }
             },
             {
-                "id": 1679032320,
+                "id": 20,
+                "full_id": 1679032320,
                 "name": "Chechnya",
                 "translations": {
                     "japanese": "チェチェン共和国",
@@ -30127,7 +31206,8 @@
                 }
             },
             {
-                "id": 1679097856,
+                "id": 21,
+                "full_id": 1679097856,
                 "name": "Chelyabinsk",
                 "translations": {
                     "japanese": "チェリャビンスク州",
@@ -30153,7 +31233,8 @@
                 }
             },
             {
-                "id": 1679163392,
+                "id": 22,
+                "full_id": 1679163392,
                 "name": "Chukot",
                 "translations": {
                     "japanese": "チュクチ自治管区",
@@ -30179,7 +31260,8 @@
                 }
             },
             {
-                "id": 1679228928,
+                "id": 23,
+                "full_id": 1679228928,
                 "name": "Chuvash",
                 "translations": {
                     "japanese": "チュヴァシ共和国",
@@ -30205,7 +31287,8 @@
                 }
             },
             {
-                "id": 1679294464,
+                "id": 24,
+                "full_id": 1679294464,
                 "name": "Dagestan",
                 "translations": {
                     "japanese": "ダゲスタン共和国",
@@ -30231,7 +31314,8 @@
                 }
             },
             {
-                "id": 1679360000,
+                "id": 25,
+                "full_id": 1679360000,
                 "name": "Ingushetia",
                 "translations": {
                     "japanese": "イングーシ共和国",
@@ -30257,7 +31341,8 @@
                 }
             },
             {
-                "id": 1679425536,
+                "id": 26,
+                "full_id": 1679425536,
                 "name": "Irkutsk",
                 "translations": {
                     "japanese": "イルクーツク州",
@@ -30283,7 +31368,8 @@
                 }
             },
             {
-                "id": 1679491072,
+                "id": 27,
+                "full_id": 1679491072,
                 "name": "Ivanovo",
                 "translations": {
                     "japanese": "イヴァノヴォ州",
@@ -30309,7 +31395,8 @@
                 }
             },
             {
-                "id": 1679556608,
+                "id": 28,
+                "full_id": 1679556608,
                 "name": "Kabardin-Balkar",
                 "translations": {
                     "japanese": "カバルダ・バルカル共和国",
@@ -30335,7 +31422,8 @@
                 }
             },
             {
-                "id": 1679622144,
+                "id": 29,
+                "full_id": 1679622144,
                 "name": "Kaliningrad",
                 "translations": {
                     "japanese": "カリーニングラード州",
@@ -30361,7 +31449,8 @@
                 }
             },
             {
-                "id": 1679687680,
+                "id": 30,
+                "full_id": 1679687680,
                 "name": "Kalmyk",
                 "translations": {
                     "japanese": "カルムイク共和国",
@@ -30387,7 +31476,8 @@
                 }
             },
             {
-                "id": 1679753216,
+                "id": 31,
+                "full_id": 1679753216,
                 "name": "Kaluga",
                 "translations": {
                     "japanese": "カルーガ州",
@@ -30413,7 +31503,8 @@
                 }
             },
             {
-                "id": 1679818752,
+                "id": 2,
+                "full_id": 1679818752,
                 "name": "Kamchatka",
                 "translations": {
                     "japanese": "カムチャツカ地方",
@@ -30439,7 +31530,8 @@
                 }
             },
             {
-                "id": 1679884288,
+                "id": 33,
+                "full_id": 1679884288,
                 "name": "Karachay-Cherkess",
                 "translations": {
                     "japanese": "カラチャイ・チェルケス共和国",
@@ -30465,14 +31557,15 @@
                 }
             },
             {
-                "id": 1679949824,
+                "id": 34,
+                "full_id": 1679949824,
                 "name": "Karelia",
                 "translations": {
                     "japanese": "カレリア共和国",
                     "english": "Karelia",
                     "french": "Carélie",
                     "german": "Republik Karelien",
-                    "italian": "씒⭤ꥠ軷bblica di Carelia",
+                    "italian": "Repubblica di Carelia",
                     "spanish": "República de Carelia",
                     "chinese_simple": "卡累利阿共和国",
                     "korean": "카렐리야 공화국",
@@ -30491,7 +31584,8 @@
                 }
             },
             {
-                "id": 1680015360,
+                "id": 35,
+                "full_id": 1680015360,
                 "name": "Kemerovo",
                 "translations": {
                     "japanese": "ケメロヴォ州",
@@ -30517,7 +31611,8 @@
                 }
             },
             {
-                "id": 1680080896,
+                "id": 36,
+                "full_id": 1680080896,
                 "name": "Khabarovsk",
                 "translations": {
                     "japanese": "ハバロフスク地方",
@@ -30543,7 +31638,8 @@
                 }
             },
             {
-                "id": 1680146432,
+                "id": 37,
+                "full_id": 1680146432,
                 "name": "Khakassia",
                 "translations": {
                     "japanese": "ハカス共和国",
@@ -30569,7 +31665,8 @@
                 }
             },
             {
-                "id": 1680211968,
+                "id": 38,
+                "full_id": 1680211968,
                 "name": "Khanty-Mansiy",
                 "translations": {
                     "japanese": "ハンティ・マンシ自治管区",
@@ -30595,7 +31692,8 @@
                 }
             },
             {
-                "id": 1680277504,
+                "id": 39,
+                "full_id": 1680277504,
                 "name": "Kirov",
                 "translations": {
                     "japanese": "キーロフ州",
@@ -30621,7 +31719,8 @@
                 }
             },
             {
-                "id": 1680343040,
+                "id": 40,
+                "full_id": 1680343040,
                 "name": "Komi",
                 "translations": {
                     "japanese": "コミ共和国",
@@ -30647,7 +31746,8 @@
                 }
             },
             {
-                "id": 1680408576,
+                "id": 41,
+                "full_id": 1680408576,
                 "name": "Kostroma",
                 "translations": {
                     "japanese": "コストロマ州",
@@ -30673,7 +31773,8 @@
                 }
             },
             {
-                "id": 1680474112,
+                "id": 42,
+                "full_id": 1680474112,
                 "name": "Krasnodar",
                 "translations": {
                     "japanese": "クラスノダール地方",
@@ -30699,7 +31800,8 @@
                 }
             },
             {
-                "id": 1680539648,
+                "id": 43,
+                "full_id": 1680539648,
                 "name": "Krasnoyarsk",
                 "translations": {
                     "japanese": "クラスノヤルスク地方",
@@ -30725,7 +31827,8 @@
                 }
             },
             {
-                "id": 1680605184,
+                "id": 44,
+                "full_id": 1680605184,
                 "name": "Kurgan",
                 "translations": {
                     "japanese": "クルガン州",
@@ -30751,7 +31854,8 @@
                 }
             },
             {
-                "id": 1680670720,
+                "id": 45,
+                "full_id": 1680670720,
                 "name": "Kursk",
                 "translations": {
                     "japanese": "クルスク州",
@@ -30777,7 +31881,8 @@
                 }
             },
             {
-                "id": 1680736256,
+                "id": 46,
+                "full_id": 1680736256,
                 "name": "Leningrad",
                 "translations": {
                     "japanese": "レニングラード州",
@@ -30803,7 +31908,8 @@
                 }
             },
             {
-                "id": 1680801792,
+                "id": 47,
+                "full_id": 1680801792,
                 "name": "Lipetsk",
                 "translations": {
                     "japanese": "リペツク州",
@@ -30829,7 +31935,8 @@
                 }
             },
             {
-                "id": 1680867328,
+                "id": 3,
+                "full_id": 1680867328,
                 "name": "Magadan",
                 "translations": {
                     "japanese": "マガダン州",
@@ -30855,7 +31962,8 @@
                 }
             },
             {
-                "id": 1680932864,
+                "id": 49,
+                "full_id": 1680932864,
                 "name": "Mariy-El",
                 "translations": {
                     "japanese": "マリ・エル共和国",
@@ -30881,7 +31989,8 @@
                 }
             },
             {
-                "id": 1680998400,
+                "id": 50,
+                "full_id": 1680998400,
                 "name": "Mordovia",
                 "translations": {
                     "japanese": "モルドヴィア共和国",
@@ -30907,7 +32016,8 @@
                 }
             },
             {
-                "id": 1681063936,
+                "id": 51,
+                "full_id": 1681063936,
                 "name": "Moscow",
                 "translations": {
                     "japanese": "モスクワ州",
@@ -30933,7 +32043,8 @@
                 }
             },
             {
-                "id": 1681129472,
+                "id": 52,
+                "full_id": 1681129472,
                 "name": "Murmansk",
                 "translations": {
                     "japanese": "ムルマンスク州",
@@ -30959,7 +32070,8 @@
                 }
             },
             {
-                "id": 1681195008,
+                "id": 53,
+                "full_id": 1681195008,
                 "name": "Nenets",
                 "translations": {
                     "japanese": "ネネツ自治管区",
@@ -30985,7 +32097,8 @@
                 }
             },
             {
-                "id": 1681260544,
+                "id": 54,
+                "full_id": 1681260544,
                 "name": "Nizhegorod",
                 "translations": {
                     "japanese": "ニジニ・ノヴゴロド州",
@@ -31011,7 +32124,8 @@
                 }
             },
             {
-                "id": 1681326080,
+                "id": 55,
+                "full_id": 1681326080,
                 "name": "Novgorod",
                 "translations": {
                     "japanese": "ノヴゴロド州",
@@ -31037,7 +32151,8 @@
                 }
             },
             {
-                "id": 1681391616,
+                "id": 56,
+                "full_id": 1681391616,
                 "name": "Novosibirsk",
                 "translations": {
                     "japanese": "ノヴォシビルスク州",
@@ -31063,7 +32178,8 @@
                 }
             },
             {
-                "id": 1681457152,
+                "id": 57,
+                "full_id": 1681457152,
                 "name": "Omsk",
                 "translations": {
                     "japanese": "オムスク州",
@@ -31089,7 +32205,8 @@
                 }
             },
             {
-                "id": 1681522688,
+                "id": 58,
+                "full_id": 1681522688,
                 "name": "Orenburg",
                 "translations": {
                     "japanese": "オレンブルク州",
@@ -31115,7 +32232,8 @@
                 }
             },
             {
-                "id": 1681588224,
+                "id": 59,
+                "full_id": 1681588224,
                 "name": "Orel",
                 "translations": {
                     "japanese": "オリョール州",
@@ -31141,7 +32259,8 @@
                 }
             },
             {
-                "id": 1681653760,
+                "id": 60,
+                "full_id": 1681653760,
                 "name": "Penza",
                 "translations": {
                     "japanese": "ペンザ州",
@@ -31167,7 +32286,8 @@
                 }
             },
             {
-                "id": 1681719296,
+                "id": 61,
+                "full_id": 1681719296,
                 "name": "Perm'",
                 "translations": {
                     "japanese": "ペルミ地方",
@@ -31193,7 +32313,8 @@
                 }
             },
             {
-                "id": 1681784832,
+                "id": 62,
+                "full_id": 1681784832,
                 "name": "Primor'ye",
                 "translations": {
                     "japanese": "沿海地方",
@@ -31219,7 +32340,8 @@
                 }
             },
             {
-                "id": 1681850368,
+                "id": 63,
+                "full_id": 1681850368,
                 "name": "Pskov",
                 "translations": {
                     "japanese": "プスコフ州",
@@ -31245,7 +32367,8 @@
                 }
             },
             {
-                "id": 1681915904,
+                "id": 4,
+                "full_id": 1681915904,
                 "name": "Rostov",
                 "translations": {
                     "japanese": "ロストフ州",
@@ -31271,7 +32394,8 @@
                 }
             },
             {
-                "id": 1681981440,
+                "id": 65,
+                "full_id": 1681981440,
                 "name": "Ryazan'",
                 "translations": {
                     "japanese": "リャザン州",
@@ -31297,7 +32421,8 @@
                 }
             },
             {
-                "id": 1682046976,
+                "id": 66,
+                "full_id": 1682046976,
                 "name": "Sakha",
                 "translations": {
                     "japanese": "サハ共和国",
@@ -31323,7 +32448,8 @@
                 }
             },
             {
-                "id": 1682112512,
+                "id": 67,
+                "full_id": 1682112512,
                 "name": "Sakhalin",
                 "translations": {
                     "japanese": "サハリン州",
@@ -31349,7 +32475,8 @@
                 }
             },
             {
-                "id": 1682178048,
+                "id": 68,
+                "full_id": 1682178048,
                 "name": "Samara",
                 "translations": {
                     "japanese": "サマラ州",
@@ -31375,7 +32502,8 @@
                 }
             },
             {
-                "id": 1682243584,
+                "id": 69,
+                "full_id": 1682243584,
                 "name": "St. Petersburg",
                 "translations": {
                     "japanese": "サンクトペテルブルク市",
@@ -31401,7 +32529,8 @@
                 }
             },
             {
-                "id": 1682309120,
+                "id": 70,
+                "full_id": 1682309120,
                 "name": "Saratov",
                 "translations": {
                     "japanese": "サラトフ州",
@@ -31427,7 +32556,8 @@
                 }
             },
             {
-                "id": 1682374656,
+                "id": 71,
+                "full_id": 1682374656,
                 "name": "North Ossetia",
                 "translations": {
                     "japanese": "北オセチア共和国",
@@ -31453,7 +32583,8 @@
                 }
             },
             {
-                "id": 1682440192,
+                "id": 72,
+                "full_id": 1682440192,
                 "name": "Smolensk",
                 "translations": {
                     "japanese": "スモレンスク州",
@@ -31479,7 +32610,8 @@
                 }
             },
             {
-                "id": 1682505728,
+                "id": 73,
+                "full_id": 1682505728,
                 "name": "Stavropol'",
                 "translations": {
                     "japanese": "スタヴロポリ地方",
@@ -31505,7 +32637,8 @@
                 }
             },
             {
-                "id": 1682571264,
+                "id": 74,
+                "full_id": 1682571264,
                 "name": "Sverdlovsk",
                 "translations": {
                     "japanese": "スヴェルドロフスク州",
@@ -31531,7 +32664,8 @@
                 }
             },
             {
-                "id": 1682636800,
+                "id": 75,
+                "full_id": 1682636800,
                 "name": "Tambov",
                 "translations": {
                     "japanese": "タンボフ州",
@@ -31557,7 +32691,8 @@
                 }
             },
             {
-                "id": 1682702336,
+                "id": 76,
+                "full_id": 1682702336,
                 "name": "Tatarstan",
                 "translations": {
                     "japanese": "タタールスタン共和国",
@@ -31583,7 +32718,8 @@
                 }
             },
             {
-                "id": 1682767872,
+                "id": 77,
+                "full_id": 1682767872,
                 "name": "Tomsk",
                 "translations": {
                     "japanese": "トムスク州",
@@ -31609,7 +32745,8 @@
                 }
             },
             {
-                "id": 1682833408,
+                "id": 78,
+                "full_id": 1682833408,
                 "name": "Tula",
                 "translations": {
                     "japanese": "トゥーラ州",
@@ -31635,7 +32772,8 @@
                 }
             },
             {
-                "id": 1682898944,
+                "id": 79,
+                "full_id": 1682898944,
                 "name": "Tver'",
                 "translations": {
                     "japanese": "トヴェリ州",
@@ -31661,7 +32799,8 @@
                 }
             },
             {
-                "id": 1682964480,
+                "id": 5,
+                "full_id": 1682964480,
                 "name": "Tyumen'",
                 "translations": {
                     "japanese": "チュメニ州",
@@ -31687,7 +32826,8 @@
                 }
             },
             {
-                "id": 1683030016,
+                "id": 81,
+                "full_id": 1683030016,
                 "name": "Tuva",
                 "translations": {
                     "japanese": "トゥヴァ共和国",
@@ -31713,7 +32853,8 @@
                 }
             },
             {
-                "id": 1683095552,
+                "id": 82,
+                "full_id": 1683095552,
                 "name": "Udmurt",
                 "translations": {
                     "japanese": "ウドムルト共和国",
@@ -31739,7 +32880,8 @@
                 }
             },
             {
-                "id": 1683161088,
+                "id": 83,
+                "full_id": 1683161088,
                 "name": "Ul'yanovsk",
                 "translations": {
                     "japanese": "ウリヤノフスク州",
@@ -31765,7 +32907,8 @@
                 }
             },
             {
-                "id": 1683226624,
+                "id": 84,
+                "full_id": 1683226624,
                 "name": "Vladimir",
                 "translations": {
                     "japanese": "ヴラジーミル州",
@@ -31791,7 +32934,8 @@
                 }
             },
             {
-                "id": 1683292160,
+                "id": 85,
+                "full_id": 1683292160,
                 "name": "Volgograd",
                 "translations": {
                     "japanese": "ヴォルゴグラード州",
@@ -31817,7 +32961,8 @@
                 }
             },
             {
-                "id": 1683357696,
+                "id": 86,
+                "full_id": 1683357696,
                 "name": "Vologda",
                 "translations": {
                     "japanese": "ヴォログダ州",
@@ -31843,7 +32988,8 @@
                 }
             },
             {
-                "id": 1683423232,
+                "id": 87,
+                "full_id": 1683423232,
                 "name": "Voronezh",
                 "translations": {
                     "japanese": "ヴォロネジ州",
@@ -31869,7 +33015,8 @@
                 }
             },
             {
-                "id": 1683488768,
+                "id": 88,
+                "full_id": 1683488768,
                 "name": "Yamal-Nenets",
                 "translations": {
                     "japanese": "ヤマロ・ネネツ自治管区",
@@ -31895,7 +33042,8 @@
                 }
             },
             {
-                "id": 1683554304,
+                "id": 89,
+                "full_id": 1683554304,
                 "name": "Yaroslavl'",
                 "translations": {
                     "japanese": "ヤロスラヴリ州",
@@ -31921,7 +33069,8 @@
                 }
             },
             {
-                "id": 1683619840,
+                "id": 90,
+                "full_id": 1683619840,
                 "name": "Yevrey",
                 "translations": {
                     "japanese": "ユダヤ自治州",
@@ -31947,7 +33096,8 @@
                 }
             },
             {
-                "id": 1683685376,
+                "id": 91,
+                "full_id": 1683685376,
                 "name": "Zabaykal'ye",
                 "translations": {
                     "japanese": "ザバイカリエ地方",
@@ -31998,7 +33148,8 @@
         },
         "regions": [
             {
-                "id": 1694498816,
+                "id": 0,
+                "full_id": 1694498816,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -32024,7 +33175,8 @@
                 }
             },
             {
-                "id": 1694564352,
+                "id": 1,
+                "full_id": 1694564352,
                 "name": "Serbia and Kosovo",
                 "translations": {
                     "japanese": "セルビア・コソヴォ",
@@ -32075,7 +33227,8 @@
         },
         "regions": [
             {
-                "id": 1711276032,
+                "id": 0,
+                "full_id": 1711276032,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -32101,7 +33254,8 @@
                 }
             },
             {
-                "id": 1711407104,
+                "id": 2,
+                "full_id": 1711407104,
                 "name": "Bratislava",
                 "translations": {
                     "japanese": "ブラティスラバ",
@@ -32127,7 +33281,8 @@
                 }
             },
             {
-                "id": 1711472640,
+                "id": 3,
+                "full_id": 1711472640,
                 "name": "Banská Bystrica",
                 "translations": {
                     "japanese": "バンスカ・ビストリツァ",
@@ -32153,7 +33308,8 @@
                 }
             },
             {
-                "id": 1711538176,
+                "id": 4,
+                "full_id": 1711538176,
                 "name": "Košice",
                 "translations": {
                     "japanese": "コシツェ",
@@ -32179,7 +33335,8 @@
                 }
             },
             {
-                "id": 1711603712,
+                "id": 5,
+                "full_id": 1711603712,
                 "name": "Nitra",
                 "translations": {
                     "japanese": "二トラ",
@@ -32205,7 +33362,8 @@
                 }
             },
             {
-                "id": 1711669248,
+                "id": 6,
+                "full_id": 1711669248,
                 "name": "Prešov",
                 "translations": {
                     "japanese": "プレショフ",
@@ -32231,7 +33389,8 @@
                 }
             },
             {
-                "id": 1711734784,
+                "id": 7,
+                "full_id": 1711734784,
                 "name": "Trencín",
                 "translations": {
                     "japanese": "トレンチーン",
@@ -32257,7 +33416,8 @@
                 }
             },
             {
-                "id": 1711800320,
+                "id": 8,
+                "full_id": 1711800320,
                 "name": "Trnava",
                 "translations": {
                     "japanese": "トルナバ",
@@ -32283,7 +33443,8 @@
                 }
             },
             {
-                "id": 1711865856,
+                "id": 9,
+                "full_id": 1711865856,
                 "name": "Žilina",
                 "translations": {
                     "japanese": "ジリナ",
@@ -32334,7 +33495,8 @@
         },
         "regions": [
             {
-                "id": 1728053248,
+                "id": 0,
+                "full_id": 1728053248,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -32360,7 +33522,8 @@
                 }
             },
             {
-                "id": 1728118784,
+                "id": 1,
+                "full_id": 1728118784,
                 "name": "Slovenia",
                 "translations": {
                     "japanese": "スロベニア",
@@ -32411,7 +33574,8 @@
         },
         "regions": [
             {
-                "id": 1744830464,
+                "id": 0,
+                "full_id": 1744830464,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -32437,7 +33601,8 @@
                 }
             },
             {
-                "id": 1744961536,
+                "id": 2,
+                "full_id": 1744961536,
                 "name": "Gauteng",
                 "translations": {
                     "japanese": "ハウテン州",
@@ -32463,7 +33628,8 @@
                 }
             },
             {
-                "id": 1745027072,
+                "id": 3,
+                "full_id": 1745027072,
                 "name": "Western Cape",
                 "translations": {
                     "japanese": "ウェスタン・ケープ州",
@@ -32489,7 +33655,8 @@
                 }
             },
             {
-                "id": 1745092608,
+                "id": 4,
+                "full_id": 1745092608,
                 "name": "Northern Cape",
                 "translations": {
                     "japanese": "ノーザン・ケープ州",
@@ -32515,7 +33682,8 @@
                 }
             },
             {
-                "id": 1745158144,
+                "id": 5,
+                "full_id": 1745158144,
                 "name": "Eastern Cape",
                 "translations": {
                     "japanese": "イースタン・ケープ州",
@@ -32541,7 +33709,8 @@
                 }
             },
             {
-                "id": 1745223680,
+                "id": 6,
+                "full_id": 1745223680,
                 "name": "KwaZulu-Natal",
                 "translations": {
                     "japanese": "クワズールー・ナタール州",
@@ -32567,7 +33736,8 @@
                 }
             },
             {
-                "id": 1745289216,
+                "id": 7,
+                "full_id": 1745289216,
                 "name": "Free State",
                 "translations": {
                     "japanese": "フリー・ステート州",
@@ -32593,7 +33763,8 @@
                 }
             },
             {
-                "id": 1745354752,
+                "id": 8,
+                "full_id": 1745354752,
                 "name": "North West",
                 "translations": {
                     "japanese": "ノース・ウェスト州",
@@ -32619,7 +33790,8 @@
                 }
             },
             {
-                "id": 1745420288,
+                "id": 9,
+                "full_id": 1745420288,
                 "name": "Mpumalanga",
                 "translations": {
                     "japanese": "ムプマランガ州",
@@ -32645,7 +33817,8 @@
                 }
             },
             {
-                "id": 1745485824,
+                "id": 10,
+                "full_id": 1745485824,
                 "name": "Limpopo",
                 "translations": {
                     "japanese": "リンポポ州",
@@ -32696,7 +33869,8 @@
         },
         "regions": [
             {
-                "id": 1761607680,
+                "id": 0,
+                "full_id": 1761607680,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -32722,7 +33896,8 @@
                 }
             },
             {
-                "id": 1761738752,
+                "id": 2,
+                "full_id": 1761738752,
                 "name": "Madrid",
                 "translations": {
                     "japanese": "マドリード州",
@@ -32748,7 +33923,8 @@
                 }
             },
             {
-                "id": 1761804288,
+                "id": 3,
+                "full_id": 1761804288,
                 "name": "Andalusia",
                 "translations": {
                     "japanese": "アンダルシーア州",
@@ -32774,7 +33950,8 @@
                 }
             },
             {
-                "id": 1761869824,
+                "id": 4,
+                "full_id": 1761869824,
                 "name": "Aragon",
                 "translations": {
                     "japanese": "アラゴン州",
@@ -32800,7 +33977,8 @@
                 }
             },
             {
-                "id": 1761935360,
+                "id": 5,
+                "full_id": 1761935360,
                 "name": "Principality of Asturias",
                 "translations": {
                     "japanese": "アストゥーリアス州",
@@ -32826,7 +34004,8 @@
                 }
             },
             {
-                "id": 1762000896,
+                "id": 6,
+                "full_id": 1762000896,
                 "name": "Balearic Islands",
                 "translations": {
                     "japanese": "バレアーレス諸島",
@@ -32852,7 +34031,8 @@
                 }
             },
             {
-                "id": 1762066432,
+                "id": 7,
+                "full_id": 1762066432,
                 "name": "Canary Islands",
                 "translations": {
                     "japanese": "カナリア諸島",
@@ -32878,7 +34058,8 @@
                 }
             },
             {
-                "id": 1762131968,
+                "id": 8,
+                "full_id": 1762131968,
                 "name": "Cantabria",
                 "translations": {
                     "japanese": "カンタブリア州",
@@ -32904,7 +34085,8 @@
                 }
             },
             {
-                "id": 1762197504,
+                "id": 9,
+                "full_id": 1762197504,
                 "name": "Castile-La Mancha",
                 "translations": {
                     "japanese": "カスティーリャ・ラ・マンチャ",
@@ -32930,7 +34112,8 @@
                 }
             },
             {
-                "id": 1762263040,
+                "id": 10,
+                "full_id": 1762263040,
                 "name": "Castilla y León",
                 "translations": {
                     "japanese": "カスティーリャ・レオン",
@@ -32956,7 +34139,8 @@
                 }
             },
             {
-                "id": 1762328576,
+                "id": 11,
+                "full_id": 1762328576,
                 "name": "Catalonia",
                 "translations": {
                     "japanese": "カタルーニャ",
@@ -32982,7 +34166,8 @@
                 }
             },
             {
-                "id": 1762394112,
+                "id": 12,
+                "full_id": 1762394112,
                 "name": "Valencia",
                 "translations": {
                     "japanese": "バレンシア州",
@@ -33008,7 +34193,8 @@
                 }
             },
             {
-                "id": 1762459648,
+                "id": 13,
+                "full_id": 1762459648,
                 "name": "Extremadura",
                 "translations": {
                     "japanese": "エストレマドゥーラ",
@@ -33034,7 +34220,8 @@
                 }
             },
             {
-                "id": 1762525184,
+                "id": 14,
+                "full_id": 1762525184,
                 "name": "Galicia",
                 "translations": {
                     "japanese": "ガリーシア",
@@ -33060,7 +34247,8 @@
                 }
             },
             {
-                "id": 1762590720,
+                "id": 15,
+                "full_id": 1762590720,
                 "name": "Murcia",
                 "translations": {
                     "japanese": "ムルシア州",
@@ -33086,7 +34274,8 @@
                 }
             },
             {
-                "id": 1762656256,
+                "id": 1,
+                "full_id": 1762656256,
                 "name": "Navarre",
                 "translations": {
                     "japanese": "ナバーラ州",
@@ -33112,7 +34301,8 @@
                 }
             },
             {
-                "id": 1762721792,
+                "id": 17,
+                "full_id": 1762721792,
                 "name": "Basque Country",
                 "translations": {
                     "japanese": "バスク",
@@ -33138,7 +34328,8 @@
                 }
             },
             {
-                "id": 1762787328,
+                "id": 18,
+                "full_id": 1762787328,
                 "name": "La Rioja",
                 "translations": {
                     "japanese": "ラ・リオハ州",
@@ -33164,7 +34355,8 @@
                 }
             },
             {
-                "id": 1762852864,
+                "id": 19,
+                "full_id": 1762852864,
                 "name": "Ceuta",
                 "translations": {
                     "japanese": "セウタ",
@@ -33190,7 +34382,8 @@
                 }
             },
             {
-                "id": 1762918400,
+                "id": 20,
+                "full_id": 1762918400,
                 "name": "Melilla",
                 "translations": {
                     "japanese": "メリラ",
@@ -33241,7 +34434,8 @@
         },
         "regions": [
             {
-                "id": 1778384896,
+                "id": 0,
+                "full_id": 1778384896,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33267,7 +34461,8 @@
                 }
             },
             {
-                "id": 1778515968,
+                "id": 2,
+                "full_id": 1778515968,
                 "name": "Hhohho",
                 "translations": {
                     "japanese": "ホホ",
@@ -33293,7 +34488,8 @@
                 }
             },
             {
-                "id": 1778581504,
+                "id": 3,
+                "full_id": 1778581504,
                 "name": "Lubombo",
                 "translations": {
                     "japanese": "ルボンボ",
@@ -33319,7 +34515,8 @@
                 }
             },
             {
-                "id": 1778647040,
+                "id": 4,
+                "full_id": 1778647040,
                 "name": "Manzini",
                 "translations": {
                     "japanese": "マンジニ",
@@ -33345,7 +34542,8 @@
                 }
             },
             {
-                "id": 1778712576,
+                "id": 5,
+                "full_id": 1778712576,
                 "name": "Shiselweni",
                 "translations": {
                     "japanese": "シセルウェニ",
@@ -33396,7 +34594,8 @@
         },
         "regions": [
             {
-                "id": 1795162112,
+                "id": 0,
+                "full_id": 1795162112,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -33422,7 +34621,8 @@
                 }
             },
             {
-                "id": 1795293184,
+                "id": 2,
+                "full_id": 1795293184,
                 "name": "Stockholm County",
                 "translations": {
                     "japanese": "ストックホルム州",
@@ -33448,7 +34648,8 @@
                 }
             },
             {
-                "id": 1795358720,
+                "id": 3,
+                "full_id": 1795358720,
                 "name": "Skåne County",
                 "translations": {
                     "japanese": "スコーネ州",
@@ -33474,7 +34675,8 @@
                 }
             },
             {
-                "id": 1795424256,
+                "id": 4,
+                "full_id": 1795424256,
                 "name": "Västra Götaland County",
                 "translations": {
                     "japanese": "ヴェストラ・イェータランド州",
@@ -33500,7 +34702,8 @@
                 }
             },
             {
-                "id": 1795489792,
+                "id": 5,
+                "full_id": 1795489792,
                 "name": "Östergötland County",
                 "translations": {
                     "japanese": "エステルイェトランド州",
@@ -33526,7 +34729,8 @@
                 }
             },
             {
-                "id": 1795555328,
+                "id": 6,
+                "full_id": 1795555328,
                 "name": "Södermanland County",
                 "translations": {
                     "japanese": "セーデルマンランド州",
@@ -33552,7 +34756,8 @@
                 }
             },
             {
-                "id": 1795620864,
+                "id": 7,
+                "full_id": 1795620864,
                 "name": "Värmland County",
                 "translations": {
                     "japanese": "ベルムランド州",
@@ -33578,7 +34783,8 @@
                 }
             },
             {
-                "id": 1795686400,
+                "id": 8,
+                "full_id": 1795686400,
                 "name": "Uppsala County",
                 "translations": {
                     "japanese": "ウプサラ州",
@@ -33604,7 +34810,8 @@
                 }
             },
             {
-                "id": 1795751936,
+                "id": 9,
+                "full_id": 1795751936,
                 "name": "Gävleborg County",
                 "translations": {
                     "japanese": "イェーブレボリ州",
@@ -33630,7 +34837,8 @@
                 }
             },
             {
-                "id": 1795817472,
+                "id": 10,
+                "full_id": 1795817472,
                 "name": "Västerbotten County",
                 "translations": {
                     "japanese": "ベステルボッテン州",
@@ -33656,7 +34864,8 @@
                 }
             },
             {
-                "id": 1795883008,
+                "id": 11,
+                "full_id": 1795883008,
                 "name": "Norrbotten County",
                 "translations": {
                     "japanese": "ノルボッテン州",
@@ -33682,7 +34891,8 @@
                 }
             },
             {
-                "id": 1795948544,
+                "id": 12,
+                "full_id": 1795948544,
                 "name": "Gotland Island",
                 "translations": {
                     "japanese": "ゴトランド州",
@@ -33708,7 +34918,8 @@
                 }
             },
             {
-                "id": 1796014080,
+                "id": 13,
+                "full_id": 1796014080,
                 "name": "Jämtland County",
                 "translations": {
                     "japanese": "イェムトランド州",
@@ -33734,7 +34945,8 @@
                 }
             },
             {
-                "id": 1796079616,
+                "id": 14,
+                "full_id": 1796079616,
                 "name": "Dalarna County",
                 "translations": {
                     "japanese": "ダーラナ州",
@@ -33760,7 +34972,8 @@
                 }
             },
             {
-                "id": 1796145152,
+                "id": 15,
+                "full_id": 1796145152,
                 "name": "Blekinge County",
                 "translations": {
                     "japanese": "ブレーキンゲ州",
@@ -33786,7 +34999,8 @@
                 }
             },
             {
-                "id": 1796210688,
+                "id": 1,
+                "full_id": 1796210688,
                 "name": "Örebro County",
                 "translations": {
                     "japanese": "エレブルー州",
@@ -33812,7 +35026,8 @@
                 }
             },
             {
-                "id": 1796276224,
+                "id": 17,
+                "full_id": 1796276224,
                 "name": "Västernorrland County",
                 "translations": {
                     "japanese": "ベステルノルランド州",
@@ -33838,7 +35053,8 @@
                 }
             },
             {
-                "id": 1796341760,
+                "id": 18,
+                "full_id": 1796341760,
                 "name": "Jönköping County",
                 "translations": {
                     "japanese": "イェンチェピング州",
@@ -33864,7 +35080,8 @@
                 }
             },
             {
-                "id": 1796407296,
+                "id": 19,
+                "full_id": 1796407296,
                 "name": "Kronoberg County",
                 "translations": {
                     "japanese": "クロノベリ州",
@@ -33890,7 +35107,8 @@
                 }
             },
             {
-                "id": 1796472832,
+                "id": 20,
+                "full_id": 1796472832,
                 "name": "Kalmar County",
                 "translations": {
                     "japanese": "カルマル州",
@@ -33916,7 +35134,8 @@
                 }
             },
             {
-                "id": 1796538368,
+                "id": 21,
+                "full_id": 1796538368,
                 "name": "Västmanland County",
                 "translations": {
                     "japanese": "ベストマンランド州",
@@ -33942,7 +35161,8 @@
                 }
             },
             {
-                "id": 1796603904,
+                "id": 22,
+                "full_id": 1796603904,
                 "name": "Halland County",
                 "translations": {
                     "japanese": "ハランド州",
@@ -33993,7 +35213,8 @@
         },
         "regions": [
             {
-                "id": 1811939328,
+                "id": 0,
+                "full_id": 1811939328,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -34019,7 +35240,8 @@
                 }
             },
             {
-                "id": 1812070400,
+                "id": 2,
+                "full_id": 1812070400,
                 "name": "Bern",
                 "translations": {
                     "japanese": "ベルン州",
@@ -34045,7 +35267,8 @@
                 }
             },
             {
-                "id": 1812201472,
+                "id": 4,
+                "full_id": 1812201472,
                 "name": "Aargau",
                 "translations": {
                     "japanese": "アールガウ州",
@@ -34071,7 +35294,8 @@
                 }
             },
             {
-                "id": 1812267008,
+                "id": 5,
+                "full_id": 1812267008,
                 "name": "Basel-City",
                 "translations": {
                     "japanese": "バーゼル＝シュタット準州",
@@ -34097,7 +35321,8 @@
                 }
             },
             {
-                "id": 1812332544,
+                "id": 6,
+                "full_id": 1812332544,
                 "name": "Fribourg",
                 "translations": {
                     "japanese": "フリブール州",
@@ -34123,7 +35348,8 @@
                 }
             },
             {
-                "id": 1812398080,
+                "id": 7,
+                "full_id": 1812398080,
                 "name": "Geneva",
                 "translations": {
                     "japanese": "ジュネーヴ州",
@@ -34149,7 +35375,8 @@
                 }
             },
             {
-                "id": 1812463616,
+                "id": 8,
+                "full_id": 1812463616,
                 "name": "Glarus",
                 "translations": {
                     "japanese": "グラールス州",
@@ -34175,7 +35402,8 @@
                 }
             },
             {
-                "id": 1812529152,
+                "id": 9,
+                "full_id": 1812529152,
                 "name": "Graubünden",
                 "translations": {
                     "japanese": "グラウビュンデン州",
@@ -34201,7 +35429,8 @@
                 }
             },
             {
-                "id": 1812594688,
+                "id": 10,
+                "full_id": 1812594688,
                 "name": "Jura",
                 "translations": {
                     "japanese": "ジュラ州",
@@ -34227,7 +35456,8 @@
                 }
             },
             {
-                "id": 1812660224,
+                "id": 11,
+                "full_id": 1812660224,
                 "name": "Luzern",
                 "translations": {
                     "japanese": "ルツェルン州",
@@ -34253,7 +35483,8 @@
                 }
             },
             {
-                "id": 1812725760,
+                "id": 12,
+                "full_id": 1812725760,
                 "name": "Neuchâtel",
                 "translations": {
                     "japanese": "ヌシャテル州",
@@ -34279,7 +35510,8 @@
                 }
             },
             {
-                "id": 1812791296,
+                "id": 13,
+                "full_id": 1812791296,
                 "name": "Obwalden",
                 "translations": {
                     "japanese": "オプバルデン準州",
@@ -34305,7 +35537,8 @@
                 }
             },
             {
-                "id": 1812856832,
+                "id": 14,
+                "full_id": 1812856832,
                 "name": "St. Gallen",
                 "translations": {
                     "japanese": "ザンクト・ガレン州",
@@ -34331,7 +35564,8 @@
                 }
             },
             {
-                "id": 1812922368,
+                "id": 15,
+                "full_id": 1812922368,
                 "name": "Schaffhausen",
                 "translations": {
                     "japanese": "シャフハウゼン州",
@@ -34357,7 +35591,8 @@
                 }
             },
             {
-                "id": 1812987904,
+                "id": 1,
+                "full_id": 1812987904,
                 "name": "Schwyz",
                 "translations": {
                     "japanese": "シュビーツ州",
@@ -34383,7 +35618,8 @@
                 }
             },
             {
-                "id": 1813053440,
+                "id": 17,
+                "full_id": 1813053440,
                 "name": "Solothurn",
                 "translations": {
                     "japanese": "ゾーロトゥルン州",
@@ -34409,7 +35645,8 @@
                 }
             },
             {
-                "id": 1813118976,
+                "id": 18,
+                "full_id": 1813118976,
                 "name": "Thurgau",
                 "translations": {
                     "japanese": "トゥールガウ州",
@@ -34435,7 +35672,8 @@
                 }
             },
             {
-                "id": 1813184512,
+                "id": 19,
+                "full_id": 1813184512,
                 "name": "Ticino",
                 "translations": {
                     "japanese": "ティチーノ州",
@@ -34461,7 +35699,8 @@
                 }
             },
             {
-                "id": 1813250048,
+                "id": 20,
+                "full_id": 1813250048,
                 "name": "Uri",
                 "translations": {
                     "japanese": "ウーリ州",
@@ -34487,7 +35726,8 @@
                 }
             },
             {
-                "id": 1813315584,
+                "id": 21,
+                "full_id": 1813315584,
                 "name": "Valais",
                 "translations": {
                     "japanese": "バレー州",
@@ -34513,7 +35753,8 @@
                 }
             },
             {
-                "id": 1813381120,
+                "id": 22,
+                "full_id": 1813381120,
                 "name": "Vaud",
                 "translations": {
                     "japanese": "ボー州",
@@ -34539,7 +35780,8 @@
                 }
             },
             {
-                "id": 1813446656,
+                "id": 23,
+                "full_id": 1813446656,
                 "name": "Zug",
                 "translations": {
                     "japanese": "ツーク州",
@@ -34565,7 +35807,8 @@
                 }
             },
             {
-                "id": 1813512192,
+                "id": 24,
+                "full_id": 1813512192,
                 "name": "Zurich",
                 "translations": {
                     "japanese": "チューリヒ州",
@@ -34591,7 +35834,8 @@
                 }
             },
             {
-                "id": 1813577728,
+                "id": 25,
+                "full_id": 1813577728,
                 "name": "Appenzell Outer Rhodes",
                 "translations": {
                     "japanese": "アッペンツェル・アウサーローデン準州",
@@ -34617,7 +35861,8 @@
                 }
             },
             {
-                "id": 1813643264,
+                "id": 26,
+                "full_id": 1813643264,
                 "name": "Appenzell Inner Rhodes",
                 "translations": {
                     "japanese": "アッペンツェル・インナーローデン準州",
@@ -34643,7 +35888,8 @@
                 }
             },
             {
-                "id": 1813708800,
+                "id": 27,
+                "full_id": 1813708800,
                 "name": "Basel-Landschaft",
                 "translations": {
                     "japanese": "バーゼル＝ラント準州",
@@ -34669,7 +35915,8 @@
                 }
             },
             {
-                "id": 1813774336,
+                "id": 28,
+                "full_id": 1813774336,
                 "name": "Nidwalden",
                 "translations": {
                     "japanese": "ニトバルデン準州",
@@ -34720,7 +35967,8 @@
         },
         "regions": [
             {
-                "id": 1828716544,
+                "id": 0,
+                "full_id": 1828716544,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -34746,7 +35994,8 @@
                 }
             },
             {
-                "id": 1828847616,
+                "id": 2,
+                "full_id": 1828847616,
                 "name": "Ankara",
                 "translations": {
                     "japanese": "アンカラ県",
@@ -34772,7 +36021,8 @@
                 }
             },
             {
-                "id": 1828913152,
+                "id": 3,
+                "full_id": 1828913152,
                 "name": "İstanbul",
                 "translations": {
                     "japanese": "イスタンブル県",
@@ -34798,7 +36048,8 @@
                 }
             },
             {
-                "id": 1828978688,
+                "id": 4,
+                "full_id": 1828978688,
                 "name": "İzmir",
                 "translations": {
                     "japanese": "イズミル県",
@@ -34824,7 +36075,8 @@
                 }
             },
             {
-                "id": 1829044224,
+                "id": 5,
+                "full_id": 1829044224,
                 "name": "Bursa",
                 "translations": {
                     "japanese": "ブルサ県",
@@ -34850,7 +36102,8 @@
                 }
             },
             {
-                "id": 1829109760,
+                "id": 6,
+                "full_id": 1829109760,
                 "name": "Adana",
                 "translations": {
                     "japanese": "アダナ県",
@@ -34876,7 +36129,8 @@
                 }
             },
             {
-                "id": 1829175296,
+                "id": 7,
+                "full_id": 1829175296,
                 "name": "Gaziantep",
                 "translations": {
                     "japanese": "ガジアンテプ県",
@@ -34902,7 +36156,8 @@
                 }
             },
             {
-                "id": 1829240832,
+                "id": 8,
+                "full_id": 1829240832,
                 "name": "Konya",
                 "translations": {
                     "japanese": "コニヤ県",
@@ -34928,7 +36183,8 @@
                 }
             },
             {
-                "id": 1829306368,
+                "id": 9,
+                "full_id": 1829306368,
                 "name": "Antalya",
                 "translations": {
                     "japanese": "アンタリヤ県",
@@ -34954,7 +36210,8 @@
                 }
             },
             {
-                "id": 1829371904,
+                "id": 10,
+                "full_id": 1829371904,
                 "name": "Diyarbakır",
                 "translations": {
                     "japanese": "ディヤルバクル県",
@@ -34980,7 +36237,8 @@
                 }
             },
             {
-                "id": 1829437440,
+                "id": 11,
+                "full_id": 1829437440,
                 "name": "Mersin",
                 "translations": {
                     "japanese": "メルシン県",
@@ -35006,7 +36264,8 @@
                 }
             },
             {
-                "id": 1829502976,
+                "id": 12,
+                "full_id": 1829502976,
                 "name": "Kayseri",
                 "translations": {
                     "japanese": "カイセリ県",
@@ -35032,7 +36291,8 @@
                 }
             },
             {
-                "id": 1829634048,
+                "id": 14,
+                "full_id": 1829634048,
                 "name": "Şanlıurfa",
                 "translations": {
                     "japanese": "シャンルウルファ県",
@@ -35058,7 +36318,8 @@
                 }
             },
             {
-                "id": 1829699584,
+                "id": 15,
+                "full_id": 1829699584,
                 "name": "Malatya",
                 "translations": {
                     "japanese": "マラティヤ県",
@@ -35084,7 +36345,8 @@
                 }
             },
             {
-                "id": 1829765120,
+                "id": 1,
+                "full_id": 1829765120,
                 "name": "Erzurum",
                 "translations": {
                     "japanese": "エルズルム県",
@@ -35110,7 +36372,8 @@
                 }
             },
             {
-                "id": 1829830656,
+                "id": 17,
+                "full_id": 1829830656,
                 "name": "Samsun",
                 "translations": {
                     "japanese": "サムスン県",
@@ -35136,7 +36399,8 @@
                 }
             },
             {
-                "id": 1829896192,
+                "id": 18,
+                "full_id": 1829896192,
                 "name": "Van",
                 "translations": {
                     "japanese": "ワン県",
@@ -35162,7 +36426,8 @@
                 }
             },
             {
-                "id": 1829961728,
+                "id": 19,
+                "full_id": 1829961728,
                 "name": "Kahramanmaraş",
                 "translations": {
                     "japanese": "カフラマンマラシュ県",
@@ -35188,7 +36453,8 @@
                 }
             },
             {
-                "id": 1830027264,
+                "id": 20,
+                "full_id": 1830027264,
                 "name": "Denizli",
                 "translations": {
                     "japanese": "デニズリ県",
@@ -35214,7 +36480,8 @@
                 }
             },
             {
-                "id": 1830092800,
+                "id": 21,
+                "full_id": 1830092800,
                 "name": "Batman",
                 "translations": {
                     "japanese": "バトマン県",
@@ -35240,7 +36507,8 @@
                 }
             },
             {
-                "id": 1830158336,
+                "id": 22,
+                "full_id": 1830158336,
                 "name": "Elazığ",
                 "translations": {
                     "japanese": "エラズー県",
@@ -35266,7 +36534,8 @@
                 }
             },
             {
-                "id": 1830223872,
+                "id": 23,
+                "full_id": 1830223872,
                 "name": "Sakarya",
                 "translations": {
                     "japanese": "サカリヤ県",
@@ -35292,7 +36561,8 @@
                 }
             },
             {
-                "id": 1830289408,
+                "id": 24,
+                "full_id": 1830289408,
                 "name": "Kocaeli",
                 "translations": {
                     "japanese": "コジャエリ県",
@@ -35318,7 +36588,8 @@
                 }
             },
             {
-                "id": 1830354944,
+                "id": 25,
+                "full_id": 1830354944,
                 "name": "Sivas",
                 "translations": {
                     "japanese": "シワス県",
@@ -35344,7 +36615,8 @@
                 }
             },
             {
-                "id": 1830420480,
+                "id": 26,
+                "full_id": 1830420480,
                 "name": "Manisa",
                 "translations": {
                     "japanese": "マニサ県",
@@ -35370,7 +36642,8 @@
                 }
             },
             {
-                "id": 1830486016,
+                "id": 27,
+                "full_id": 1830486016,
                 "name": "Trabzon",
                 "translations": {
                     "japanese": "トラブゾン県",
@@ -35396,7 +36669,8 @@
                 }
             },
             {
-                "id": 1830551552,
+                "id": 28,
+                "full_id": 1830551552,
                 "name": "Balıkesir",
                 "translations": {
                     "japanese": "バルケシル県",
@@ -35422,7 +36696,8 @@
                 }
             },
             {
-                "id": 1830617088,
+                "id": 29,
+                "full_id": 1830617088,
                 "name": "Adıyaman",
                 "translations": {
                     "japanese": "アディヤマン県",
@@ -35448,7 +36723,8 @@
                 }
             },
             {
-                "id": 1830682624,
+                "id": 30,
+                "full_id": 1830682624,
                 "name": "Tekirdağ",
                 "translations": {
                     "japanese": "テキルダー県",
@@ -35474,7 +36750,8 @@
                 }
             },
             {
-                "id": 1830748160,
+                "id": 31,
+                "full_id": 1830748160,
                 "name": "Kırıkkale",
                 "translations": {
                     "japanese": "クルッカレ県",
@@ -35500,7 +36777,8 @@
                 }
             },
             {
-                "id": 1830813696,
+                "id": 2,
+                "full_id": 1830813696,
                 "name": "Osmaniye",
                 "translations": {
                     "japanese": "オスマニエ県",
@@ -35526,7 +36804,8 @@
                 }
             },
             {
-                "id": 1830879232,
+                "id": 33,
+                "full_id": 1830879232,
                 "name": "Kütahya",
                 "translations": {
                     "japanese": "キュターヤ県",
@@ -35552,7 +36831,8 @@
                 }
             },
             {
-                "id": 1830944768,
+                "id": 34,
+                "full_id": 1830944768,
                 "name": "Çorum",
                 "translations": {
                     "japanese": "チョルム県",
@@ -35578,7 +36858,8 @@
                 }
             },
             {
-                "id": 1831010304,
+                "id": 35,
+                "full_id": 1831010304,
                 "name": "Isparta",
                 "translations": {
                     "japanese": "イスパルタ県",
@@ -35604,7 +36885,8 @@
                 }
             },
             {
-                "id": 1831075840,
+                "id": 36,
+                "full_id": 1831075840,
                 "name": "Aydın",
                 "translations": {
                     "japanese": "アイドゥン県",
@@ -35630,7 +36912,8 @@
                 }
             },
             {
-                "id": 1831141376,
+                "id": 37,
+                "full_id": 1831141376,
                 "name": "Hatay",
                 "translations": {
                     "japanese": "ハタイ県",
@@ -35656,7 +36939,8 @@
                 }
             },
             {
-                "id": 1831206912,
+                "id": 38,
+                "full_id": 1831206912,
                 "name": "Mardin",
                 "translations": {
                     "japanese": "マルディン県",
@@ -35682,7 +36966,8 @@
                 }
             },
             {
-                "id": 1831272448,
+                "id": 39,
+                "full_id": 1831272448,
                 "name": "Aksaray",
                 "translations": {
                     "japanese": "アクサライ県",
@@ -35708,7 +36993,8 @@
                 }
             },
             {
-                "id": 1831337984,
+                "id": 40,
+                "full_id": 1831337984,
                 "name": "Afyonkarahisar",
                 "translations": {
                     "japanese": "アフィヨンカラヒサール県",
@@ -35734,7 +37020,8 @@
                 }
             },
             {
-                "id": 1831403520,
+                "id": 41,
+                "full_id": 1831403520,
                 "name": "Tokat",
                 "translations": {
                     "japanese": "トカト県",
@@ -35760,7 +37047,8 @@
                 }
             },
             {
-                "id": 1831469056,
+                "id": 42,
+                "full_id": 1831469056,
                 "name": "Edirne",
                 "translations": {
                     "japanese": "エディルネ県",
@@ -35786,7 +37074,8 @@
                 }
             },
             {
-                "id": 1831534592,
+                "id": 43,
+                "full_id": 1831534592,
                 "name": "Karaman",
                 "translations": {
                     "japanese": "カラマン県",
@@ -35812,7 +37101,8 @@
                 }
             },
             {
-                "id": 1831600128,
+                "id": 44,
+                "full_id": 1831600128,
                 "name": "Ordu",
                 "translations": {
                     "japanese": "オルドゥ県",
@@ -35838,7 +37128,8 @@
                 }
             },
             {
-                "id": 1831665664,
+                "id": 45,
+                "full_id": 1831665664,
                 "name": "Siirt",
                 "translations": {
                     "japanese": "シイルト県",
@@ -35864,7 +37155,8 @@
                 }
             },
             {
-                "id": 1831731200,
+                "id": 46,
+                "full_id": 1831731200,
                 "name": "Erzincan",
                 "translations": {
                     "japanese": "エルジンジャン県",
@@ -35890,7 +37182,8 @@
                 }
             },
             {
-                "id": 1831796736,
+                "id": 47,
+                "full_id": 1831796736,
                 "name": "Çankırı",
                 "translations": {
                     "japanese": "チャンクル県",
@@ -35916,7 +37209,8 @@
                 }
             },
             {
-                "id": 1831862272,
+                "id": 3,
+                "full_id": 1831862272,
                 "name": "Zonguldak",
                 "translations": {
                     "japanese": "ゾングルダク県",
@@ -35942,7 +37236,8 @@
                 }
             },
             {
-                "id": 1831927808,
+                "id": 49,
+                "full_id": 1831927808,
                 "name": "Yozgat",
                 "translations": {
                     "japanese": "ヨズガト県",
@@ -35968,7 +37263,8 @@
                 }
             },
             {
-                "id": 1831993344,
+                "id": 50,
+                "full_id": 1831993344,
                 "name": "Uşak",
                 "translations": {
                     "japanese": "ウシャク県",
@@ -35994,7 +37290,8 @@
                 }
             },
             {
-                "id": 1832058880,
+                "id": 51,
+                "full_id": 1832058880,
                 "name": "Ağrı",
                 "translations": {
                     "japanese": "アール県",
@@ -36020,7 +37317,8 @@
                 }
             },
             {
-                "id": 1832124416,
+                "id": 52,
+                "full_id": 1832124416,
                 "name": "Amasya",
                 "translations": {
                     "japanese": "アマシヤ県",
@@ -36046,7 +37344,8 @@
                 }
             },
             {
-                "id": 1832189952,
+                "id": 53,
+                "full_id": 1832189952,
                 "name": "Ardahan",
                 "translations": {
                     "japanese": "アルダハン県",
@@ -36072,7 +37371,8 @@
                 }
             },
             {
-                "id": 1832255488,
+                "id": 54,
+                "full_id": 1832255488,
                 "name": "Artvin",
                 "translations": {
                     "japanese": "アルトウィン県",
@@ -36098,7 +37398,8 @@
                 }
             },
             {
-                "id": 1832321024,
+                "id": 55,
+                "full_id": 1832321024,
                 "name": "Bartın",
                 "translations": {
                     "japanese": "バルトゥン県",
@@ -36124,7 +37425,8 @@
                 }
             },
             {
-                "id": 1832386560,
+                "id": 56,
+                "full_id": 1832386560,
                 "name": "Bayburt",
                 "translations": {
                     "japanese": "バイブルト県",
@@ -36150,7 +37452,8 @@
                 }
             },
             {
-                "id": 1832452096,
+                "id": 57,
+                "full_id": 1832452096,
                 "name": "Bilecik",
                 "translations": {
                     "japanese": "ビレジク県",
@@ -36176,7 +37479,8 @@
                 }
             },
             {
-                "id": 1832517632,
+                "id": 58,
+                "full_id": 1832517632,
                 "name": "Bingöl",
                 "translations": {
                     "japanese": "ビンギョル県",
@@ -36202,7 +37506,8 @@
                 }
             },
             {
-                "id": 1832583168,
+                "id": 59,
+                "full_id": 1832583168,
                 "name": "Bitlis",
                 "translations": {
                     "japanese": "ビトリス県",
@@ -36228,7 +37533,8 @@
                 }
             },
             {
-                "id": 1832648704,
+                "id": 60,
+                "full_id": 1832648704,
                 "name": "Bolu",
                 "translations": {
                     "japanese": "ボル県",
@@ -36254,7 +37560,8 @@
                 }
             },
             {
-                "id": 1832714240,
+                "id": 61,
+                "full_id": 1832714240,
                 "name": "Burdur",
                 "translations": {
                     "japanese": "ブルドゥル県",
@@ -36280,7 +37587,8 @@
                 }
             },
             {
-                "id": 1832779776,
+                "id": 62,
+                "full_id": 1832779776,
                 "name": "Çanakkale",
                 "translations": {
                     "japanese": "チャナッカレ県",
@@ -36306,7 +37614,8 @@
                 }
             },
             {
-                "id": 1832845312,
+                "id": 63,
+                "full_id": 1832845312,
                 "name": "Düzce",
                 "translations": {
                     "japanese": "デュズジェ県",
@@ -36332,7 +37641,8 @@
                 }
             },
             {
-                "id": 1832910848,
+                "id": 4,
+                "full_id": 1832910848,
                 "name": "Eskişehir",
                 "translations": {
                     "japanese": "エスキシェヒル県",
@@ -36358,7 +37668,8 @@
                 }
             },
             {
-                "id": 1832976384,
+                "id": 65,
+                "full_id": 1832976384,
                 "name": "Giresun",
                 "translations": {
                     "japanese": "ギレスン県",
@@ -36384,7 +37695,8 @@
                 }
             },
             {
-                "id": 1833041920,
+                "id": 66,
+                "full_id": 1833041920,
                 "name": "Gümüşhane",
                 "translations": {
                     "japanese": "ギュミュシュハーネ県",
@@ -36410,7 +37722,8 @@
                 }
             },
             {
-                "id": 1833107456,
+                "id": 67,
+                "full_id": 1833107456,
                 "name": "Hakkari",
                 "translations": {
                     "japanese": "ハッキャリ県",
@@ -36436,7 +37749,8 @@
                 }
             },
             {
-                "id": 1833172992,
+                "id": 68,
+                "full_id": 1833172992,
                 "name": "Iğdır",
                 "translations": {
                     "japanese": "ウードゥル県",
@@ -36462,7 +37776,8 @@
                 }
             },
             {
-                "id": 1833238528,
+                "id": 69,
+                "full_id": 1833238528,
                 "name": "Karabük",
                 "translations": {
                     "japanese": "カラビュック県",
@@ -36488,7 +37803,8 @@
                 }
             },
             {
-                "id": 1833304064,
+                "id": 70,
+                "full_id": 1833304064,
                 "name": "Kars",
                 "translations": {
                     "japanese": "カルス県",
@@ -36514,7 +37830,8 @@
                 }
             },
             {
-                "id": 1833369600,
+                "id": 71,
+                "full_id": 1833369600,
                 "name": "Kastamonu",
                 "translations": {
                     "japanese": "カスタモヌ県",
@@ -36540,7 +37857,8 @@
                 }
             },
             {
-                "id": 1833435136,
+                "id": 72,
+                "full_id": 1833435136,
                 "name": "Kilis",
                 "translations": {
                     "japanese": "キリス県",
@@ -36566,7 +37884,8 @@
                 }
             },
             {
-                "id": 1833500672,
+                "id": 73,
+                "full_id": 1833500672,
                 "name": "Kırklareli",
                 "translations": {
                     "japanese": "クルクラーレリ県",
@@ -36592,7 +37911,8 @@
                 }
             },
             {
-                "id": 1833566208,
+                "id": 74,
+                "full_id": 1833566208,
                 "name": "Kırşehir",
                 "translations": {
                     "japanese": "クルシェヒル県",
@@ -36618,7 +37938,8 @@
                 }
             },
             {
-                "id": 1833631744,
+                "id": 75,
+                "full_id": 1833631744,
                 "name": "Muğla",
                 "translations": {
                     "japanese": "ムーラ県",
@@ -36644,7 +37965,8 @@
                 }
             },
             {
-                "id": 1833697280,
+                "id": 76,
+                "full_id": 1833697280,
                 "name": "Muş",
                 "translations": {
                     "japanese": "ムシュ県",
@@ -36670,7 +37992,8 @@
                 }
             },
             {
-                "id": 1833762816,
+                "id": 77,
+                "full_id": 1833762816,
                 "name": "Nevşehir",
                 "translations": {
                     "japanese": "ネヴシェヒル県",
@@ -36696,7 +38019,8 @@
                 }
             },
             {
-                "id": 1833828352,
+                "id": 78,
+                "full_id": 1833828352,
                 "name": "Niğde",
                 "translations": {
                     "japanese": "ニーデ県",
@@ -36722,7 +38046,8 @@
                 }
             },
             {
-                "id": 1833893888,
+                "id": 79,
+                "full_id": 1833893888,
                 "name": "Rize",
                 "translations": {
                     "japanese": "リゼ県",
@@ -36748,7 +38073,8 @@
                 }
             },
             {
-                "id": 1833959424,
+                "id": 5,
+                "full_id": 1833959424,
                 "name": "Sinop",
                 "translations": {
                     "japanese": "シノプ県",
@@ -36774,7 +38100,8 @@
                 }
             },
             {
-                "id": 1834024960,
+                "id": 81,
+                "full_id": 1834024960,
                 "name": "Şırnak",
                 "translations": {
                     "japanese": "シュルナク県",
@@ -36800,7 +38127,8 @@
                 }
             },
             {
-                "id": 1834090496,
+                "id": 82,
+                "full_id": 1834090496,
                 "name": "Tunceli",
                 "translations": {
                     "japanese": "トゥンジェリ県",
@@ -36826,7 +38154,8 @@
                 }
             },
             {
-                "id": 1834156032,
+                "id": 83,
+                "full_id": 1834156032,
                 "name": "Yalova",
                 "translations": {
                     "japanese": "ヤロワ県",
@@ -36877,7 +38206,8 @@
         },
         "regions": [
             {
-                "id": 1845493760,
+                "id": 0,
+                "full_id": 1845493760,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -36903,7 +38233,8 @@
                 }
             },
             {
-                "id": 1845690368,
+                "id": 3,
+                "full_id": 1845690368,
                 "name": "London",
                 "translations": {
                     "japanese": "ロンドン",
@@ -36929,7 +38260,8 @@
                 }
             },
             {
-                "id": 1845821440,
+                "id": 5,
+                "full_id": 1845821440,
                 "name": "Scotland",
                 "translations": {
                     "japanese": "スコットランド",
@@ -36955,7 +38287,8 @@
                 }
             },
             {
-                "id": 1845886976,
+                "id": 6,
+                "full_id": 1845886976,
                 "name": "Wales",
                 "translations": {
                     "japanese": "ウェールズ",
@@ -36981,7 +38314,8 @@
                 }
             },
             {
-                "id": 1845952512,
+                "id": 7,
+                "full_id": 1845952512,
                 "name": "Northern Ireland",
                 "translations": {
                     "japanese": "北アイルランド",
@@ -37007,7 +38341,8 @@
                 }
             },
             {
-                "id": 1846018048,
+                "id": 8,
+                "full_id": 1846018048,
                 "name": "South West",
                 "translations": {
                     "japanese": "南西部地方",
@@ -37033,7 +38368,8 @@
                 }
             },
             {
-                "id": 1846083584,
+                "id": 9,
+                "full_id": 1846083584,
                 "name": "West Midlands",
                 "translations": {
                     "japanese": "ウェスト・ミッドランド地方",
@@ -37059,7 +38395,8 @@
                 }
             },
             {
-                "id": 1846149120,
+                "id": 10,
+                "full_id": 1846149120,
                 "name": "North West",
                 "translations": {
                     "japanese": "北西部地方",
@@ -37085,7 +38422,8 @@
                 }
             },
             {
-                "id": 1846214656,
+                "id": 11,
+                "full_id": 1846214656,
                 "name": "North East",
                 "translations": {
                     "japanese": "北東部地方",
@@ -37111,7 +38449,8 @@
                 }
             },
             {
-                "id": 1846280192,
+                "id": 12,
+                "full_id": 1846280192,
                 "name": "Yorkshire and the Humber",
                 "translations": {
                     "japanese": "ヨークシャー・アンド・ザ・ハンバー地方",
@@ -37137,7 +38476,8 @@
                 }
             },
             {
-                "id": 1846345728,
+                "id": 13,
+                "full_id": 1846345728,
                 "name": "East Midlands",
                 "translations": {
                     "japanese": "イースト・ミッドランド地方",
@@ -37163,7 +38503,8 @@
                 }
             },
             {
-                "id": 1846411264,
+                "id": 14,
+                "full_id": 1846411264,
                 "name": "East of England",
                 "translations": {
                     "japanese": "イングランド東部地方",
@@ -37189,7 +38530,8 @@
                 }
             },
             {
-                "id": 1846476800,
+                "id": 15,
+                "full_id": 1846476800,
                 "name": "South East",
                 "translations": {
                     "japanese": "南東部地方",
@@ -37197,7 +38539,7 @@
                     "french": "Sud-Est",
                     "german": "South East",
                     "italian": "Sud Est",
-                    "spanish": "씒⭤ꥠ軷됎矙ᑻ۱埣ἴឦ",
+                    "spanish": "Sureste",
                     "chinese_simple": "东南英格兰",
                     "korean": "사우스이스트",
                     "dutch": "South East",
@@ -37240,7 +38582,8 @@
         },
         "regions": [
             {
-                "id": 1862270976,
+                "id": 0,
+                "full_id": 1862270976,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37266,7 +38609,8 @@
                 }
             },
             {
-                "id": 1862336512,
+                "id": 1,
+                "full_id": 1862336512,
                 "name": "Zambia",
                 "translations": {
                     "japanese": "ザンビア",
@@ -37317,7 +38661,8 @@
         },
         "regions": [
             {
-                "id": 1879048192,
+                "id": 0,
+                "full_id": 1879048192,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37343,7 +38688,8 @@
                 }
             },
             {
-                "id": 1879113728,
+                "id": 1,
+                "full_id": 1879113728,
                 "name": "Zimbabwe",
                 "translations": {
                     "japanese": "ジンバブエ",
@@ -37394,7 +38740,8 @@
         },
         "regions": [
             {
-                "id": 1895825408,
+                "id": 0,
+                "full_id": 1895825408,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37420,7 +38767,8 @@
                 }
             },
             {
-                "id": 1895890944,
+                "id": 1,
+                "full_id": 1895890944,
                 "name": "Azerbaijan",
                 "translations": {
                     "japanese": "アゼルバイジャン",
@@ -37471,7 +38819,8 @@
         },
         "regions": [
             {
-                "id": 1912602624,
+                "id": 0,
+                "full_id": 1912602624,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37497,7 +38846,8 @@
                 }
             },
             {
-                "id": 1912668160,
+                "id": 1,
+                "full_id": 1912668160,
                 "name": "Mauritania",
                 "translations": {
                     "japanese": "モーリタニア",
@@ -37548,7 +38898,8 @@
         },
         "regions": [
             {
-                "id": 1929379840,
+                "id": 0,
+                "full_id": 1929379840,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37574,7 +38925,8 @@
                 }
             },
             {
-                "id": 1929445376,
+                "id": 1,
+                "full_id": 1929445376,
                 "name": "Mali",
                 "translations": {
                     "japanese": "マリ",
@@ -37625,7 +38977,8 @@
         },
         "regions": [
             {
-                "id": 1946157056,
+                "id": 0,
+                "full_id": 1946157056,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37651,7 +39004,8 @@
                 }
             },
             {
-                "id": 1946222592,
+                "id": 1,
+                "full_id": 1946222592,
                 "name": "Niger",
                 "translations": {
                     "japanese": "ニジェール",
@@ -37702,7 +39056,8 @@
         },
         "regions": [
             {
-                "id": 1962934272,
+                "id": 0,
+                "full_id": 1962934272,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37728,7 +39083,8 @@
                 }
             },
             {
-                "id": 1962999808,
+                "id": 1,
+                "full_id": 1962999808,
                 "name": "Chad",
                 "translations": {
                     "japanese": "チャド",
@@ -37779,7 +39135,8 @@
         },
         "regions": [
             {
-                "id": 1979711488,
+                "id": 0,
+                "full_id": 1979711488,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37805,7 +39162,8 @@
                 }
             },
             {
-                "id": 1979777024,
+                "id": 1,
+                "full_id": 1979777024,
                 "name": "Sudan",
                 "translations": {
                     "japanese": "スーダン",
@@ -37856,7 +39214,8 @@
         },
         "regions": [
             {
-                "id": 1996488704,
+                "id": 0,
+                "full_id": 1996488704,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37882,7 +39241,8 @@
                 }
             },
             {
-                "id": 1996554240,
+                "id": 1,
+                "full_id": 1996554240,
                 "name": "Eritrea",
                 "translations": {
                     "japanese": "エリトリア",
@@ -37933,7 +39293,8 @@
         },
         "regions": [
             {
-                "id": 2013265920,
+                "id": 0,
+                "full_id": 2013265920,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -37959,7 +39320,8 @@
                 }
             },
             {
-                "id": 2013331456,
+                "id": 1,
+                "full_id": 2013331456,
                 "name": "Djibouti",
                 "translations": {
                     "japanese": "ジブチ",
@@ -38010,7 +39372,8 @@
         },
         "regions": [
             {
-                "id": 2030043136,
+                "id": 0,
+                "full_id": 2030043136,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38036,7 +39399,8 @@
                 }
             },
             {
-                "id": 2030108672,
+                "id": 1,
+                "full_id": 2030108672,
                 "name": "Somalia",
                 "translations": {
                     "japanese": "ソマリア",
@@ -38087,7 +39451,8 @@
         },
         "regions": [
             {
-                "id": 2046820352,
+                "id": 0,
+                "full_id": 2046820352,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38113,7 +39478,8 @@
                 }
             },
             {
-                "id": 2046885888,
+                "id": 1,
+                "full_id": 2046885888,
                 "name": "Andorra",
                 "translations": {
                     "japanese": "アンドラ",
@@ -38164,7 +39530,8 @@
         },
         "regions": [
             {
-                "id": 2063597568,
+                "id": 0,
+                "full_id": 2063597568,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38190,7 +39557,8 @@
                 }
             },
             {
-                "id": 2063663104,
+                "id": 1,
+                "full_id": 2063663104,
                 "name": "Gibraltar",
                 "translations": {
                     "japanese": "ジブラルタル",
@@ -38241,7 +39609,8 @@
         },
         "regions": [
             {
-                "id": 2080374784,
+                "id": 0,
+                "full_id": 2080374784,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38267,7 +39636,8 @@
                 }
             },
             {
-                "id": 2080440320,
+                "id": 1,
+                "full_id": 2080440320,
                 "name": "Guernsey",
                 "translations": {
                     "japanese": "ガーンジー島",
@@ -38318,7 +39688,8 @@
         },
         "regions": [
             {
-                "id": 2097152000,
+                "id": 0,
+                "full_id": 2097152000,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38344,7 +39715,8 @@
                 }
             },
             {
-                "id": 2097217536,
+                "id": 1,
+                "full_id": 2097217536,
                 "name": "Isle of Man",
                 "translations": {
                     "japanese": "マン島",
@@ -38395,7 +39767,8 @@
         },
         "regions": [
             {
-                "id": 2113929216,
+                "id": 0,
+                "full_id": 2113929216,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38421,7 +39794,8 @@
                 }
             },
             {
-                "id": 2113994752,
+                "id": 1,
+                "full_id": 2113994752,
                 "name": "Jersey",
                 "translations": {
                     "japanese": "ジャージー島",
@@ -38472,7 +39846,8 @@
         },
         "regions": [
             {
-                "id": 2130706432,
+                "id": 0,
+                "full_id": 2130706432,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38498,7 +39873,8 @@
                 }
             },
             {
-                "id": 2130771968,
+                "id": 1,
+                "full_id": 2130771968,
                 "name": "Monaco",
                 "translations": {
                     "japanese": "モナコ",
@@ -38549,7 +39925,8 @@
         },
         "regions": [
             {
-                "id": 2147483648,
+                "id": 0,
+                "full_id": 2147483648,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -38575,7 +39952,8 @@
                 }
             },
             {
-                "id": 2147614720,
+                "id": 2,
+                "full_id": 2147614720,
                 "name": "Taipei City",
                 "translations": {
                     "japanese": "台北市",
@@ -38601,7 +39979,8 @@
                 }
             },
             {
-                "id": 2147680256,
+                "id": 3,
+                "full_id": 2147680256,
                 "name": "Kaohsiung City",
                 "translations": {
                     "japanese": "高雄市",
@@ -38627,7 +40006,8 @@
                 }
             },
             {
-                "id": 2147745792,
+                "id": 4,
+                "full_id": 2147745792,
                 "name": "Keelung City",
                 "translations": {
                     "japanese": "基隆市",
@@ -38653,7 +40033,8 @@
                 }
             },
             {
-                "id": 2147811328,
+                "id": 5,
+                "full_id": 2147811328,
                 "name": "Hsinchu City",
                 "translations": {
                     "japanese": "新竹市",
@@ -38679,7 +40060,8 @@
                 }
             },
             {
-                "id": 2147876864,
+                "id": 6,
+                "full_id": 2147876864,
                 "name": "Taichung City",
                 "translations": {
                     "japanese": "台中市",
@@ -38705,7 +40087,8 @@
                 }
             },
             {
-                "id": 2147942400,
+                "id": 7,
+                "full_id": 2147942400,
                 "name": "Chiayi City",
                 "translations": {
                     "japanese": "嘉義市",
@@ -38731,7 +40114,8 @@
                 }
             },
             {
-                "id": 2148007936,
+                "id": 8,
+                "full_id": 2148007936,
                 "name": "Tainan City",
                 "translations": {
                     "japanese": "台南市",
@@ -38757,7 +40141,8 @@
                 }
             },
             {
-                "id": 2148073472,
+                "id": 9,
+                "full_id": 2148073472,
                 "name": "New Taipei City",
                 "translations": {
                     "japanese": "新北市",
@@ -38783,7 +40168,8 @@
                 }
             },
             {
-                "id": 2148139008,
+                "id": 10,
+                "full_id": 2148139008,
                 "name": "Taoyuan City",
                 "translations": {
                     "japanese": "桃園市",
@@ -38809,7 +40195,8 @@
                 }
             },
             {
-                "id": 2148204544,
+                "id": 11,
+                "full_id": 2148204544,
                 "name": "HsinChu County",
                 "translations": {
                     "japanese": "新竹県",
@@ -38835,7 +40222,8 @@
                 }
             },
             {
-                "id": 2148270080,
+                "id": 12,
+                "full_id": 2148270080,
                 "name": "Miaoli County",
                 "translations": {
                     "japanese": "苗栗県",
@@ -38861,7 +40249,8 @@
                 }
             },
             {
-                "id": 2148335616,
+                "id": 13,
+                "full_id": 2148335616,
                 "name": "Taichung County",
                 "translations": {
                     "japanese": "台中県",
@@ -38887,7 +40276,8 @@
                 }
             },
             {
-                "id": 2148401152,
+                "id": 14,
+                "full_id": 2148401152,
                 "name": "Changhua County",
                 "translations": {
                     "japanese": "彰化県",
@@ -38913,7 +40303,8 @@
                 }
             },
             {
-                "id": 2148466688,
+                "id": 15,
+                "full_id": 2148466688,
                 "name": "Nantou County",
                 "translations": {
                     "japanese": "南投県",
@@ -38939,7 +40330,8 @@
                 }
             },
             {
-                "id": 2148532224,
+                "id": 1,
+                "full_id": 2148532224,
                 "name": "Yunlin County",
                 "translations": {
                     "japanese": "雲林県",
@@ -38965,7 +40357,8 @@
                 }
             },
             {
-                "id": 2148597760,
+                "id": 17,
+                "full_id": 2148597760,
                 "name": "Chiayi County",
                 "translations": {
                     "japanese": "嘉義県",
@@ -38991,7 +40384,8 @@
                 }
             },
             {
-                "id": 2148663296,
+                "id": 18,
+                "full_id": 2148663296,
                 "name": "Tainan County",
                 "translations": {
                     "japanese": "台南県",
@@ -39017,7 +40411,8 @@
                 }
             },
             {
-                "id": 2148728832,
+                "id": 19,
+                "full_id": 2148728832,
                 "name": "Kaohsiung County",
                 "translations": {
                     "japanese": "高雄県",
@@ -39043,7 +40438,8 @@
                 }
             },
             {
-                "id": 2148794368,
+                "id": 20,
+                "full_id": 2148794368,
                 "name": "Pingtung County",
                 "translations": {
                     "japanese": "屏東県",
@@ -39069,7 +40465,8 @@
                 }
             },
             {
-                "id": 2148859904,
+                "id": 21,
+                "full_id": 2148859904,
                 "name": "Yilan County",
                 "translations": {
                     "japanese": "宜蘭県",
@@ -39095,7 +40492,8 @@
                 }
             },
             {
-                "id": 2148925440,
+                "id": 22,
+                "full_id": 2148925440,
                 "name": "Hualien County",
                 "translations": {
                     "japanese": "花蓮県",
@@ -39121,7 +40519,8 @@
                 }
             },
             {
-                "id": 2148990976,
+                "id": 23,
+                "full_id": 2148990976,
                 "name": "Taitung County",
                 "translations": {
                     "japanese": "台東県",
@@ -39147,7 +40546,8 @@
                 }
             },
             {
-                "id": 2149056512,
+                "id": 24,
+                "full_id": 2149056512,
                 "name": "Penghu County",
                 "translations": {
                     "japanese": "澎湖県",
@@ -39173,7 +40573,8 @@
                 }
             },
             {
-                "id": 2149122048,
+                "id": 25,
+                "full_id": 2149122048,
                 "name": "Kinmen County",
                 "translations": {
                     "japanese": "金門県",
@@ -39199,7 +40600,8 @@
                 }
             },
             {
-                "id": 2149187584,
+                "id": 26,
+                "full_id": 2149187584,
                 "name": "Lienchiang County",
                 "translations": {
                     "japanese": "連江県",
@@ -39250,7 +40652,8 @@
         },
         "regions": [
             {
-                "id": 2281701376,
+                "id": 0,
+                "full_id": 2281701376,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39276,7 +40679,8 @@
                 }
             },
             {
-                "id": 2281832448,
+                "id": 2,
+                "full_id": 2281832448,
                 "name": "Seoul-teukbyeolsi",
                 "translations": {
                     "japanese": "ソウル特別市",
@@ -39302,7 +40706,8 @@
                 }
             },
             {
-                "id": 2281897984,
+                "id": 3,
+                "full_id": 2281897984,
                 "name": "Busan-gwangyeoksi",
                 "translations": {
                     "japanese": "プサン広域市",
@@ -39328,7 +40733,8 @@
                 }
             },
             {
-                "id": 2281963520,
+                "id": 4,
+                "full_id": 2281963520,
                 "name": "Daegu-gwangyeoksi",
                 "translations": {
                     "japanese": "テグ広域市",
@@ -39354,7 +40760,8 @@
                 }
             },
             {
-                "id": 2282029056,
+                "id": 5,
+                "full_id": 2282029056,
                 "name": "Incheon-gwangyeoksi",
                 "translations": {
                     "japanese": "インチョン広域市",
@@ -39380,7 +40787,8 @@
                 }
             },
             {
-                "id": 2282094592,
+                "id": 6,
+                "full_id": 2282094592,
                 "name": "Gwangju-gwangyeoksi",
                 "translations": {
                     "japanese": "クァンジュ広域市",
@@ -39406,7 +40814,8 @@
                 }
             },
             {
-                "id": 2282160128,
+                "id": 7,
+                "full_id": 2282160128,
                 "name": "Daejeon-gwangyeoksi",
                 "translations": {
                     "japanese": "テジョン広域市",
@@ -39432,7 +40841,8 @@
                 }
             },
             {
-                "id": 2282225664,
+                "id": 8,
+                "full_id": 2282225664,
                 "name": "Ulsan-gwangyeoksi",
                 "translations": {
                     "japanese": "ウルサン広域市",
@@ -39458,7 +40868,8 @@
                 }
             },
             {
-                "id": 2282291200,
+                "id": 9,
+                "full_id": 2282291200,
                 "name": "Gyeonggi-do",
                 "translations": {
                     "japanese": "キョンギ道",
@@ -39484,7 +40895,8 @@
                 }
             },
             {
-                "id": 2282356736,
+                "id": 10,
+                "full_id": 2282356736,
                 "name": "Gangwon-do",
                 "translations": {
                     "japanese": "カンウォン道",
@@ -39510,7 +40922,8 @@
                 }
             },
             {
-                "id": 2282422272,
+                "id": 11,
+                "full_id": 2282422272,
                 "name": "Chungcheongbuk-do",
                 "translations": {
                     "japanese": "チュンチョンブク道",
@@ -39536,7 +40949,8 @@
                 }
             },
             {
-                "id": 2282487808,
+                "id": 12,
+                "full_id": 2282487808,
                 "name": "Chungcheongnam-do",
                 "translations": {
                     "japanese": "チュンチョンナム道",
@@ -39562,7 +40976,8 @@
                 }
             },
             {
-                "id": 2282553344,
+                "id": 13,
+                "full_id": 2282553344,
                 "name": "Jeollabuk-do",
                 "translations": {
                     "japanese": "チョルラブク道",
@@ -39588,7 +41003,8 @@
                 }
             },
             {
-                "id": 2282618880,
+                "id": 14,
+                "full_id": 2282618880,
                 "name": "Jeollanam-do",
                 "translations": {
                     "japanese": "チョルラナム道",
@@ -39614,7 +41030,8 @@
                 }
             },
             {
-                "id": 2282684416,
+                "id": 15,
+                "full_id": 2282684416,
                 "name": "Gyeongsangbuk-do",
                 "translations": {
                     "japanese": "キョンサンブク道",
@@ -39640,7 +41057,8 @@
                 }
             },
             {
-                "id": 2282749952,
+                "id": 1,
+                "full_id": 2282749952,
                 "name": "Gyeongsangnam-do",
                 "translations": {
                     "japanese": "キョンサンナム道",
@@ -39666,7 +41084,8 @@
                 }
             },
             {
-                "id": 2282815488,
+                "id": 17,
+                "full_id": 2282815488,
                 "name": "Jeju-teukbyeoljachido",
                 "translations": {
                     "japanese": "チェジュ特別自治道",
@@ -39717,7 +41136,8 @@
         },
         "regions": [
             {
-                "id": 2415919104,
+                "id": 0,
+                "full_id": 2415919104,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39743,7 +41163,8 @@
                 }
             },
             {
-                "id": 2415984640,
+                "id": 1,
+                "full_id": 2415984640,
                 "name": "Hong Kong",
                 "translations": {
                     "japanese": "ホンコン",
@@ -39794,7 +41215,8 @@
         },
         "regions": [
             {
-                "id": 2432696320,
+                "id": 0,
+                "full_id": 2432696320,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39820,7 +41242,8 @@
                 }
             },
             {
-                "id": 2432761856,
+                "id": 1,
+                "full_id": 2432761856,
                 "name": "Macao",
                 "translations": {
                     "japanese": "マカオ",
@@ -39871,7 +41294,8 @@
         },
         "regions": [
             {
-                "id": 2566914048,
+                "id": 0,
+                "full_id": 2566914048,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39897,7 +41321,8 @@
                 }
             },
             {
-                "id": 2566979584,
+                "id": 1,
+                "full_id": 2566979584,
                 "name": "Singapore",
                 "translations": {
                     "japanese": "シンガポール",
@@ -39948,7 +41373,8 @@
         },
         "regions": [
             {
-                "id": 2617245696,
+                "id": 0,
+                "full_id": 2617245696,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -39974,7 +41400,8 @@
                 }
             },
             {
-                "id": 2617376768,
+                "id": 2,
+                "full_id": 2617376768,
                 "name": "Kuala Lumpur",
                 "translations": {
                     "japanese": "クアラ・ルンプール",
@@ -40000,7 +41427,8 @@
                 }
             },
             {
-                "id": 2617442304,
+                "id": 3,
+                "full_id": 2617442304,
                 "name": "Johor",
                 "translations": {
                     "japanese": "ジョホール州",
@@ -40026,7 +41454,8 @@
                 }
             },
             {
-                "id": 2617507840,
+                "id": 4,
+                "full_id": 2617507840,
                 "name": "Kedah",
                 "translations": {
                     "japanese": "ケダ州",
@@ -40052,7 +41481,8 @@
                 }
             },
             {
-                "id": 2617573376,
+                "id": 5,
+                "full_id": 2617573376,
                 "name": "Kelantan",
                 "translations": {
                     "japanese": "ケランタン州",
@@ -40078,7 +41508,8 @@
                 }
             },
             {
-                "id": 2617638912,
+                "id": 6,
+                "full_id": 2617638912,
                 "name": "Melaka",
                 "translations": {
                     "japanese": "マラッカ州",
@@ -40104,7 +41535,8 @@
                 }
             },
             {
-                "id": 2617704448,
+                "id": 7,
+                "full_id": 2617704448,
                 "name": "Negeri Sembilan",
                 "translations": {
                     "japanese": "ヌグリ・センビラン州",
@@ -40130,7 +41562,8 @@
                 }
             },
             {
-                "id": 2617769984,
+                "id": 8,
+                "full_id": 2617769984,
                 "name": "Pahang",
                 "translations": {
                     "japanese": "パハン州",
@@ -40156,7 +41589,8 @@
                 }
             },
             {
-                "id": 2617835520,
+                "id": 9,
+                "full_id": 2617835520,
                 "name": "Perak",
                 "translations": {
                     "japanese": "ペラ州",
@@ -40182,7 +41616,8 @@
                 }
             },
             {
-                "id": 2617901056,
+                "id": 10,
+                "full_id": 2617901056,
                 "name": "Perlis",
                 "translations": {
                     "japanese": "ペルリス州",
@@ -40208,7 +41643,8 @@
                 }
             },
             {
-                "id": 2617966592,
+                "id": 11,
+                "full_id": 2617966592,
                 "name": "Penang",
                 "translations": {
                     "japanese": "ピナン州",
@@ -40234,7 +41670,8 @@
                 }
             },
             {
-                "id": 2618032128,
+                "id": 12,
+                "full_id": 2618032128,
                 "name": "Sarawak",
                 "translations": {
                     "japanese": "サラワク州",
@@ -40260,7 +41697,8 @@
                 }
             },
             {
-                "id": 2618097664,
+                "id": 13,
+                "full_id": 2618097664,
                 "name": "Selangor",
                 "translations": {
                     "japanese": "セランゴール州",
@@ -40286,7 +41724,8 @@
                 }
             },
             {
-                "id": 2618163200,
+                "id": 14,
+                "full_id": 2618163200,
                 "name": "Terengganu",
                 "translations": {
                     "japanese": "トレンガヌ州",
@@ -40312,7 +41751,8 @@
                 }
             },
             {
-                "id": 2618228736,
+                "id": 15,
+                "full_id": 2618228736,
                 "name": "Labuan",
                 "translations": {
                     "japanese": "ラブアン",
@@ -40338,7 +41778,8 @@
                 }
             },
             {
-                "id": 2618294272,
+                "id": 1,
+                "full_id": 2618294272,
                 "name": "Sabah",
                 "translations": {
                     "japanese": "サバ州",
@@ -40364,7 +41805,8 @@
                 }
             },
             {
-                "id": 2618359808,
+                "id": 17,
+                "full_id": 2618359808,
                 "name": "Putrajaya",
                 "translations": {
                     "japanese": "プトラジャヤ",
@@ -40415,7 +41857,8 @@
         },
         "regions": [
             {
-                "id": 2684354560,
+                "id": 0,
+                "full_id": 2684354560,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -40441,7 +41884,8 @@
                 }
             },
             {
-                "id": 2684485632,
+                "id": 2,
+                "full_id": 2684485632,
                 "name": "Beijing",
                 "translations": {
                     "japanese": "北京市",
@@ -40467,7 +41911,8 @@
                 }
             },
             {
-                "id": 2684551168,
+                "id": 3,
+                "full_id": 2684551168,
                 "name": "Chongqing",
                 "translations": {
                     "japanese": "重慶市",
@@ -40493,7 +41938,8 @@
                 }
             },
             {
-                "id": 2684616704,
+                "id": 4,
+                "full_id": 2684616704,
                 "name": "Shanghai",
                 "translations": {
                     "japanese": "上海市",
@@ -40519,7 +41965,8 @@
                 }
             },
             {
-                "id": 2684682240,
+                "id": 5,
+                "full_id": 2684682240,
                 "name": "Tianjin",
                 "translations": {
                     "japanese": "天津市",
@@ -40545,7 +41992,8 @@
                 }
             },
             {
-                "id": 2684747776,
+                "id": 6,
+                "full_id": 2684747776,
                 "name": "Anhui",
                 "translations": {
                     "japanese": "安徽省",
@@ -40571,7 +42019,8 @@
                 }
             },
             {
-                "id": 2684813312,
+                "id": 7,
+                "full_id": 2684813312,
                 "name": "Fujian",
                 "translations": {
                     "japanese": "福建省",
@@ -40597,7 +42046,8 @@
                 }
             },
             {
-                "id": 2684878848,
+                "id": 8,
+                "full_id": 2684878848,
                 "name": "Gansu",
                 "translations": {
                     "japanese": "甘粛省",
@@ -40623,7 +42073,8 @@
                 }
             },
             {
-                "id": 2684944384,
+                "id": 9,
+                "full_id": 2684944384,
                 "name": "Guangdong",
                 "translations": {
                     "japanese": "広東省",
@@ -40649,7 +42100,8 @@
                 }
             },
             {
-                "id": 2685009920,
+                "id": 10,
+                "full_id": 2685009920,
                 "name": "Guizhou",
                 "translations": {
                     "japanese": "貴州省",
@@ -40675,7 +42127,8 @@
                 }
             },
             {
-                "id": 2685075456,
+                "id": 11,
+                "full_id": 2685075456,
                 "name": "Hainan",
                 "translations": {
                     "japanese": "海南省",
@@ -40701,7 +42154,8 @@
                 }
             },
             {
-                "id": 2685140992,
+                "id": 12,
+                "full_id": 2685140992,
                 "name": "Hebei",
                 "translations": {
                     "japanese": "河北省",
@@ -40727,7 +42181,8 @@
                 }
             },
             {
-                "id": 2685206528,
+                "id": 13,
+                "full_id": 2685206528,
                 "name": "Heilongjiang",
                 "translations": {
                     "japanese": "黒龍江省",
@@ -40753,7 +42208,8 @@
                 }
             },
             {
-                "id": 2685272064,
+                "id": 14,
+                "full_id": 2685272064,
                 "name": "Henan",
                 "translations": {
                     "japanese": "河南省",
@@ -40779,7 +42235,8 @@
                 }
             },
             {
-                "id": 2685337600,
+                "id": 15,
+                "full_id": 2685337600,
                 "name": "Hubei",
                 "translations": {
                     "japanese": "湖北省",
@@ -40805,7 +42262,8 @@
                 }
             },
             {
-                "id": 2685403136,
+                "id": 1,
+                "full_id": 2685403136,
                 "name": "Húnán",
                 "translations": {
                     "japanese": "湖南省",
@@ -40831,7 +42289,8 @@
                 }
             },
             {
-                "id": 2685468672,
+                "id": 17,
+                "full_id": 2685468672,
                 "name": "Jiangsu",
                 "translations": {
                     "japanese": "江蘇省",
@@ -40857,7 +42316,8 @@
                 }
             },
             {
-                "id": 2685534208,
+                "id": 18,
+                "full_id": 2685534208,
                 "name": "Jiangxi",
                 "translations": {
                     "japanese": "江西省",
@@ -40883,7 +42343,8 @@
                 }
             },
             {
-                "id": 2685599744,
+                "id": 19,
+                "full_id": 2685599744,
                 "name": "Jilin",
                 "translations": {
                     "japanese": "吉林省",
@@ -40909,7 +42370,8 @@
                 }
             },
             {
-                "id": 2685665280,
+                "id": 20,
+                "full_id": 2685665280,
                 "name": "Liaoning",
                 "translations": {
                     "japanese": "遼寧省",
@@ -40935,7 +42397,8 @@
                 }
             },
             {
-                "id": 2685730816,
+                "id": 21,
+                "full_id": 2685730816,
                 "name": "Qinghai",
                 "translations": {
                     "japanese": "青海省",
@@ -40961,7 +42424,8 @@
                 }
             },
             {
-                "id": 2685796352,
+                "id": 22,
+                "full_id": 2685796352,
                 "name": "Shanxi",
                 "translations": {
                     "japanese": "陝西省",
@@ -40987,7 +42451,8 @@
                 }
             },
             {
-                "id": 2685861888,
+                "id": 23,
+                "full_id": 2685861888,
                 "name": "Shandong",
                 "translations": {
                     "japanese": "山東省",
@@ -41013,7 +42478,8 @@
                 }
             },
             {
-                "id": 2685927424,
+                "id": 24,
+                "full_id": 2685927424,
                 "name": "Shanxi",
                 "translations": {
                     "japanese": "山西省",
@@ -41039,7 +42505,8 @@
                 }
             },
             {
-                "id": 2685992960,
+                "id": 25,
+                "full_id": 2685992960,
                 "name": "Sichuan",
                 "translations": {
                     "japanese": "四川省",
@@ -41065,7 +42532,8 @@
                 }
             },
             {
-                "id": 2686058496,
+                "id": 26,
+                "full_id": 2686058496,
                 "name": "Yunnan",
                 "translations": {
                     "japanese": "雲南省",
@@ -41091,7 +42559,8 @@
                 }
             },
             {
-                "id": 2686124032,
+                "id": 27,
+                "full_id": 2686124032,
                 "name": "Zhejiang",
                 "translations": {
                     "japanese": "浙江省",
@@ -41117,7 +42586,8 @@
                 }
             },
             {
-                "id": 2686189568,
+                "id": 28,
+                "full_id": 2686189568,
                 "name": "Taiwan",
                 "translations": {
                     "japanese": "台湾省",
@@ -41143,7 +42613,8 @@
                 }
             },
             {
-                "id": 2686255104,
+                "id": 29,
+                "full_id": 2686255104,
                 "name": "Guangxi-Zhuangzu",
                 "translations": {
                     "japanese": "広西チワン族自治区",
@@ -41169,7 +42640,8 @@
                 }
             },
             {
-                "id": 2686320640,
+                "id": 30,
+                "full_id": 2686320640,
                 "name": "Nei-Menggu",
                 "translations": {
                     "japanese": "内モンゴル自治区",
@@ -41195,7 +42667,8 @@
                 }
             },
             {
-                "id": 2686386176,
+                "id": 31,
+                "full_id": 2686386176,
                 "name": "Ningxia-huizu",
                 "translations": {
                     "japanese": "寧夏回族自治区",
@@ -41221,7 +42694,8 @@
                 }
             },
             {
-                "id": 2686451712,
+                "id": 2,
+                "full_id": 2686451712,
                 "name": "Xinjiang-Weiwu'er-zu",
                 "translations": {
                     "japanese": "新疆ウイグル自治区",
@@ -41247,7 +42721,8 @@
                 }
             },
             {
-                "id": 2686517248,
+                "id": 33,
+                "full_id": 2686517248,
                 "name": "Xizang",
                 "translations": {
                     "japanese": "チベット自治区",
@@ -41273,7 +42748,8 @@
                 }
             },
             {
-                "id": 2686582784,
+                "id": 34,
+                "full_id": 2686582784,
                 "name": "Macao",
                 "translations": {
                     "japanese": "マカオ",
@@ -41299,7 +42775,8 @@
                 }
             },
             {
-                "id": 2686648320,
+                "id": 35,
+                "full_id": 2686648320,
                 "name": "Hong Kong",
                 "translations": {
                     "japanese": "ホンコン",
@@ -41350,7 +42827,8 @@
         },
         "regions": [
             {
-                "id": 2818572288,
+                "id": 0,
+                "full_id": 2818572288,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41376,7 +42854,8 @@
                 }
             },
             {
-                "id": 2818703360,
+                "id": 2,
+                "full_id": 2818703360,
                 "name": "Abu Dhabi",
                 "translations": {
                     "japanese": "アブダビ",
@@ -41402,7 +42881,8 @@
                 }
             },
             {
-                "id": 2818768896,
+                "id": 3,
+                "full_id": 2818768896,
                 "name": "Ajman",
                 "translations": {
                     "japanese": "アジュマン",
@@ -41428,7 +42908,8 @@
                 }
             },
             {
-                "id": 2818834432,
+                "id": 4,
+                "full_id": 2818834432,
                 "name": "Ash Shariqah",
                 "translations": {
                     "japanese": "シャルジャ",
@@ -41454,7 +42935,8 @@
                 }
             },
             {
-                "id": 2818899968,
+                "id": 5,
+                "full_id": 2818899968,
                 "name": "Ras al-Khaimah",
                 "translations": {
                     "japanese": "ラアス・アル・カイマー",
@@ -41480,7 +42962,8 @@
                 }
             },
             {
-                "id": 2818965504,
+                "id": 6,
+                "full_id": 2818965504,
                 "name": "Dubai",
                 "translations": {
                     "japanese": "ドゥバイ",
@@ -41506,7 +42989,8 @@
                 }
             },
             {
-                "id": 2819031040,
+                "id": 7,
+                "full_id": 2819031040,
                 "name": "Al Fujayrah",
                 "translations": {
                     "japanese": "フジャイラー",
@@ -41532,7 +43016,8 @@
                 }
             },
             {
-                "id": 2819096576,
+                "id": 8,
+                "full_id": 2819096576,
                 "name": "Umm al Qaywayn",
                 "translations": {
                     "japanese": "ウム・アル・カイワイン",
@@ -41583,7 +43068,8 @@
         },
         "regions": [
             {
-                "id": 2919235584,
+                "id": 0,
+                "full_id": 2919235584,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41609,7 +43095,8 @@
                 }
             },
             {
-                "id": 2919366656,
+                "id": 2,
+                "full_id": 2919366656,
                 "name": "Ar Riyad",
                 "translations": {
                     "japanese": "リヤド州",
@@ -41635,7 +43122,8 @@
                 }
             },
             {
-                "id": 2919432192,
+                "id": 3,
+                "full_id": 2919432192,
                 "name": "Al Bahah",
                 "translations": {
                     "japanese": "バーハ州",
@@ -41661,7 +43149,8 @@
                 }
             },
             {
-                "id": 2919497728,
+                "id": 4,
+                "full_id": 2919497728,
                 "name": "Al Madinah",
                 "translations": {
                     "japanese": "メディナ州",
@@ -41687,7 +43176,8 @@
                 }
             },
             {
-                "id": 2919563264,
+                "id": 5,
+                "full_id": 2919563264,
                 "name": "Ash Sharqiyah",
                 "translations": {
                     "japanese": "東部州",
@@ -41713,7 +43203,8 @@
                 }
             },
             {
-                "id": 2919628800,
+                "id": 6,
+                "full_id": 2919628800,
                 "name": "Al Qasim",
                 "translations": {
                     "japanese": "カスィーム州",
@@ -41739,7 +43230,8 @@
                 }
             },
             {
-                "id": 2919694336,
+                "id": 7,
+                "full_id": 2919694336,
                 "name": "'Asir",
                 "translations": {
                     "japanese": "アシール州",
@@ -41765,7 +43257,8 @@
                 }
             },
             {
-                "id": 2919759872,
+                "id": 8,
+                "full_id": 2919759872,
                 "name": "Ha'il",
                 "translations": {
                     "japanese": "ハーイル州",
@@ -41791,7 +43284,8 @@
                 }
             },
             {
-                "id": 2919825408,
+                "id": 9,
+                "full_id": 2919825408,
                 "name": "Makkah",
                 "translations": {
                     "japanese": "メッカ州",
@@ -41817,7 +43311,8 @@
                 }
             },
             {
-                "id": 2919890944,
+                "id": 10,
+                "full_id": 2919890944,
                 "name": "Al Hudud ash Shamaliyah",
                 "translations": {
                     "japanese": "北部国境州",
@@ -41843,7 +43338,8 @@
                 }
             },
             {
-                "id": 2919956480,
+                "id": 11,
+                "full_id": 2919956480,
                 "name": "Najran",
                 "translations": {
                     "japanese": "ナジュラーン州",
@@ -41869,7 +43365,8 @@
                 }
             },
             {
-                "id": 2920022016,
+                "id": 12,
+                "full_id": 2920022016,
                 "name": "Jizan",
                 "translations": {
                     "japanese": "ジーザーン州",
@@ -41895,7 +43392,8 @@
                 }
             },
             {
-                "id": 2920087552,
+                "id": 13,
+                "full_id": 2920087552,
                 "name": "Tabuk",
                 "translations": {
                     "japanese": "タブーク州",
@@ -41921,7 +43419,8 @@
                 }
             },
             {
-                "id": 2920153088,
+                "id": 14,
+                "full_id": 2920153088,
                 "name": "Al Jawf",
                 "translations": {
                     "japanese": "ジャウフ州",
@@ -41972,7 +43471,8 @@
         },
         "regions": [
             {
-                "id": 3087007744,
+                "id": 0,
+                "full_id": 3087007744,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -41998,7 +43498,8 @@
                 }
             },
             {
-                "id": 3087073280,
+                "id": 1,
+                "full_id": 3087073280,
                 "name": "San Marino",
                 "translations": {
                     "japanese": "サンマリノ",
@@ -42049,7 +43550,8 @@
         },
         "regions": [
             {
-                "id": 3103784960,
+                "id": 0,
+                "full_id": 3103784960,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -42075,7 +43577,8 @@
                 }
             },
             {
-                "id": 3103850496,
+                "id": 1,
+                "full_id": 3103850496,
                 "name": "Vatican City",
                 "translations": {
                     "japanese": "バチカン",
@@ -42126,7 +43629,8 @@
         },
         "regions": [
             {
-                "id": 3120562176,
+                "id": 0,
+                "full_id": 3120562176,
                 "name": "Unspecified",
                 "translations": {
                     "japanese": "—",
@@ -42152,7 +43656,8 @@
                 }
             },
             {
-                "id": 3120627712,
+                "id": 1,
+                "full_id": 3120627712,
                 "name": "Bermuda",
                 "translations": {
                     "japanese": "バーミューダ",


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->
This PR allows the extractor to get the clean region ID, as it contains the country ID in it. It is removed alongside all `0x00` bytes to get a "clean" ID. This clean ID is seen in at least the `X-Nintendo-ParamPack` header in all Miiverse/olv requests under the `area_id` value.

The "clean" ID is in a new field called `individual_id`.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.